### PR TITLE
node.js on RPi Zero

### DIFF
--- a/getting_started/running_zigbee2mqtt.md
+++ b/getting_started/running_zigbee2mqtt.md
@@ -25,6 +25,9 @@ lrwxrwxrwx. 1 root root 13 Oct 19 19:26 usb-Texas_Instruments_TI_CC2531_USB_CDC_
 # Setup Node.js repository
 sudo curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 
+If you are on a RaspberryPi Zero that won't work.
+Follow this guide https://warlord0blog.wordpress.com/2018/06/27/node-js-v8-on-raspberry-pi-zero/
+
 # Install Node.js
 sudo apt-get install -y nodejs git make g++ gcc
 

--- a/getting_started/running_zigbee2mqtt.md
+++ b/getting_started/running_zigbee2mqtt.md
@@ -23,10 +23,8 @@ lrwxrwxrwx. 1 root root 13 Oct 19 19:26 usb-Texas_Instruments_TI_CC2531_USB_CDC_
 ## 2. Installing
 ```bash
 # Setup Node.js repository
+# NOTE: For Raspberry Pi Zero follow https://warlord0blog.wordpress.com/2018/06/27/node-js-v8-on-raspberry-pi-zero/
 sudo curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-
-If you are on a RaspberryPi Zero that won't work.
-Follow this guide https://warlord0blog.wordpress.com/2018/06/27/node-js-v8-on-raspberry-pi-zero/
 
 # Install Node.js
 sudo apt-get install -y nodejs git make g++ gcc


### PR DESCRIPTION
the required version of node.js is not available by default. 
The linked guide worked for me.
Not sure if you want to link to someone else's page or include the instructions yourself.