### PR TITLE
Add restart req after config to Group doc

### DIFF
--- a/information/groups.md
+++ b/information/groups.md
@@ -18,6 +18,8 @@ groups:
 
 The group ID (in the above example `'1'`) should be a numerical string. In case you want to use a hexadecimal group ID (e.g. `0xe24c`) you should first convert it to a numerical string (e.g. `57932`).
 
+If using the Hassio add-on, restart it after modifying your `configuration.yaml` as above.
+
 ## Commands
 The group of a node can be configured using the following commands:
 


### PR DESCRIPTION
Was getting a "xxx group doesn't exist" error when attempting to add. I restarted Home Assistant (Hassio) and doublechecked everything several times before realizing that I needed to restart the Home Assistant add-on. I don't know what the procedure is with other types of Home Assistant implementation.