### PR TITLE
Add mqtt debug tool

### DIFF
--- a/index.md
+++ b/index.md
@@ -21,6 +21,7 @@ Welcome to the Zigbee2mqtt documentation!
 * [Admin Panel for Node-Red](https://github.com/ben423423n32j14e/zigbee2mqttadminpanel)
 * [Domoticz](https://github.com/stas-demydiuk/domoticz-zigbee2mqtt-plugin)
 * [Majordomo](https://github.com/directman66/majordomo-zigbee2mqtt/) (Only for Russian speaking users)
+* [MQTT Explorer](https://thomasnordquist.github.io/MQTT-Explorer/) (debug tool for custom integrations)
 
 ### How tos
 * [How to support new devices](how_tos/how_to_support_new_devices.md)

--- a/index.md
+++ b/index.md
@@ -21,7 +21,7 @@ Welcome to the Zigbee2mqtt documentation!
 * [Admin Panel for Node-Red](https://github.com/ben423423n32j14e/zigbee2mqttadminpanel)
 * [Domoticz](https://github.com/stas-demydiuk/domoticz-zigbee2mqtt-plugin)
 * [Majordomo](https://github.com/directman66/majordomo-zigbee2mqtt/) (Only for Russian speaking users)
-* [MQTT Explorer](https://thomasnordquist.github.io/MQTT-Explorer/) (debug tool for custom integrations)
+* [MQTT Explorer](https://mqtt-explorer.com) (debug tool for custom integrations)
 
 ### How tos
 * [How to support new devices](how_tos/how_to_support_new_devices.md)


### PR DESCRIPTION
I use this tool a lot to integrate new devices in my node-red instance, see which topics update, and which values the different devices publish.
In fact, zigbee2mqtt was a big reason for me to write the application.

Sure, the link also advertising my app, but I really believe that this application is very helpful for everyone that is not using an out-of-the-box solution. The topic hierarchy makes MQTT super easy to understand and use.

![Ohne Titel](https://user-images.githubusercontent.com/7721625/54616079-719d6600-4a5f-11e9-9bd5-5d4ceae319f1.png)
[MQTT Explorer](https://thomasnordquist.github.io/MQTT-Explorer/?c=pr)
