### PR TITLE
Added a little SEO for devices

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,5 @@
 theme: jekyll-theme-cayman
 url: https://www.zigbee2mqtt.io
+
+plugins:
+  - jekyll-sitemap

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 theme: jekyll-theme-cayman
+url: https://www.zigbee2mqtt.io

--- a/devices/046677476816.md
+++ b/devices/046677476816.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 046677476816 control via MQTT"
+description: "Integrate your Philips 046677476816 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 046677476816
 
 | Model | 046677476816  |
 | Vendor  | Philips  |

--- a/devices/100.110.39.md
+++ b/devices/100.110.39.md
@@ -1,8 +1,13 @@
+---
+title: "Paul Neuhaus 100.110.39 control via MQTT"
+description: "Integrate your Paul Neuhaus 100.110.39 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Paul Neuhaus 100.110.39
 
 | Model | 100.110.39  |
 | Vendor  | Paul Neuhaus  |

--- a/devices/100.424.11.md
+++ b/devices/100.424.11.md
@@ -1,8 +1,13 @@
+---
+title: "Paul Neuhaus 100.424.11 control via MQTT"
+description: "Integrate your Paul Neuhaus 100.424.11 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Paul Neuhaus 100.424.11
 
 | Model | 100.424.11  |
 | Vendor  | Paul Neuhaus  |

--- a/devices/100.425.90.md
+++ b/devices/100.425.90.md
@@ -1,8 +1,13 @@
+---
+title: "Paul Neuhaus 100.425.90 control via MQTT"
+description: "Integrate your Paul Neuhaus 100.425.90 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Paul Neuhaus 100.425.90
 
 | Model | 100.425.90  |
 | Vendor  | Paul Neuhaus  |

--- a/devices/12031.md
+++ b/devices/12031.md
@@ -1,8 +1,13 @@
+---
+title: "Lupus 12031 control via MQTT"
+description: "Integrate your Lupus 12031 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Lupus 12031
 
 | Model | 12031  |
 | Vendor  | Lupus  |

--- a/devices/12050.md
+++ b/devices/12050.md
@@ -1,8 +1,13 @@
+---
+title: "Lupus 12050 control via MQTT"
+description: "Integrate your Lupus 12050 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Lupus 12050
 
 | Model | 12050  |
 | Vendor  | Lupus  |

--- a/devices/1613V.md
+++ b/devices/1613V.md
@@ -1,8 +1,13 @@
+---
+title: "Hive 1613V control via MQTT"
+description: "Integrate your Hive 1613V via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Hive 1613V
 
 | Model | 1613V  |
 | Vendor  | Hive  |

--- a/devices/1TST-EU.md
+++ b/devices/1TST-EU.md
@@ -1,8 +1,13 @@
+---
+title: "eCozy 1TST-EU control via MQTT"
+description: "Integrate your eCozy 1TST-EU via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# eCozy 1TST-EU
 
 | Model | 1TST-EU  |
 | Vendor  | eCozy  |

--- a/devices/22670.md
+++ b/devices/22670.md
@@ -1,8 +1,13 @@
+---
+title: "GE 22670 control via MQTT"
+description: "Integrate your GE 22670 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# GE 22670
 
 | Model | 22670  |
 | Vendor  | GE  |

--- a/devices/2430-100.md
+++ b/devices/2430-100.md
@@ -1,8 +1,13 @@
+---
+title: "Gira 2430-100 control via MQTT"
+description: "Integrate your Gira 2430-100 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Gira 2430-100
 
 | Model | 2430-100  |
 | Vendor  | Gira  |

--- a/devices/316GLEDRF.md
+++ b/devices/316GLEDRF.md
@@ -1,8 +1,13 @@
+---
+title: "ELKO 316GLEDRF control via MQTT"
+description: "Integrate your ELKO 316GLEDRF via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# ELKO 316GLEDRF
 
 | Model | 316GLEDRF  |
 | Vendor  | ELKO  |

--- a/devices/3210-L.md
+++ b/devices/3210-L.md
@@ -1,8 +1,13 @@
+---
+title: "Iris 3210-L control via MQTT"
+description: "Integrate your Iris 3210-L via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Iris 3210-L
 
 | Model | 3210-L  |
 | Vendor  | Iris  |

--- a/devices/3216131P5.md
+++ b/devices/3216131P5.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 3216131P5 control via MQTT"
+description: "Integrate your Philips 3216131P5 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 3216131P5
 
 | Model | 3216131P5  |
 | Vendor  | Philips  |

--- a/devices/3216231P5.md
+++ b/devices/3216231P5.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 3216231P5 control via MQTT"
+description: "Integrate your Philips 3216231P5 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 3216231P5
 
 | Model | 3216231P5  |
 | Vendor  | Philips  |

--- a/devices/3216331P5.md
+++ b/devices/3216331P5.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 3216331P5 control via MQTT"
+description: "Integrate your Philips 3216331P5 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 3216331P5
 
 | Model | 3216331P5  |
 | Vendor  | Philips  |

--- a/devices/3216431P5.md
+++ b/devices/3216431P5.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 3216431P5 control via MQTT"
+description: "Integrate your Philips 3216431P5 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 3216431P5
 
 | Model | 3216431P5  |
 | Vendor  | Philips  |

--- a/devices/324131092621.md
+++ b/devices/324131092621.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 324131092621 control via MQTT"
+description: "Integrate your Philips 324131092621 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 324131092621
 
 | Model | 324131092621  |
 | Vendor  | Philips  |

--- a/devices/3261030P7.md
+++ b/devices/3261030P7.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 3261030P7 control via MQTT"
+description: "Integrate your Philips 3261030P7 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 3261030P7
 
 | Model | 3261030P7  |
 | Vendor  | Philips  |

--- a/devices/3261331P7.md
+++ b/devices/3261331P7.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 3261331P7 control via MQTT"
+description: "Integrate your Philips 3261331P7 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 3261331P7
 
 | Model | 3261331P7  |
 | Vendor  | Philips  |

--- a/devices/3300-S.md
+++ b/devices/3300-S.md
@@ -1,8 +1,13 @@
+---
+title: "SmartThings 3300-S control via MQTT"
+description: "Integrate your SmartThings 3300-S via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# SmartThings 3300-S
 
 | Model | 3300-S  |
 | Vendor  | SmartThings  |

--- a/devices/3305-S.md
+++ b/devices/3305-S.md
@@ -1,8 +1,13 @@
+---
+title: "SmartThings 3305-S control via MQTT"
+description: "Integrate your SmartThings 3305-S via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# SmartThings 3305-S
 
 | Model | 3305-S  |
 | Vendor  | SmartThings  |

--- a/devices/3310-S.md
+++ b/devices/3310-S.md
@@ -1,8 +1,13 @@
+---
+title: "SmartThings 3310-S control via MQTT"
+description: "Integrate your SmartThings 3310-S via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# SmartThings 3310-S
 
 | Model | 3310-S  |
 | Vendor  | SmartThings  |

--- a/devices/3315-G.md
+++ b/devices/3315-G.md
@@ -1,8 +1,13 @@
+---
+title: "SmartThings 3315-G control via MQTT"
+description: "Integrate your SmartThings 3315-G via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# SmartThings 3315-G
 
 | Model | 3315-G  |
 | Vendor  | SmartThings  |

--- a/devices/3315-S.md
+++ b/devices/3315-S.md
@@ -1,8 +1,13 @@
+---
+title: "SmartThings 3315-S control via MQTT"
+description: "Integrate your SmartThings 3315-S via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# SmartThings 3315-S
 
 | Model | 3315-S  |
 | Vendor  | SmartThings  |

--- a/devices/3320-L.md
+++ b/devices/3320-L.md
@@ -1,8 +1,13 @@
+---
+title: "Iris 3320-L control via MQTT"
+description: "Integrate your Iris 3320-L via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Iris 3320-L
 
 | Model | 3320-L  |
 | Vendor  | Iris  |

--- a/devices/3321-S.md
+++ b/devices/3321-S.md
@@ -1,8 +1,13 @@
+---
+title: "SmartThings 3321-S control via MQTT"
+description: "Integrate your SmartThings 3321-S via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# SmartThings 3321-S
 
 | Model | 3321-S  |
 | Vendor  | SmartThings  |

--- a/devices/3325-S.md
+++ b/devices/3325-S.md
@@ -1,8 +1,13 @@
+---
+title: "SmartThings 3325-S control via MQTT"
+description: "Integrate your SmartThings 3325-S via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# SmartThings 3325-S
 
 | Model | 3325-S  |
 | Vendor  | SmartThings  |

--- a/devices/3326-L.md
+++ b/devices/3326-L.md
@@ -1,8 +1,13 @@
+---
+title: "Iris 3326-L control via MQTT"
+description: "Integrate your Iris 3326-L via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Iris 3326-L
 
 | Model | 3326-L  |
 | Vendor  | Iris  |

--- a/devices/3RSS008Z.md
+++ b/devices/3RSS008Z.md
@@ -1,8 +1,13 @@
+---
+title: "Third Reality 3RSS008Z control via MQTT"
+description: "Integrate your Third Reality 3RSS008Z via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Third Reality 3RSS008Z
 
 | Model | 3RSS008Z  |
 | Vendor  | Third Reality  |

--- a/devices/4033930P7.md
+++ b/devices/4033930P7.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 4033930P7 control via MQTT"
+description: "Integrate your Philips 4033930P7 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 4033930P7
 
 | Model | 4033930P7  |
 | Vendor  | Philips  |

--- a/devices/404000_404005_404012.md
+++ b/devices/404000_404005_404012.md
@@ -1,8 +1,13 @@
+---
+title: "Müller Licht 404000/404005/404012 control via MQTT"
+description: "Integrate your Müller Licht 404000/404005/404012 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Müller Licht 404000/404005/404012
 
 | Model | 404000/404005/404012  |
 | Vendor  | Müller Licht  |

--- a/devices/404006_404008_404004.md
+++ b/devices/404006_404008_404004.md
@@ -1,8 +1,13 @@
+---
+title: "Müller Licht 404006/404008/404004 control via MQTT"
+description: "Integrate your Müller Licht 404006/404008/404004 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Müller Licht 404006/404008/404004
 
 | Model | 404006/404008/404004  |
 | Vendor  | Müller Licht  |

--- a/devices/4052899926110.md
+++ b/devices/4052899926110.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM 4052899926110 control via MQTT"
+description: "Integrate your OSRAM 4052899926110 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM 4052899926110
 
 | Model | 4052899926110  |
 | Vendor  | OSRAM  |

--- a/devices/4052899926158.md
+++ b/devices/4052899926158.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM 4052899926158 control via MQTT"
+description: "Integrate your OSRAM 4052899926158 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM 4052899926158
 
 | Model | 4052899926158  |
 | Vendor  | OSRAM  |

--- a/devices/4058075036147.md
+++ b/devices/4058075036147.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM 4058075036147 control via MQTT"
+description: "Integrate your OSRAM 4058075036147 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM 4058075036147
 
 | Model | 4058075036147  |
 | Vendor  | OSRAM  |

--- a/devices/4058075036185.md
+++ b/devices/4058075036185.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM 4058075036185 control via MQTT"
+description: "Integrate your OSRAM 4058075036185 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM 4058075036185
 
 | Model | 4058075036185  |
 | Vendor  | OSRAM  |

--- a/devices/4058075816718.md
+++ b/devices/4058075816718.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM 4058075816718 control via MQTT"
+description: "Integrate your OSRAM 4058075816718 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM 4058075816718
 
 | Model | 4058075816718  |
 | Vendor  | OSRAM  |

--- a/devices/4058075816794.md
+++ b/devices/4058075816794.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM 4058075816794 control via MQTT"
+description: "Integrate your OSRAM 4058075816794 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM 4058075816794
 
 | Model | 4058075816794  |
 | Vendor  | OSRAM  |

--- a/devices/4090130P7.md
+++ b/devices/4090130P7.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 4090130P7 control via MQTT"
+description: "Integrate your Philips 4090130P7 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 4090130P7
 
 | Model | 4090130P7  |
 | Vendor  | Philips  |

--- a/devices/4090531P7.md
+++ b/devices/4090531P7.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 4090531P7 control via MQTT"
+description: "Integrate your Philips 4090531P7 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 4090531P7
 
 | Model | 4090531P7  |
 | Vendor  | Philips  |

--- a/devices/4096730U7.md
+++ b/devices/4096730U7.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 4096730U7 control via MQTT"
+description: "Integrate your Philips 4096730U7 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 4096730U7
 
 | Model | 4096730U7  |
 | Vendor  | Philips  |

--- a/devices/421786.md
+++ b/devices/421786.md
@@ -1,8 +1,13 @@
+---
+title: "Calex 421786 control via MQTT"
+description: "Integrate your Calex 421786 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Calex 421786
 
 | Model | 421786  |
 | Vendor  | Calex  |

--- a/devices/421792.md
+++ b/devices/421792.md
@@ -1,8 +1,13 @@
+---
+title: "Calex 421792 control via MQTT"
+description: "Integrate your Calex 421792 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Calex 421792
 
 | Model | 421792  |
 | Vendor  | Calex  |

--- a/devices/4256251-RZHAC.md
+++ b/devices/4256251-RZHAC.md
@@ -1,8 +1,13 @@
+---
+title: "Centralite 4256251-RZHAC control via MQTT"
+description: "Integrate your Centralite 4256251-RZHAC via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Centralite 4256251-RZHAC
 
 | Model | 4256251-RZHAC  |
 | Vendor  | Centralite  |

--- a/devices/433714.md
+++ b/devices/433714.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 433714 control via MQTT"
+description: "Integrate your Philips 433714 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 433714
 
 | Model | 433714  |
 | Vendor  | Philips  |

--- a/devices/45852GE.md
+++ b/devices/45852GE.md
@@ -1,8 +1,13 @@
+---
+title: "GE 45852GE control via MQTT"
+description: "Integrate your GE 45852GE via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# GE 45852GE
 
 | Model | 45852GE  |
 | Vendor  | GE  |

--- a/devices/45853GE.md
+++ b/devices/45853GE.md
@@ -1,8 +1,13 @@
+---
+title: "GE 45853GE control via MQTT"
+description: "Integrate your GE 45853GE via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# GE 45853GE
 
 | Model | 45853GE  |
 | Vendor  | GE  |

--- a/devices/45856GE.md
+++ b/devices/45856GE.md
@@ -1,8 +1,13 @@
+---
+title: "GE 45856GE control via MQTT"
+description: "Integrate your GE 45856GE via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# GE 45856GE
 
 | Model | 45856GE  |
 | Vendor  | GE  |

--- a/devices/45857GE.md
+++ b/devices/45857GE.md
@@ -1,8 +1,13 @@
+---
+title: "GE 45857GE control via MQTT"
+description: "Integrate your GE 45857GE via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# GE 45857GE
 
 | Model | 45857GE  |
 | Vendor  | GE  |

--- a/devices/464800.md
+++ b/devices/464800.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 464800 control via MQTT"
+description: "Integrate your Philips 464800 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 464800
 
 | Model | 464800  |
 | Vendor  | Philips  |

--- a/devices/4713407.md
+++ b/devices/4713407.md
@@ -1,8 +1,13 @@
+---
+title: "Airam 4713407 control via MQTT"
+description: "Integrate your Airam 4713407 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Airam 4713407
 
 | Model | 4713407  |
 | Vendor  | Airam  |

--- a/devices/50043.md
+++ b/devices/50043.md
@@ -1,8 +1,13 @@
+---
+title: "Paulmann 50043 control via MQTT"
+description: "Integrate your Paulmann 50043 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Paulmann 50043
 
 | Model | 50043  |
 | Vendor  | Paulmann  |

--- a/devices/50045.md
+++ b/devices/50045.md
@@ -1,8 +1,13 @@
+---
+title: "Paulmann 50045 control via MQTT"
+description: "Integrate your Paulmann 50045 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Paulmann 50045
 
 | Model | 50045  |
 | Vendor  | Paulmann  |

--- a/devices/50049.md
+++ b/devices/50049.md
@@ -1,8 +1,13 @@
+---
+title: "Paulmann 50049 control via MQTT"
+description: "Integrate your Paulmann 50049 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Paulmann 50049
 
 | Model | 50049  |
 | Vendor  | Paulmann  |

--- a/devices/50064.md
+++ b/devices/50064.md
@@ -1,8 +1,13 @@
+---
+title: "Paulmann 50064 control via MQTT"
+description: "Integrate your Paulmann 50064 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Paulmann 50064
 
 | Model | 50064  |
 | Vendor  | Paulmann  |

--- a/devices/511.10.md
+++ b/devices/511.10.md
@@ -1,8 +1,13 @@
+---
+title: "Iluminize 511.10 control via MQTT"
+description: "Integrate your Iluminize 511.10 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Iluminize 511.10
 
 | Model | 511.10  |
 | Vendor  | Iluminize  |

--- a/devices/53170161.md
+++ b/devices/53170161.md
@@ -1,8 +1,13 @@
+---
+title: "Commercial Electric 53170161 control via MQTT"
+description: "Integrate your Commercial Electric 53170161 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Commercial Electric 53170161
 
 | Model | 53170161  |
 | Vendor  | Commercial Electric  |

--- a/devices/67200BL.md
+++ b/devices/67200BL.md
@@ -1,8 +1,13 @@
+---
+title: "Anchor 67200BL control via MQTT"
+description: "Integrate your Anchor 67200BL via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Anchor 67200BL
 
 | Model | 67200BL  |
 | Vendor  | Anchor  |

--- a/devices/7099860PH.md
+++ b/devices/7099860PH.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 7099860PH control via MQTT"
+description: "Integrate your Philips 7099860PH via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 7099860PH
 
 | Model | 7099860PH  |
 | Vendor  | Philips  |

--- a/devices/7146060PH.md
+++ b/devices/7146060PH.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 7146060PH control via MQTT"
+description: "Integrate your Philips 7146060PH via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 7146060PH
 
 | Model | 7146060PH  |
 | Vendor  | Philips  |

--- a/devices/71831.md
+++ b/devices/71831.md
@@ -1,8 +1,13 @@
+---
+title: "Sylvania 71831 control via MQTT"
+description: "Integrate your Sylvania 71831 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sylvania 71831
 
 | Model | 71831  |
 | Vendor  | Sylvania  |

--- a/devices/7199960PH.md
+++ b/devices/7199960PH.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 7199960PH control via MQTT"
+description: "Integrate your Philips 7199960PH via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 7199960PH
 
 | Model | 7199960PH  |
 | Vendor  | Philips  |

--- a/devices/72922-A.md
+++ b/devices/72922-A.md
@@ -1,8 +1,13 @@
+---
+title: "Sylvania 72922-A control via MQTT"
+description: "Integrate your Sylvania 72922-A via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sylvania 72922-A
 
 | Model | 72922-A  |
 | Vendor  | Sylvania  |

--- a/devices/7299355PH.md
+++ b/devices/7299355PH.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 7299355PH control via MQTT"
+description: "Integrate your Philips 7299355PH via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 7299355PH
 
 | Model | 7299355PH  |
 | Vendor  | Philips  |

--- a/devices/7299760PH.md
+++ b/devices/7299760PH.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 7299760PH control via MQTT"
+description: "Integrate your Philips 7299760PH via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 7299760PH
 
 | Model | 7299760PH  |
 | Vendor  | Philips  |

--- a/devices/73693.md
+++ b/devices/73693.md
@@ -1,8 +1,13 @@
+---
+title: "Sylvania 73693 control via MQTT"
+description: "Integrate your Sylvania 73693 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sylvania 73693
 
 | Model | 73693  |
 | Vendor  | Sylvania  |

--- a/devices/73739.md
+++ b/devices/73739.md
@@ -1,8 +1,13 @@
+---
+title: "Sylvania 73739 control via MQTT"
+description: "Integrate your Sylvania 73739 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sylvania 73739
 
 | Model | 73739  |
 | Vendor  | Sylvania  |

--- a/devices/73740.md
+++ b/devices/73740.md
@@ -1,8 +1,13 @@
+---
+title: "Sylvania 73740 control via MQTT"
+description: "Integrate your Sylvania 73740 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sylvania 73740
 
 | Model | 73740  |
 | Vendor  | Sylvania  |

--- a/devices/73742.md
+++ b/devices/73742.md
@@ -1,8 +1,13 @@
+---
+title: "Sylvania 73742 control via MQTT"
+description: "Integrate your Sylvania 73742 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sylvania 73742
 
 | Model | 73742  |
 | Vendor  | Sylvania  |

--- a/devices/74282.md
+++ b/devices/74282.md
@@ -1,8 +1,13 @@
+---
+title: "Sylvania 74282 control via MQTT"
+description: "Integrate your Sylvania 74282 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sylvania 74282
 
 | Model | 74282  |
 | Vendor  | Sylvania  |

--- a/devices/74283.md
+++ b/devices/74283.md
@@ -1,8 +1,13 @@
+---
+title: "Sylvania 74283 control via MQTT"
+description: "Integrate your Sylvania 74283 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sylvania 74283
 
 | Model | 74283  |
 | Vendor  | Sylvania  |

--- a/devices/74580.md
+++ b/devices/74580.md
@@ -1,8 +1,13 @@
+---
+title: "Sylvania 74580 control via MQTT"
+description: "Integrate your Sylvania 74580 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sylvania 74580
 
 | Model | 74580  |
 | Vendor  | Sylvania  |

--- a/devices/74696.md
+++ b/devices/74696.md
@@ -1,8 +1,13 @@
+---
+title: "Sylvania 74696 control via MQTT"
+description: "Integrate your Sylvania 74696 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sylvania 74696
 
 | Model | 74696  |
 | Vendor  | Sylvania  |

--- a/devices/81809.md
+++ b/devices/81809.md
@@ -1,8 +1,13 @@
+---
+title: "AduroSmart 81809 control via MQTT"
+description: "Integrate your AduroSmart 81809 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# AduroSmart 81809
 
 | Model | 81809  |
 | Vendor  | AduroSmart  |

--- a/devices/81825.md
+++ b/devices/81825.md
@@ -1,8 +1,13 @@
+---
+title: "AduroSmart 81825 control via MQTT"
+description: "Integrate your AduroSmart 81825 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# AduroSmart 81825
 
 | Model | 81825  |
 | Vendor  | AduroSmart  |

--- a/devices/8718696170625.md
+++ b/devices/8718696170625.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 8718696170625 control via MQTT"
+description: "Integrate your Philips 8718696170625 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 8718696170625
 
 | Model | 8718696170625  |
 | Vendor  | Philips  |

--- a/devices/8718696449691.md
+++ b/devices/8718696449691.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 8718696449691 control via MQTT"
+description: "Integrate your Philips 8718696449691 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 8718696449691
 
 | Model | 8718696449691  |
 | Vendor  | Philips  |

--- a/devices/8718696485880.md
+++ b/devices/8718696485880.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 8718696485880 control via MQTT"
+description: "Integrate your Philips 8718696485880 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 8718696485880
 
 | Model | 8718696485880  |
 | Vendor  | Philips  |

--- a/devices/8718696548738.md
+++ b/devices/8718696548738.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 8718696548738 control via MQTT"
+description: "Integrate your Philips 8718696548738 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 8718696548738
 
 | Model | 8718696548738  |
 | Vendor  | Philips  |

--- a/devices/8718696598283.md
+++ b/devices/8718696598283.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 8718696598283 control via MQTT"
+description: "Integrate your Philips 8718696598283 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 8718696598283
 
 | Model | 8718696598283  |
 | Vendor  | Philips  |

--- a/devices/8718696695203.md
+++ b/devices/8718696695203.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 8718696695203 control via MQTT"
+description: "Integrate your Philips 8718696695203 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 8718696695203
 
 | Model | 8718696695203  |
 | Vendor  | Philips  |

--- a/devices/900008-WW.md
+++ b/devices/900008-WW.md
@@ -1,8 +1,13 @@
+---
+title: "ilux 900008-WW control via MQTT"
+description: "Integrate your ilux 900008-WW via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# ilux 900008-WW
 
 | Model | 900008-WW  |
 | Vendor  | ilux  |

--- a/devices/915005106701.md
+++ b/devices/915005106701.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 915005106701 control via MQTT"
+description: "Integrate your Philips 915005106701 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 915005106701
 
 | Model | 915005106701  |
 | Vendor  | Philips  |

--- a/devices/915005733701.md
+++ b/devices/915005733701.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 915005733701 control via MQTT"
+description: "Integrate your Philips 915005733701 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 915005733701
 
 | Model | 915005733701  |
 | Vendor  | Philips  |

--- a/devices/9290002579A.md
+++ b/devices/9290002579A.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 9290002579A control via MQTT"
+description: "Integrate your Philips 9290002579A via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 9290002579A
 
 | Model | 9290002579A  |
 | Vendor  | Philips  |

--- a/devices/9290011370.md
+++ b/devices/9290011370.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 9290011370 control via MQTT"
+description: "Integrate your Philips 9290011370 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 9290011370
 
 | Model | 9290011370  |
 | Vendor  | Philips  |

--- a/devices/9290011370B.md
+++ b/devices/9290011370B.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 9290011370B control via MQTT"
+description: "Integrate your Philips 9290011370B via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 9290011370B
 
 | Model | 9290011370B  |
 | Vendor  | Philips  |

--- a/devices/9290011998B.md
+++ b/devices/9290011998B.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 9290011998B control via MQTT"
+description: "Integrate your Philips 9290011998B via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 9290011998B
 
 | Model | 9290011998B  |
 | Vendor  | Philips  |

--- a/devices/9290012573A.md
+++ b/devices/9290012573A.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 9290012573A control via MQTT"
+description: "Integrate your Philips 9290012573A via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 9290012573A
 
 | Model | 9290012573A  |
 | Vendor  | Philips  |

--- a/devices/9290012607.md
+++ b/devices/9290012607.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 9290012607 control via MQTT"
+description: "Integrate your Philips 9290012607 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 9290012607
 
 | Model | 9290012607  |
 | Vendor  | Philips  |

--- a/devices/9290018195.md
+++ b/devices/9290018195.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 9290018195 control via MQTT"
+description: "Integrate your Philips 9290018195 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 9290018195
 
 | Model | 9290018195  |
 | Vendor  | Philips  |

--- a/devices/9290019758.md
+++ b/devices/9290019758.md
@@ -1,8 +1,13 @@
+---
+title: "Philips 9290019758 control via MQTT"
+description: "Integrate your Philips 9290019758 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Philips 9290019758
 
 | Model | 9290019758  |
 | Vendor  | Philips  |

--- a/devices/99432.md
+++ b/devices/99432.md
@@ -1,8 +1,13 @@
+---
+title: "Hampton Bay 99432 control via MQTT"
+description: "Integrate your Hampton Bay 99432 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Hampton Bay 99432
 
 | Model | 99432  |
 | Vendor  | Hampton Bay  |

--- a/devices/A6121.md
+++ b/devices/A6121.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi A6121 control via MQTT"
+description: "Integrate your Xiaomi A6121 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi A6121
 
 | Model | A6121  |
 | Vendor  | Xiaomi  |

--- a/devices/A806S-Q1R.md
+++ b/devices/A806S-Q1R.md
@@ -1,8 +1,13 @@
+---
+title: "Leedarson A806S-Q1R control via MQTT"
+description: "Integrate your Leedarson A806S-Q1R via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Leedarson A806S-Q1R
 
 | Model | A806S-Q1R  |
 | Vendor  | Leedarson  |

--- a/devices/AA68199.md
+++ b/devices/AA68199.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AA68199 control via MQTT"
+description: "Integrate your OSRAM AA68199 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AA68199
 
 | Model | AA68199  |
 | Vendor  | OSRAM  |

--- a/devices/AA69697.md
+++ b/devices/AA69697.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AA69697 control via MQTT"
+description: "Integrate your OSRAM AA69697 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AA69697
 
 | Model | AA69697  |
 | Vendor  | OSRAM  |

--- a/devices/AA70155.md
+++ b/devices/AA70155.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AA70155 control via MQTT"
+description: "Integrate your OSRAM AA70155 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AA70155
 
 | Model | AA70155  |
 | Vendor  | OSRAM  |

--- a/devices/AB3257001NJ.md
+++ b/devices/AB3257001NJ.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AB3257001NJ control via MQTT"
+description: "Integrate your OSRAM AB3257001NJ via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AB3257001NJ
 
 | Model | AB3257001NJ  |
 | Vendor  | OSRAM  |

--- a/devices/AB32840.md
+++ b/devices/AB32840.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AB32840 control via MQTT"
+description: "Integrate your OSRAM AB32840 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AB32840
 
 | Model | AB32840  |
 | Vendor  | OSRAM  |

--- a/devices/AB35996.md
+++ b/devices/AB35996.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AB35996 control via MQTT"
+description: "Integrate your OSRAM AB35996 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AB35996
 
 | Model | AB35996  |
 | Vendor  | OSRAM  |

--- a/devices/AB401130055.md
+++ b/devices/AB401130055.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AB401130055 control via MQTT"
+description: "Integrate your OSRAM AB401130055 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AB401130055
 
 | Model | AB401130055  |
 | Vendor  | OSRAM  |

--- a/devices/AC01353010G.md
+++ b/devices/AC01353010G.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AC01353010G control via MQTT"
+description: "Integrate your OSRAM AC01353010G via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AC01353010G
 
 | Model | AC01353010G  |
 | Vendor  | OSRAM  |

--- a/devices/AC0251100NJ.md
+++ b/devices/AC0251100NJ.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AC0251100NJ control via MQTT"
+description: "Integrate your OSRAM AC0251100NJ via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AC0251100NJ
 
 | Model | AC0251100NJ  |
 | Vendor  | OSRAM  |

--- a/devices/AC0363900NJ.md
+++ b/devices/AC0363900NJ.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AC0363900NJ control via MQTT"
+description: "Integrate your OSRAM AC0363900NJ via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AC0363900NJ
 
 | Model | AC0363900NJ  |
 | Vendor  | OSRAM  |

--- a/devices/AC03641.md
+++ b/devices/AC03641.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AC03641 control via MQTT"
+description: "Integrate your OSRAM AC03641 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AC03641
 
 | Model | AC03641  |
 | Vendor  | OSRAM  |

--- a/devices/AC03642.md
+++ b/devices/AC03642.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AC03642 control via MQTT"
+description: "Integrate your OSRAM AC03642 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AC03642
 
 | Model | AC03642  |
 | Vendor  | OSRAM  |

--- a/devices/AC03645.md
+++ b/devices/AC03645.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AC03645 control via MQTT"
+description: "Integrate your OSRAM AC03645 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AC03645
 
 | Model | AC03645  |
 | Vendor  | OSRAM  |

--- a/devices/AC03647.md
+++ b/devices/AC03647.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AC03647 control via MQTT"
+description: "Integrate your OSRAM AC03647 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AC03647
 
 | Model | AC03647  |
 | Vendor  | OSRAM  |

--- a/devices/AC03648.md
+++ b/devices/AC03648.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AC03648 control via MQTT"
+description: "Integrate your OSRAM AC03648 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AC03648
 
 | Model | AC03648  |
 | Vendor  | OSRAM  |

--- a/devices/AC08562.md
+++ b/devices/AC08562.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM AC08562 control via MQTT"
+description: "Integrate your OSRAM AC08562 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM AC08562
 
 | Model | AC08562  |
 | Vendor  | OSRAM  |

--- a/devices/AIRAM-CTR.U.md
+++ b/devices/AIRAM-CTR.U.md
@@ -1,8 +1,13 @@
+---
+title: "Airam AIRAM-CTR.U control via MQTT"
+description: "Integrate your Airam AIRAM-CTR.U via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Airam AIRAM-CTR.U
 
 | Model | AIRAM-CTR.U  |
 | Vendor  | Airam  |

--- a/devices/AV2010_22.md
+++ b/devices/AV2010_22.md
@@ -1,8 +1,13 @@
+---
+title: "Bitron AV2010/22 control via MQTT"
+description: "Integrate your Bitron AV2010/22 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Bitron AV2010/22
 
 | Model | AV2010/22  |
 | Vendor  | Bitron  |

--- a/devices/AV2010_25.md
+++ b/devices/AV2010_25.md
@@ -1,8 +1,13 @@
+---
+title: "Bitron AV2010/25 control via MQTT"
+description: "Integrate your Bitron AV2010/25 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Bitron AV2010/25
 
 | Model | AV2010/25  |
 | Vendor  | Bitron  |

--- a/devices/AV2010_32.md
+++ b/devices/AV2010_32.md
@@ -1,8 +1,13 @@
+---
+title: "Bitron AV2010/32 control via MQTT"
+description: "Integrate your Bitron AV2010/32 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Bitron AV2010/32
 
 | Model | AV2010/32  |
 | Vendor  | Bitron  |

--- a/devices/AV2010_34.md
+++ b/devices/AV2010_34.md
@@ -1,8 +1,13 @@
+---
+title: "Bitron AV2010/34 control via MQTT"
+description: "Integrate your Bitron AV2010/34 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Bitron AV2010/34
 
 | Model | AV2010/34  |
 | Vendor  | Bitron  |

--- a/devices/B07KG5KF5R.md
+++ b/devices/B07KG5KF5R.md
@@ -1,8 +1,13 @@
+---
+title: "GMY Smart Bulb B07KG5KF5R control via MQTT"
+description: "Integrate your GMY Smart Bulb B07KG5KF5R via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# GMY Smart Bulb B07KG5KF5R
 
 | Model | B07KG5KF5R  |
 | Vendor  | GMY Smart Bulb  |

--- a/devices/BY_165.md
+++ b/devices/BY_165.md
@@ -1,8 +1,13 @@
+---
+title: "Innr BY 165 control via MQTT"
+description: "Integrate your Innr BY 165 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr BY 165
 
 | Model | BY 165  |
 | Vendor  | Innr  |

--- a/devices/BY_185_C.md
+++ b/devices/BY_185_C.md
@@ -1,8 +1,13 @@
+---
+title: "Innr BY 185 C control via MQTT"
+description: "Integrate your Innr BY 185 C via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr BY 185 C
 
 | Model | BY 185 C  |
 | Vendor  | Innr  |

--- a/devices/BY_285_C.md
+++ b/devices/BY_285_C.md
@@ -1,8 +1,13 @@
+---
+title: "Innr BY 285 C control via MQTT"
+description: "Integrate your Innr BY 285 C via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr BY 285 C
 
 | Model | BY 285 C  |
 | Vendor  | Innr  |

--- a/devices/CC2530.ROUTER.md
+++ b/devices/CC2530.ROUTER.md
@@ -1,8 +1,13 @@
+---
+title: "Custom devices (DiY) CC2530.ROUTER control via MQTT"
+description: "Integrate your Custom devices (DiY) CC2530.ROUTER via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Custom devices (DiY) CC2530.ROUTER
 
 | Model | CC2530.ROUTER  |
 | Vendor  | Custom devices (DiY)  |

--- a/devices/CR701-YZ.md
+++ b/devices/CR701-YZ.md
@@ -1,8 +1,13 @@
+---
+title: "Oujiabao CR701-YZ control via MQTT"
+description: "Integrate your Oujiabao CR701-YZ via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Oujiabao CR701-YZ
 
 | Model | CR701-YZ  |
 | Vendor  | Oujiabao  |

--- a/devices/D1531.md
+++ b/devices/D1531.md
@@ -1,8 +1,13 @@
+---
+title: "EcoSmart D1531 control via MQTT"
+description: "Integrate your EcoSmart D1531 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# EcoSmart D1531
 
 | Model | D1531  |
 | Vendor  | EcoSmart  |

--- a/devices/D1532.md
+++ b/devices/D1532.md
@@ -1,8 +1,13 @@
+---
+title: "EcoSmart D1532 control via MQTT"
+description: "Integrate your EcoSmart D1532 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# EcoSmart D1532
 
 | Model | D1532  |
 | Vendor  | EcoSmart  |

--- a/devices/D1542.md
+++ b/devices/D1542.md
@@ -1,8 +1,13 @@
+---
+title: "EcoSmart D1542 control via MQTT"
+description: "Integrate your EcoSmart D1542 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# EcoSmart D1542
 
 | Model | D1542  |
 | Vendor  | EcoSmart  |

--- a/devices/D1821.md
+++ b/devices/D1821.md
@@ -1,8 +1,13 @@
+---
+title: "EcoSmart D1821 control via MQTT"
+description: "Integrate your EcoSmart D1821 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# EcoSmart D1821
 
 | Model | D1821  |
 | Vendor  | EcoSmart  |

--- a/devices/DIYRUZ_R4_5.md
+++ b/devices/DIYRUZ_R4_5.md
@@ -1,8 +1,13 @@
+---
+title: "Custom devices (DiY) DIYRUZ_R4_5 control via MQTT"
+description: "Integrate your Custom devices (DiY) DIYRUZ_R4_5 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Custom devices (DiY) DIYRUZ_R4_5
 
 | Model | DIYRUZ_R4_5  |
 | Vendor  | Custom devices (DiY)  |

--- a/devices/DJT11LM.md
+++ b/devices/DJT11LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi DJT11LM control via MQTT"
+description: "Integrate your Xiaomi DJT11LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi DJT11LM
 
 | Model | DJT11LM  |
 | Vendor  | Xiaomi  |

--- a/devices/DL_110_N.md
+++ b/devices/DL_110_N.md
@@ -1,8 +1,13 @@
+---
+title: "Innr DL 110 N control via MQTT"
+description: "Integrate your Innr DL 110 N via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr DL 110 N
 
 | Model | DL 110 N  |
 | Vendor  | Innr  |

--- a/devices/DL_110_W.md
+++ b/devices/DL_110_W.md
@@ -1,8 +1,13 @@
+---
+title: "Innr DL 110 W control via MQTT"
+description: "Integrate your Innr DL 110 W via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr DL 110 W
 
 | Model | DL 110 W  |
 | Vendor  | Innr  |

--- a/devices/DNCKATSW001.md
+++ b/devices/DNCKATSW001.md
@@ -1,8 +1,13 @@
+---
+title: "Custom devices (DiY) DNCKATSW001 control via MQTT"
+description: "Integrate your Custom devices (DiY) DNCKATSW001 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Custom devices (DiY) DNCKATSW001
 
 | Model | DNCKATSW001  |
 | Vendor  | Custom devices (DiY)  |

--- a/devices/DNCKATSW002.md
+++ b/devices/DNCKATSW002.md
@@ -1,8 +1,13 @@
+---
+title: "Custom devices (DiY) DNCKATSW002 control via MQTT"
+description: "Integrate your Custom devices (DiY) DNCKATSW002 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Custom devices (DiY) DNCKATSW002
 
 | Model | DNCKATSW002  |
 | Vendor  | Custom devices (DiY)  |

--- a/devices/DNCKATSW003.md
+++ b/devices/DNCKATSW003.md
@@ -1,8 +1,13 @@
+---
+title: "Custom devices (DiY) DNCKATSW003 control via MQTT"
+description: "Integrate your Custom devices (DiY) DNCKATSW003 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Custom devices (DiY) DNCKATSW003
 
 | Model | DNCKATSW003  |
 | Vendor  | Custom devices (DiY)  |

--- a/devices/DNCKATSW004.md
+++ b/devices/DNCKATSW004.md
@@ -1,8 +1,13 @@
+---
+title: "Custom devices (DiY) DNCKATSW004 control via MQTT"
+description: "Integrate your Custom devices (DiY) DNCKATSW004 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Custom devices (DiY) DNCKATSW004
 
 | Model | DNCKATSW004  |
 | Vendor  | Custom devices (DiY)  |

--- a/devices/E11-G13.md
+++ b/devices/E11-G13.md
@@ -1,8 +1,13 @@
+---
+title: "Sengled E11-G13 control via MQTT"
+description: "Integrate your Sengled E11-G13 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sengled E11-G13
 
 | Model | E11-G13  |
 | Vendor  | Sengled  |

--- a/devices/E11-G23_E11-G33.md
+++ b/devices/E11-G23_E11-G33.md
@@ -1,8 +1,13 @@
+---
+title: "Sengled E11-G23/E11-G33 control via MQTT"
+description: "Integrate your Sengled E11-G23/E11-G33 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sengled E11-G23/E11-G33
 
 | Model | E11-G23/E11-G33  |
 | Vendor  | Sengled  |

--- a/devices/E11-N1EA.md
+++ b/devices/E11-N1EA.md
@@ -1,8 +1,13 @@
+---
+title: "Sengled E11-N1EA control via MQTT"
+description: "Integrate your Sengled E11-N1EA via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sengled E11-N1EA
 
 | Model | E11-N1EA  |
 | Vendor  | Sengled  |

--- a/devices/E12-N14.md
+++ b/devices/E12-N14.md
@@ -1,8 +1,13 @@
+---
+title: "Sengled E12-N14 control via MQTT"
+description: "Integrate your Sengled E12-N14 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sengled E12-N14
 
 | Model | E12-N14  |
 | Vendor  | Sengled  |

--- a/devices/E1524.md
+++ b/devices/E1524.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA E1524 control via MQTT"
+description: "Integrate your IKEA E1524 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA E1524
 
 | Model | E1524  |
 | Vendor  | IKEA  |

--- a/devices/E1525.md
+++ b/devices/E1525.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA E1525 control via MQTT"
+description: "Integrate your IKEA E1525 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA E1525
 
 | Model | E1525  |
 | Vendor  | IKEA  |

--- a/devices/E1603_E1702.md
+++ b/devices/E1603_E1702.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA E1603/E1702 control via MQTT"
+description: "Integrate your IKEA E1603/E1702 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA E1603/E1702
 
 | Model | E1603/E1702  |
 | Vendor  | IKEA  |

--- a/devices/E1743.md
+++ b/devices/E1743.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA E1743 control via MQTT"
+description: "Integrate your IKEA E1743 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA E1743
 
 | Model | E1743  |
 | Vendor  | IKEA  |

--- a/devices/E1746.md
+++ b/devices/E1746.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA E1746 control via MQTT"
+description: "Integrate your IKEA E1746 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA E1746
 
 | Model | E1746  |
 | Vendor  | IKEA  |

--- a/devices/E1ACA4ABE38A.md
+++ b/devices/E1ACA4ABE38A.md
@@ -1,8 +1,13 @@
+---
+title: "Sengled E1ACA4ABE38A control via MQTT"
+description: "Integrate your Sengled E1ACA4ABE38A via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sengled E1ACA4ABE38A
 
 | Model | E1ACA4ABE38A  |
 | Vendor  | Sengled  |

--- a/devices/F-MLT-US-2.md
+++ b/devices/F-MLT-US-2.md
@@ -1,8 +1,13 @@
+---
+title: "SmartThings F-MLT-US-2 control via MQTT"
+description: "Integrate your SmartThings F-MLT-US-2 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# SmartThings F-MLT-US-2
 
 | Model | F-MLT-US-2  |
 | Vendor  | SmartThings  |

--- a/devices/F7C033.md
+++ b/devices/F7C033.md
@@ -1,8 +1,13 @@
+---
+title: "Belkin F7C033 control via MQTT"
+description: "Integrate your Belkin F7C033 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Belkin F7C033
 
 | Model | F7C033  |
 | Vendor  | Belkin  |

--- a/devices/GD-CZ-006.md
+++ b/devices/GD-CZ-006.md
@@ -1,8 +1,13 @@
+---
+title: "Gledopto GD-CZ-006 control via MQTT"
+description: "Integrate your Gledopto GD-CZ-006 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Gledopto GD-CZ-006
 
 | Model | GD-CZ-006  |
 | Vendor  | Gledopto  |

--- a/devices/GL-B-001Z.md
+++ b/devices/GL-B-001Z.md
@@ -1,8 +1,13 @@
+---
+title: "Gledopto GL-B-001Z control via MQTT"
+description: "Integrate your Gledopto GL-B-001Z via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Gledopto GL-B-001Z
 
 | Model | GL-B-001Z  |
 | Vendor  | Gledopto  |

--- a/devices/GL-B-007Z.md
+++ b/devices/GL-B-007Z.md
@@ -1,8 +1,13 @@
+---
+title: "Gledopto GL-B-007Z control via MQTT"
+description: "Integrate your Gledopto GL-B-007Z via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Gledopto GL-B-007Z
 
 | Model | GL-B-007Z  |
 | Vendor  | Gledopto  |

--- a/devices/GL-B-008Z.md
+++ b/devices/GL-B-008Z.md
@@ -1,8 +1,13 @@
+---
+title: "Gledopto GL-B-008Z control via MQTT"
+description: "Integrate your Gledopto GL-B-008Z via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Gledopto GL-B-008Z
 
 | Model | GL-B-008Z  |
 | Vendor  | Gledopto  |

--- a/devices/GL-C-006_GL-C-009.md
+++ b/devices/GL-C-006_GL-C-009.md
@@ -1,8 +1,13 @@
+---
+title: "Gledopto GL-C-006/GL-C-009 control via MQTT"
+description: "Integrate your Gledopto GL-C-006/GL-C-009 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Gledopto GL-C-006/GL-C-009
 
 | Model | GL-C-006/GL-C-009  |
 | Vendor  | Gledopto  |

--- a/devices/GL-C-008.md
+++ b/devices/GL-C-008.md
@@ -1,8 +1,13 @@
+---
+title: "Gledopto GL-C-008 control via MQTT"
+description: "Integrate your Gledopto GL-C-008 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Gledopto GL-C-008
 
 | Model | GL-C-008  |
 | Vendor  | Gledopto  |

--- a/devices/GL-D-003Z.md
+++ b/devices/GL-D-003Z.md
@@ -1,8 +1,13 @@
+---
+title: "Gledopto GL-D-003Z control via MQTT"
+description: "Integrate your Gledopto GL-D-003Z via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Gledopto GL-D-003Z
 
 | Model | GL-D-003Z  |
 | Vendor  | Gledopto  |

--- a/devices/GL-FL-004TZ.md
+++ b/devices/GL-FL-004TZ.md
@@ -1,8 +1,13 @@
+---
+title: "Gledopto GL-FL-004TZ control via MQTT"
+description: "Integrate your Gledopto GL-FL-004TZ via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Gledopto GL-FL-004TZ
 
 | Model | GL-FL-004TZ  |
 | Vendor  | Gledopto  |

--- a/devices/GL-G-001Z.md
+++ b/devices/GL-G-001Z.md
@@ -1,8 +1,13 @@
+---
+title: "Gledopto GL-G-001Z control via MQTT"
+description: "Integrate your Gledopto GL-G-001Z via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Gledopto GL-G-001Z
 
 | Model | GL-G-001Z  |
 | Vendor  | Gledopto  |

--- a/devices/GL-S-003Z.md
+++ b/devices/GL-S-003Z.md
@@ -1,8 +1,13 @@
+---
+title: "Gledopto GL-S-003Z control via MQTT"
+description: "Integrate your Gledopto GL-S-003Z via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Gledopto GL-S-003Z
 
 | Model | GL-S-003Z  |
 | Vendor  | Gledopto  |

--- a/devices/GL-S-004Z.md
+++ b/devices/GL-S-004Z.md
@@ -1,8 +1,13 @@
+---
+title: "Gledopto GL-S-004Z control via MQTT"
+description: "Integrate your Gledopto GL-S-004Z via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Gledopto GL-S-004Z
 
 | Model | GL-S-004Z  |
 | Vendor  | Gledopto  |

--- a/devices/GL-S-007Z.md
+++ b/devices/GL-S-007Z.md
@@ -1,8 +1,13 @@
+---
+title: "Gledopto GL-S-007Z control via MQTT"
+description: "Integrate your Gledopto GL-S-007Z via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Gledopto GL-S-007Z
 
 | Model | GL-S-007Z  |
 | Vendor  | Gledopto  |

--- a/devices/GR-ZB01-W.md
+++ b/devices/GR-ZB01-W.md
@@ -1,8 +1,13 @@
+---
+title: "AXIS GR-ZB01-W control via MQTT"
+description: "Integrate your AXIS GR-ZB01-W via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# AXIS GR-ZB01-W
 
 | Model | GR-ZB01-W  |
 | Vendor  | AXIS  |

--- a/devices/HALIGHTDIMWWB22.md
+++ b/devices/HALIGHTDIMWWB22.md
@@ -1,8 +1,13 @@
+---
+title: "Hive HALIGHTDIMWWB22 control via MQTT"
+description: "Integrate your Hive HALIGHTDIMWWB22 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Hive HALIGHTDIMWWB22
 
 | Model | HALIGHTDIMWWB22  |
 | Vendor  | Hive  |

--- a/devices/HALIGHTDIMWWE27.md
+++ b/devices/HALIGHTDIMWWE27.md
@@ -1,8 +1,13 @@
+---
+title: "Hive HALIGHTDIMWWE27 control via MQTT"
+description: "Integrate your Hive HALIGHTDIMWWE27 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Hive HALIGHTDIMWWE27
 
 | Model | HALIGHTDIMWWE27  |
 | Vendor  | Hive  |

--- a/devices/HEIMAN-M1.md
+++ b/devices/HEIMAN-M1.md
@@ -1,8 +1,13 @@
+---
+title: "HEIMAN HEIMAN-M1 control via MQTT"
+description: "Integrate your HEIMAN HEIMAN-M1 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# HEIMAN HEIMAN-M1
 
 | Model | HEIMAN-M1  |
 | Vendor  | HEIMAN  |

--- a/devices/HGZB-01A.md
+++ b/devices/HGZB-01A.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A HGZB-01A control via MQTT"
+description: "Integrate your Nue / 3A HGZB-01A via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A HGZB-01A
 
 | Model | HGZB-01A  |
 | Vendor  | Nue / 3A  |

--- a/devices/HGZB-01A_02A.md
+++ b/devices/HGZB-01A_02A.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A HGZB-01A/02A control via MQTT"
+description: "Integrate your Nue / 3A HGZB-01A/02A via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A HGZB-01A/02A
 
 | Model | HGZB-01A/02A  |
 | Vendor  | Nue / 3A  |

--- a/devices/HGZB-02A.md
+++ b/devices/HGZB-02A.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A HGZB-02A control via MQTT"
+description: "Integrate your Nue / 3A HGZB-02A via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A HGZB-02A
 
 | Model | HGZB-02A  |
 | Vendor  | Nue / 3A  |

--- a/devices/HGZB-02S.md
+++ b/devices/HGZB-02S.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A HGZB-02S control via MQTT"
+description: "Integrate your Nue / 3A HGZB-02S via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A HGZB-02S
 
 | Model | HGZB-02S  |
 | Vendor  | Nue / 3A  |

--- a/devices/HGZB-042.md
+++ b/devices/HGZB-042.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A HGZB-042 control via MQTT"
+description: "Integrate your Nue / 3A HGZB-042 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A HGZB-042
 
 | Model | HGZB-042  |
 | Vendor  | Nue / 3A  |

--- a/devices/HGZB-043.md
+++ b/devices/HGZB-043.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A HGZB-043 control via MQTT"
+description: "Integrate your Nue / 3A HGZB-043 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A HGZB-043
 
 | Model | HGZB-043  |
 | Vendor  | Nue / 3A  |

--- a/devices/HGZB-045.md
+++ b/devices/HGZB-045.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A HGZB-045 control via MQTT"
+description: "Integrate your Nue / 3A HGZB-045 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A HGZB-045
 
 | Model | HGZB-045  |
 | Vendor  | Nue / 3A  |

--- a/devices/HGZB-04D.md
+++ b/devices/HGZB-04D.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A HGZB-04D control via MQTT"
+description: "Integrate your Nue / 3A HGZB-04D via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A HGZB-04D
 
 | Model | HGZB-04D  |
 | Vendor  | Nue / 3A  |

--- a/devices/HGZB-06A.md
+++ b/devices/HGZB-06A.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A HGZB-06A control via MQTT"
+description: "Integrate your Nue / 3A HGZB-06A via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A HGZB-06A
 
 | Model | HGZB-06A  |
 | Vendor  | Nue / 3A  |

--- a/devices/HGZB-07A.md
+++ b/devices/HGZB-07A.md
@@ -1,8 +1,13 @@
+---
+title: "Smart Home Pty HGZB-07A control via MQTT"
+description: "Integrate your Smart Home Pty HGZB-07A via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Smart Home Pty HGZB-07A
 
 | Model | HGZB-07A  |
 | Vendor  | Smart Home Pty  |

--- a/devices/HGZB-1S.md
+++ b/devices/HGZB-1S.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A HGZB-1S control via MQTT"
+description: "Integrate your Nue / 3A HGZB-1S via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A HGZB-1S
 
 | Model | HGZB-1S  |
 | Vendor  | Nue / 3A  |

--- a/devices/HGZB-20-DE.md
+++ b/devices/HGZB-20-DE.md
@@ -1,8 +1,13 @@
+---
+title: "Smart Home Pty HGZB-20-DE control via MQTT"
+description: "Integrate your Smart Home Pty HGZB-20-DE via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Smart Home Pty HGZB-20-DE
 
 | Model | HGZB-20-DE  |
 | Vendor  | Smart Home Pty  |

--- a/devices/HGZB-41.md
+++ b/devices/HGZB-41.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A HGZB-41 control via MQTT"
+description: "Integrate your Nue / 3A HGZB-41 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A HGZB-41
 
 | Model | HGZB-41  |
 | Vendor  | Nue / 3A  |

--- a/devices/HGZB-42-UK___HGZB-41.md
+++ b/devices/HGZB-42-UK___HGZB-41.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A HGZB-42-UK / HGZB-41 control via MQTT"
+description: "Integrate your Nue / 3A HGZB-42-UK / HGZB-41 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A HGZB-42-UK / HGZB-41
 
 | Model | HGZB-42-UK / HGZB-41  |
 | Vendor  | Nue / 3A  |

--- a/devices/HGZB-42.md
+++ b/devices/HGZB-42.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A HGZB-42 control via MQTT"
+description: "Integrate your Nue / 3A HGZB-42 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A HGZB-42
 
 | Model | HGZB-42  |
 | Vendor  | Nue / 3A  |

--- a/devices/HGZB-43.md
+++ b/devices/HGZB-43.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A HGZB-43 control via MQTT"
+description: "Integrate your Nue / 3A HGZB-43 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A HGZB-43
 
 | Model | HGZB-43  |
 | Vendor  | Nue / 3A  |

--- a/devices/HLC610-Z.md
+++ b/devices/HLC610-Z.md
@@ -1,8 +1,13 @@
+---
+title: "Shenzhen Homa HLC610-Z control via MQTT"
+description: "Integrate your Shenzhen Homa HLC610-Z via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Shenzhen Homa HLC610-Z
 
 | Model | HLC610-Z  |
 | Vendor  | Shenzhen Homa  |

--- a/devices/HLC821-Z-SC.md
+++ b/devices/HLC821-Z-SC.md
@@ -1,8 +1,13 @@
+---
+title: "Shenzhen Homa HLC821-Z-SC control via MQTT"
+description: "Integrate your Shenzhen Homa HLC821-Z-SC via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Shenzhen Homa HLC821-Z-SC
 
 | Model | HLC821-Z-SC  |
 | Vendor  | Shenzhen Homa  |

--- a/devices/HLD812-Z-SC.md
+++ b/devices/HLD812-Z-SC.md
@@ -1,8 +1,13 @@
+---
+title: "Shenzhen Homa HLD812-Z-SC control via MQTT"
+description: "Integrate your Shenzhen Homa HLD812-Z-SC via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Shenzhen Homa HLD812-Z-SC
 
 | Model | HLD812-Z-SC  |
 | Vendor  | Shenzhen Homa  |

--- a/devices/HS1-WL-E.md
+++ b/devices/HS1-WL-E.md
@@ -1,8 +1,13 @@
+---
+title: "HEIMAN HS1-WL-E control via MQTT"
+description: "Integrate your HEIMAN HS1-WL-E via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# HEIMAN HS1-WL-E
 
 | Model | HS1-WL-E  |
 | Vendor  | HEIMAN  |

--- a/devices/HS1CA-E.md
+++ b/devices/HS1CA-E.md
@@ -1,8 +1,13 @@
+---
+title: "HEIMAN HS1CA-E control via MQTT"
+description: "Integrate your HEIMAN HS1CA-E via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# HEIMAN HS1CA-E
 
 | Model | HS1CA-E  |
 | Vendor  | HEIMAN  |

--- a/devices/HS1CA-M.md
+++ b/devices/HS1CA-M.md
@@ -1,8 +1,13 @@
+---
+title: "HEIMAN HS1CA-M control via MQTT"
+description: "Integrate your HEIMAN HS1CA-M via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# HEIMAN HS1CA-M
 
 | Model | HS1CA-M  |
 | Vendor  | HEIMAN  |

--- a/devices/HS1DS-E.md
+++ b/devices/HS1DS-E.md
@@ -1,8 +1,13 @@
+---
+title: "HEIMAN HS1DS-E control via MQTT"
+description: "Integrate your HEIMAN HS1DS-E via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# HEIMAN HS1DS-E
 
 | Model | HS1DS-E  |
 | Vendor  | HEIMAN  |

--- a/devices/HS1DS_HS3DS.md
+++ b/devices/HS1DS_HS3DS.md
@@ -1,8 +1,13 @@
+---
+title: "HEIMAN HS1DS/HS3DS control via MQTT"
+description: "Integrate your HEIMAN HS1DS/HS3DS via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# HEIMAN HS1DS/HS3DS
 
 | Model | HS1DS/HS3DS  |
 | Vendor  | HEIMAN  |

--- a/devices/HS1RC-M.md
+++ b/devices/HS1RC-M.md
@@ -1,8 +1,13 @@
+---
+title: "HEIMAN HS1RC-M control via MQTT"
+description: "Integrate your HEIMAN HS1RC-M via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# HEIMAN HS1RC-M
 
 | Model | HS1RC-M  |
 | Vendor  | HEIMAN  |

--- a/devices/HS1SA.md
+++ b/devices/HS1SA.md
@@ -1,8 +1,13 @@
+---
+title: "HEIMAN HS1SA control via MQTT"
+description: "Integrate your HEIMAN HS1SA via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# HEIMAN HS1SA
 
 | Model | HS1SA  |
 | Vendor  | HEIMAN  |

--- a/devices/HS1WL_HS3WL.md
+++ b/devices/HS1WL_HS3WL.md
@@ -1,8 +1,13 @@
+---
+title: "HEIMAN HS1WL/HS3WL control via MQTT"
+description: "Integrate your HEIMAN HS1WL/HS3WL via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# HEIMAN HS1WL/HS3WL
 
 | Model | HS1WL/HS3WL  |
 | Vendor  | HEIMAN  |

--- a/devices/HS2SK.md
+++ b/devices/HS2SK.md
@@ -1,8 +1,13 @@
+---
+title: "HEIMAN HS2SK control via MQTT"
+description: "Integrate your HEIMAN HS2SK via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# HEIMAN HS2SK
 
 | Model | HS2SK  |
 | Vendor  | HEIMAN  |

--- a/devices/HS2WD-E.md
+++ b/devices/HS2WD-E.md
@@ -1,8 +1,13 @@
+---
+title: "HEIMAN HS2WD-E control via MQTT"
+description: "Integrate your HEIMAN HS2WD-E via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# HEIMAN HS2WD-E
 
 | Model | HS2WD-E  |
 | Vendor  | HEIMAN  |

--- a/devices/HS3CG.md
+++ b/devices/HS3CG.md
@@ -1,8 +1,13 @@
+---
+title: "HEIMAN HS3CG control via MQTT"
+description: "Integrate your HEIMAN HS3CG via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# HEIMAN HS3CG
 
 | Model | HS3CG  |
 | Vendor  | HEIMAN  |

--- a/devices/HS3MS.md
+++ b/devices/HS3MS.md
@@ -1,8 +1,13 @@
+---
+title: "HEIMAN HS3MS control via MQTT"
+description: "Integrate your HEIMAN HS3MS via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# HEIMAN HS3MS
 
 | Model | HS3MS  |
 | Vendor  | HEIMAN  |

--- a/devices/HS3SA.md
+++ b/devices/HS3SA.md
@@ -1,8 +1,13 @@
+---
+title: "HEIMAN HS3SA control via MQTT"
+description: "Integrate your HEIMAN HS3SA via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# HEIMAN HS3SA
 
 | Model | HS3SA  |
 | Vendor  | HEIMAN  |

--- a/devices/HV-GSCXZB269.md
+++ b/devices/HV-GSCXZB269.md
@@ -1,8 +1,13 @@
+---
+title: "Hive HV-GSCXZB269 control via MQTT"
+description: "Integrate your Hive HV-GSCXZB269 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Hive HV-GSCXZB269
 
 | Model | HV-GSCXZB269  |
 | Vendor  | Hive  |

--- a/devices/HV-GSCXZB279_HV-GSCXZB229.md
+++ b/devices/HV-GSCXZB279_HV-GSCXZB229.md
@@ -1,8 +1,13 @@
+---
+title: "Hive HV-GSCXZB279_HV-GSCXZB229 control via MQTT"
+description: "Integrate your Hive HV-GSCXZB279_HV-GSCXZB229 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Hive HV-GSCXZB279_HV-GSCXZB229
 
 | Model | HV-GSCXZB279_HV-GSCXZB229  |
 | Vendor  | Hive  |

--- a/devices/ICPSHC24-10EU-IL-1.md
+++ b/devices/ICPSHC24-10EU-IL-1.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA ICPSHC24-10EU-IL-1 control via MQTT"
+description: "Integrate your IKEA ICPSHC24-10EU-IL-1 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA ICPSHC24-10EU-IL-1
 
 | Model | ICPSHC24-10EU-IL-1  |
 | Vendor  | IKEA  |

--- a/devices/ICPSHC24-30EU-IL-1.md
+++ b/devices/ICPSHC24-30EU-IL-1.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA ICPSHC24-30EU-IL-1 control via MQTT"
+description: "Integrate your IKEA ICPSHC24-30EU-IL-1 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA ICPSHC24-30EU-IL-1
 
 | Model | ICPSHC24-30EU-IL-1  |
 | Vendor  | IKEA  |

--- a/devices/ICTC-G-1.md
+++ b/devices/ICTC-G-1.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA ICTC-G-1 control via MQTT"
+description: "Integrate your IKEA ICTC-G-1 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA ICTC-G-1
 
 | Model | ICTC-G-1  |
 | Vendor  | IKEA  |

--- a/devices/ICZB-IW11D.md
+++ b/devices/ICZB-IW11D.md
@@ -1,8 +1,13 @@
+---
+title: "iCasa ICZB-IW11D control via MQTT"
+description: "Integrate your iCasa ICZB-IW11D via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# iCasa ICZB-IW11D
 
 | Model | ICZB-IW11D  |
 | Vendor  | iCasa  |

--- a/devices/IM-Z3.0-DIM.md
+++ b/devices/IM-Z3.0-DIM.md
@@ -1,8 +1,13 @@
+---
+title: "Immax IM-Z3.0-DIM control via MQTT"
+description: "Integrate your Immax IM-Z3.0-DIM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Immax IM-Z3.0-DIM
 
 | Model | IM-Z3.0-DIM  |
 | Vendor  | Immax  |

--- a/devices/IM6001-BTP01.md
+++ b/devices/IM6001-BTP01.md
@@ -1,8 +1,13 @@
+---
+title: "SmartThings IM6001-BTP01 control via MQTT"
+description: "Integrate your SmartThings IM6001-BTP01 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# SmartThings IM6001-BTP01
 
 | Model | IM6001-BTP01  |
 | Vendor  | SmartThings  |

--- a/devices/IM6001-MPP01.md
+++ b/devices/IM6001-MPP01.md
@@ -1,8 +1,13 @@
+---
+title: "SmartThings IM6001-MPP01 control via MQTT"
+description: "Integrate your SmartThings IM6001-MPP01 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# SmartThings IM6001-MPP01
 
 | Model | IM6001-MPP01  |
 | Vendor  | SmartThings  |

--- a/devices/IM6001-MTP01.md
+++ b/devices/IM6001-MTP01.md
@@ -1,8 +1,13 @@
+---
+title: "SmartThings IM6001-MTP01 control via MQTT"
+description: "Integrate your SmartThings IM6001-MTP01 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# SmartThings IM6001-MTP01
 
 | Model | IM6001-MTP01  |
 | Vendor  | SmartThings  |

--- a/devices/IM6001-OTP05.md
+++ b/devices/IM6001-OTP05.md
@@ -1,8 +1,13 @@
+---
+title: "SmartThings IM6001-OTP05 control via MQTT"
+description: "Integrate your SmartThings IM6001-OTP05 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# SmartThings IM6001-OTP05
 
 | Model | IM6001-OTP05  |
 | Vendor  | SmartThings  |

--- a/devices/ISW-ZPR1-WP13.md
+++ b/devices/ISW-ZPR1-WP13.md
@@ -1,8 +1,13 @@
+---
+title: "Bosch ISW-ZPR1-WP13 control via MQTT"
+description: "Integrate your Bosch ISW-ZPR1-WP13 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Bosch ISW-ZPR1-WP13
 
 | Model | ISW-ZPR1-WP13  |
 | Vendor  | Bosch  |

--- a/devices/JTQJ-BF-01LM_BW.md
+++ b/devices/JTQJ-BF-01LM_BW.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi JTQJ-BF-01LM/BW control via MQTT"
+description: "Integrate your Xiaomi JTQJ-BF-01LM/BW via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi JTQJ-BF-01LM/BW
 
 | Model | JTQJ-BF-01LM/BW  |
 | Vendor  | Xiaomi  |

--- a/devices/JTYJ-GD-01LM_BW.md
+++ b/devices/JTYJ-GD-01LM_BW.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi JTYJ-GD-01LM/BW control via MQTT"
+description: "Integrate your Xiaomi JTYJ-GD-01LM/BW via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi JTYJ-GD-01LM/BW
 
 | Model | JTYJ-GD-01LM/BW  |
 | Vendor  | Xiaomi  |

--- a/devices/K2RGBW01.md
+++ b/devices/K2RGBW01.md
@@ -1,8 +1,13 @@
+---
+title: "JIAWEN K2RGBW01 control via MQTT"
+description: "Integrate your JIAWEN K2RGBW01 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# JIAWEN K2RGBW01
 
 | Model | K2RGBW01  |
 | Vendor  | JIAWEN  |

--- a/devices/KS-SM001.md
+++ b/devices/KS-SM001.md
@@ -1,8 +1,13 @@
+---
+title: "Ksentry Electronics KS-SM001 control via MQTT"
+description: "Integrate your Ksentry Electronics KS-SM001 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Ksentry Electronics KS-SM001
 
 | Model | KS-SM001  |
 | Vendor  | Ksentry Electronics  |

--- a/devices/L1527.md
+++ b/devices/L1527.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA L1527 control via MQTT"
+description: "Integrate your IKEA L1527 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA L1527
 
 | Model | L1527  |
 | Vendor  | IKEA  |

--- a/devices/L1528.md
+++ b/devices/L1528.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA L1528 control via MQTT"
+description: "Integrate your IKEA L1528 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA L1528
 
 | Model | L1528  |
 | Vendor  | IKEA  |

--- a/devices/L1529.md
+++ b/devices/L1529.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA L1529 control via MQTT"
+description: "Integrate your IKEA L1529 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA L1529
 
 | Model | L1529  |
 | Vendor  | IKEA  |

--- a/devices/L1531.md
+++ b/devices/L1531.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA L1531 control via MQTT"
+description: "Integrate your IKEA L1531 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA L1531
 
 | Model | L1531  |
 | Vendor  | IKEA  |

--- a/devices/LED1536G5.md
+++ b/devices/LED1536G5.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA LED1536G5 control via MQTT"
+description: "Integrate your IKEA LED1536G5 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA LED1536G5
 
 | Model | LED1536G5  |
 | Vendor  | IKEA  |

--- a/devices/LED1537R6.md
+++ b/devices/LED1537R6.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA LED1537R6 control via MQTT"
+description: "Integrate your IKEA LED1537R6 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA LED1537R6
 
 | Model | LED1537R6  |
 | Vendor  | IKEA  |

--- a/devices/LED1545G12.md
+++ b/devices/LED1545G12.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA LED1545G12 control via MQTT"
+description: "Integrate your IKEA LED1545G12 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA LED1545G12
 
 | Model | LED1545G12  |
 | Vendor  | IKEA  |

--- a/devices/LED1546G12.md
+++ b/devices/LED1546G12.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA LED1546G12 control via MQTT"
+description: "Integrate your IKEA LED1546G12 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA LED1546G12
 
 | Model | LED1546G12  |
 | Vendor  | IKEA  |

--- a/devices/LED1622G12.md
+++ b/devices/LED1622G12.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA LED1622G12 control via MQTT"
+description: "Integrate your IKEA LED1622G12 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA LED1622G12
 
 | Model | LED1622G12  |
 | Vendor  | IKEA  |

--- a/devices/LED1623G12.md
+++ b/devices/LED1623G12.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA LED1623G12 control via MQTT"
+description: "Integrate your IKEA LED1623G12 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA LED1623G12
 
 | Model | LED1623G12  |
 | Vendor  | IKEA  |

--- a/devices/LED1624G9.md
+++ b/devices/LED1624G9.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA LED1624G9 control via MQTT"
+description: "Integrate your IKEA LED1624G9 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA LED1624G9
 
 | Model | LED1624G9  |
 | Vendor  | IKEA  |

--- a/devices/LED1649C5.md
+++ b/devices/LED1649C5.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA LED1649C5 control via MQTT"
+description: "Integrate your IKEA LED1649C5 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA LED1649C5
 
 | Model | LED1649C5  |
 | Vendor  | IKEA  |

--- a/devices/LED1650R5.md
+++ b/devices/LED1650R5.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA LED1650R5 control via MQTT"
+description: "Integrate your IKEA LED1650R5 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA LED1650R5
 
 | Model | LED1650R5  |
 | Vendor  | IKEA  |

--- a/devices/LED1732G11.md
+++ b/devices/LED1732G11.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA LED1732G11 control via MQTT"
+description: "Integrate your IKEA LED1732G11 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA LED1732G11
 
 | Model | LED1732G11  |
 | Vendor  | IKEA  |

--- a/devices/LED1733G7.md
+++ b/devices/LED1733G7.md
@@ -1,8 +1,13 @@
+---
+title: "IKEA LED1733G7 control via MQTT"
+description: "Integrate your IKEA LED1733G7 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# IKEA LED1733G7
 
 | Model | LED1733G7  |
 | Vendor  | IKEA  |

--- a/devices/LLKZMK11LM.md
+++ b/devices/LLKZMK11LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi LLKZMK11LM control via MQTT"
+description: "Integrate your Xiaomi LLKZMK11LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi LLKZMK11LM
 
 | Model | LLKZMK11LM  |
 | Vendor  | Xiaomi  |

--- a/devices/LTFY004.md
+++ b/devices/LTFY004.md
@@ -1,8 +1,13 @@
+---
+title: "Sylvania LTFY004 control via MQTT"
+description: "Integrate your Sylvania LTFY004 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sylvania LTFY004
 
 | Model | LTFY004  |
 | Vendor  | Sylvania  |

--- a/devices/LVS-SM10ZW.md
+++ b/devices/LVS-SM10ZW.md
@@ -1,8 +1,13 @@
+---
+title: "LivingWise LVS-SM10ZW control via MQTT"
+description: "Integrate your LivingWise LVS-SM10ZW via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# LivingWise LVS-SM10ZW
 
 | Model | LVS-SM10ZW  |
 | Vendor  | LivingWise  |

--- a/devices/LVS-ZB500D.md
+++ b/devices/LVS-ZB500D.md
@@ -1,8 +1,13 @@
+---
+title: "LivingWise LVS-ZB500D control via MQTT"
+description: "Integrate your LivingWise LVS-ZB500D via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# LivingWise LVS-ZB500D
 
 | Model | LVS-ZB500D  |
 | Vendor  | LivingWise  |

--- a/devices/LXZB-02A.md
+++ b/devices/LXZB-02A.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A LXZB-02A control via MQTT"
+description: "Integrate your Nue / 3A LXZB-02A via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A LXZB-02A
 
 | Model | LXZB-02A  |
 | Vendor  | Nue / 3A  |

--- a/devices/M350STW1.md
+++ b/devices/M350STW1.md
@@ -1,8 +1,13 @@
+---
+title: "Leedarson M350STW1 control via MQTT"
+description: "Integrate your Leedarson M350STW1 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Leedarson M350STW1
 
 | Model | M350STW1  |
 | Vendor  | Leedarson  |

--- a/devices/MCCGQ01LM.md
+++ b/devices/MCCGQ01LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi MCCGQ01LM control via MQTT"
+description: "Integrate your Xiaomi MCCGQ01LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi MCCGQ01LM
 
 | Model | MCCGQ01LM  |
 | Vendor  | Xiaomi  |

--- a/devices/MCCGQ11LM.md
+++ b/devices/MCCGQ11LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi MCCGQ11LM control via MQTT"
+description: "Integrate your Xiaomi MCCGQ11LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi MCCGQ11LM
 
 | Model | MCCGQ11LM  |
 | Vendor  | Xiaomi  |

--- a/devices/MCT-340_E.md
+++ b/devices/MCT-340_E.md
@@ -1,8 +1,13 @@
+---
+title: "Visonic MCT-340 E control via MQTT"
+description: "Integrate your Visonic MCT-340 E via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Visonic MCT-340 E
 
 | Model | MCT-340 E  |
 | Vendor  | Visonic  |

--- a/devices/MCT-350_SMA.md
+++ b/devices/MCT-350_SMA.md
@@ -1,8 +1,13 @@
+---
+title: "Visonic MCT-350 SMA control via MQTT"
+description: "Integrate your Visonic MCT-350 SMA via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Visonic MCT-350 SMA
 
 | Model | MCT-350 SMA  |
 | Vendor  | Visonic  |

--- a/devices/MEAZON_BIZY_PLUG.md
+++ b/devices/MEAZON_BIZY_PLUG.md
@@ -1,8 +1,13 @@
+---
+title: "Meazon MEAZON_BIZY_PLUG control via MQTT"
+description: "Integrate your Meazon MEAZON_BIZY_PLUG via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Meazon MEAZON_BIZY_PLUG
 
 | Model | MEAZON_BIZY_PLUG  |
 | Vendor  | Meazon  |

--- a/devices/MEAZON_DINRAIL.md
+++ b/devices/MEAZON_DINRAIL.md
@@ -1,8 +1,13 @@
+---
+title: "Meazon MEAZON_DINRAIL control via MQTT"
+description: "Integrate your Meazon MEAZON_DINRAIL via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Meazon MEAZON_DINRAIL
 
 | Model | MEAZON_DINRAIL  |
 | Vendor  | Meazon  |

--- a/devices/MFKZQ01LM.md
+++ b/devices/MFKZQ01LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi MFKZQ01LM control via MQTT"
+description: "Integrate your Xiaomi MFKZQ01LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi MFKZQ01LM
 
 | Model | MFKZQ01LM  |
 | Vendor  | Xiaomi  |

--- a/devices/MG-AUWS01.md
+++ b/devices/MG-AUWS01.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A MG-AUWS01 control via MQTT"
+description: "Integrate your Nue / 3A MG-AUWS01 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A MG-AUWS01
 
 | Model | MG-AUWS01  |
 | Vendor  | Nue / 3A  |

--- a/devices/MLI-404011.md
+++ b/devices/MLI-404011.md
@@ -1,8 +1,13 @@
+---
+title: "Müller Licht MLI-404011 control via MQTT"
+description: "Integrate your Müller Licht MLI-404011 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Müller Licht MLI-404011
 
 | Model | MLI-404011  |
 | Vendor  | Müller Licht  |

--- a/devices/Mega23M12.md
+++ b/devices/Mega23M12.md
@@ -1,8 +1,13 @@
+---
+title: "Dresden Elektronik Mega23M12 control via MQTT"
+description: "Integrate your Dresden Elektronik Mega23M12 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Dresden Elektronik Mega23M12
 
 | Model | Mega23M12  |
 | Vendor  | Dresden Elektronik  |

--- a/devices/N2G-SP.md
+++ b/devices/N2G-SP.md
@@ -1,8 +1,13 @@
+---
+title: "NET2GRID N2G-SP control via MQTT"
+description: "Integrate your NET2GRID N2G-SP via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# NET2GRID N2G-SP
 
 | Model | N2G-SP  |
 | Vendor  | NET2GRID  |

--- a/devices/NCZ-3011-HA.md
+++ b/devices/NCZ-3011-HA.md
@@ -1,8 +1,13 @@
+---
+title: "Nyce NCZ-3011-HA control via MQTT"
+description: "Integrate your Nyce NCZ-3011-HA via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nyce NCZ-3011-HA
 
 | Model | NCZ-3011-HA  |
 | Vendor  | Nyce  |

--- a/devices/NCZ-3041-HA.md
+++ b/devices/NCZ-3041-HA.md
@@ -1,8 +1,13 @@
+---
+title: "Nyce NCZ-3041-HA control via MQTT"
+description: "Integrate your Nyce NCZ-3041-HA via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nyce NCZ-3041-HA
 
 | Model | NCZ-3041-HA  |
 | Vendor  | Nyce  |

--- a/devices/NCZ-3043-HA.md
+++ b/devices/NCZ-3043-HA.md
@@ -1,8 +1,13 @@
+---
+title: "Nyce NCZ-3043-HA control via MQTT"
+description: "Integrate your Nyce NCZ-3043-HA via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nyce NCZ-3043-HA
 
 | Model | NCZ-3043-HA  |
 | Vendor  | Nyce  |

--- a/devices/NCZ-3045-HA.md
+++ b/devices/NCZ-3045-HA.md
@@ -1,8 +1,13 @@
+---
+title: "Nyce NCZ-3045-HA control via MQTT"
+description: "Integrate your Nyce NCZ-3045-HA via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nyce NCZ-3045-HA
 
 | Model | NCZ-3045-HA  |
 | Vendor  | Nyce  |

--- a/devices/NL08-0800.md
+++ b/devices/NL08-0800.md
@@ -1,8 +1,13 @@
+---
+title: "Nanoleaf NL08-0800 control via MQTT"
+description: "Integrate your Nanoleaf NL08-0800 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nanoleaf NL08-0800
 
 | Model | NL08-0800  |
 | Vendor  | Nanoleaf  |

--- a/devices/PLUG_EDP_RE_DY.md
+++ b/devices/PLUG_EDP_RE_DY.md
@@ -1,8 +1,13 @@
+---
+title: "EDP PLUG EDP RE:DY control via MQTT"
+description: "Integrate your EDP PLUG EDP RE:DY via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# EDP PLUG EDP RE:DY
 
 | Model | PLUG EDP RE:DY  |
 | Vendor  | EDP  |

--- a/devices/PL_110.md
+++ b/devices/PL_110.md
@@ -1,8 +1,13 @@
+---
+title: "Innr PL 110 control via MQTT"
+description: "Integrate your Innr PL 110 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr PL 110
 
 | Model | PL 110  |
 | Vendor  | Innr  |

--- a/devices/PP-WHT-US.md
+++ b/devices/PP-WHT-US.md
@@ -1,8 +1,13 @@
+---
+title: "Securifi PP-WHT-US control via MQTT"
+description: "Integrate your Securifi PP-WHT-US via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Securifi PP-WHT-US
 
 | Model | PP-WHT-US  |
 | Vendor  | Securifi  |

--- a/devices/PSM-29ZBSR.md
+++ b/devices/PSM-29ZBSR.md
@@ -1,8 +1,13 @@
+---
+title: "Climax PSM-29ZBSR control via MQTT"
+description: "Integrate your Climax PSM-29ZBSR via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Climax PSM-29ZBSR
 
 | Model | PSM-29ZBSR  |
 | Vendor  | Climax  |

--- a/devices/PSS-23ZBS.md
+++ b/devices/PSS-23ZBS.md
@@ -1,8 +1,13 @@
+---
+title: "Climax PSS-23ZBS control via MQTT"
+description: "Integrate your Climax PSS-23ZBS via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Climax PSS-23ZBS
 
 | Model | PSS-23ZBS  |
 | Vendor  | Climax  |

--- a/devices/QBCZ11LM.md
+++ b/devices/QBCZ11LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi QBCZ11LM control via MQTT"
+description: "Integrate your Xiaomi QBCZ11LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi QBCZ11LM
 
 | Model | QBCZ11LM  |
 | Vendor  | Xiaomi  |

--- a/devices/QBKG03LM.md
+++ b/devices/QBKG03LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi QBKG03LM control via MQTT"
+description: "Integrate your Xiaomi QBKG03LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi QBKG03LM
 
 | Model | QBKG03LM  |
 | Vendor  | Xiaomi  |

--- a/devices/QBKG04LM.md
+++ b/devices/QBKG04LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi QBKG04LM control via MQTT"
+description: "Integrate your Xiaomi QBKG04LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi QBKG04LM
 
 | Model | QBKG04LM  |
 | Vendor  | Xiaomi  |

--- a/devices/QBKG11LM.md
+++ b/devices/QBKG11LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi QBKG11LM control via MQTT"
+description: "Integrate your Xiaomi QBKG11LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi QBKG11LM
 
 | Model | QBKG11LM  |
 | Vendor  | Xiaomi  |

--- a/devices/QBKG12LM.md
+++ b/devices/QBKG12LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi QBKG12LM control via MQTT"
+description: "Integrate your Xiaomi QBKG12LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi QBKG12LM
 
 | Model | QBKG12LM  |
 | Vendor  | Xiaomi  |

--- a/devices/RADON_TriTech_ZB.md
+++ b/devices/RADON_TriTech_ZB.md
@@ -1,8 +1,13 @@
+---
+title: "Bosch RADON TriTech ZB control via MQTT"
+description: "Integrate your Bosch RADON TriTech ZB via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Bosch RADON TriTech ZB
 
 | Model | RADON TriTech ZB  |
 | Vendor  | Bosch  |

--- a/devices/RB_145.md
+++ b/devices/RB_145.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RB 145 control via MQTT"
+description: "Integrate your Innr RB 145 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RB 145
 
 | Model | RB 145  |
 | Vendor  | Innr  |

--- a/devices/RB_165.md
+++ b/devices/RB_165.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RB 165 control via MQTT"
+description: "Integrate your Innr RB 165 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RB 165
 
 | Model | RB 165  |
 | Vendor  | Innr  |

--- a/devices/RB_175_W.md
+++ b/devices/RB_175_W.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RB 175 W control via MQTT"
+description: "Integrate your Innr RB 175 W via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RB 175 W
 
 | Model | RB 175 W  |
 | Vendor  | Innr  |

--- a/devices/RB_178_T.md
+++ b/devices/RB_178_T.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RB 178 T control via MQTT"
+description: "Integrate your Innr RB 178 T via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RB 178 T
 
 | Model | RB 178 T  |
 | Vendor  | Innr  |

--- a/devices/RB_185_C.md
+++ b/devices/RB_185_C.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RB 185 C control via MQTT"
+description: "Integrate your Innr RB 185 C via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RB 185 C
 
 | Model | RB 185 C  |
 | Vendor  | Innr  |

--- a/devices/RB_245.md
+++ b/devices/RB_245.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RB 245 control via MQTT"
+description: "Integrate your Innr RB 245 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RB 245
 
 | Model | RB 245  |
 | Vendor  | Innr  |

--- a/devices/RB_248_T.md
+++ b/devices/RB_248_T.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RB 248 T control via MQTT"
+description: "Integrate your Innr RB 248 T via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RB 248 T
 
 | Model | RB 248 T  |
 | Vendor  | Innr  |

--- a/devices/RB_250_C.md
+++ b/devices/RB_250_C.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RB 250 C control via MQTT"
+description: "Integrate your Innr RB 250 C via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RB 250 C
 
 | Model | RB 250 C  |
 | Vendor  | Innr  |

--- a/devices/RB_265.md
+++ b/devices/RB_265.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RB 265 control via MQTT"
+description: "Integrate your Innr RB 265 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RB 265
 
 | Model | RB 265  |
 | Vendor  | Innr  |

--- a/devices/RB_278_T.md
+++ b/devices/RB_278_T.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RB 278 T control via MQTT"
+description: "Integrate your Innr RB 278 T via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RB 278 T
 
 | Model | RB 278 T  |
 | Vendor  | Innr  |

--- a/devices/RB_285_C.md
+++ b/devices/RB_285_C.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RB 285 C control via MQTT"
+description: "Integrate your Innr RB 285 C via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RB 285 C
 
 | Model | RB 285 C  |
 | Vendor  | Innr  |

--- a/devices/RH3040.md
+++ b/devices/RH3040.md
@@ -1,8 +1,13 @@
+---
+title: "TUYATEC RH3040 control via MQTT"
+description: "Integrate your TUYATEC RH3040 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# TUYATEC RH3040
 
 | Model | RH3040  |
 | Vendor  | TUYATEC  |

--- a/devices/ROB_200-004-0.md
+++ b/devices/ROB_200-004-0.md
@@ -1,8 +1,13 @@
+---
+title: "ROBB ROB_200-004-0 control via MQTT"
+description: "Integrate your ROBB ROB_200-004-0 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# ROBB ROB_200-004-0
 
 | Model | ROB_200-004-0  |
 | Vendor  | ROBB  |

--- a/devices/RS_122.md
+++ b/devices/RS_122.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RS 122 control via MQTT"
+description: "Integrate your Innr RS 122 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RS 122
 
 | Model | RS 122  |
 | Vendor  | Innr  |

--- a/devices/RS_125.md
+++ b/devices/RS_125.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RS 125 control via MQTT"
+description: "Integrate your Innr RS 125 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RS 125
 
 | Model | RS 125  |
 | Vendor  | Innr  |

--- a/devices/RS_128_T.md
+++ b/devices/RS_128_T.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RS 128 T control via MQTT"
+description: "Integrate your Innr RS 128 T via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RS 128 T
 
 | Model | RS 128 T  |
 | Vendor  | Innr  |

--- a/devices/RS_225.md
+++ b/devices/RS_225.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RS 225 control via MQTT"
+description: "Integrate your Innr RS 225 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RS 225
 
 | Model | RS 225  |
 | Vendor  | Innr  |

--- a/devices/RS_228_T.md
+++ b/devices/RS_228_T.md
@@ -1,8 +1,13 @@
+---
+title: "Innr RS 228 T control via MQTT"
+description: "Integrate your Innr RS 228 T via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr RS 228 T
 
 | Model | RS 228 T  |
 | Vendor  | Innr  |

--- a/devices/RTCGQ01LM.md
+++ b/devices/RTCGQ01LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi RTCGQ01LM control via MQTT"
+description: "Integrate your Xiaomi RTCGQ01LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi RTCGQ01LM
 
 | Model | RTCGQ01LM  |
 | Vendor  | Xiaomi  |

--- a/devices/RTCGQ11LM.md
+++ b/devices/RTCGQ11LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi RTCGQ11LM control via MQTT"
+description: "Integrate your Xiaomi RTCGQ11LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi RTCGQ11LM
 
 | Model | RTCGQ11LM  |
 | Vendor  | Xiaomi  |

--- a/devices/SCM-5ZBS.md
+++ b/devices/SCM-5ZBS.md
@@ -1,8 +1,13 @@
+---
+title: "Climax SCM-5ZBS control via MQTT"
+description: "Integrate your Climax SCM-5ZBS via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Climax SCM-5ZBS
 
 | Model | SCM-5ZBS  |
 | Vendor  | Climax  |

--- a/devices/SCM-S1.md
+++ b/devices/SCM-S1.md
@@ -1,8 +1,13 @@
+---
+title: "Blaupunkt SCM-S1 control via MQTT"
+description: "Integrate your Blaupunkt SCM-S1 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Blaupunkt SCM-S1
 
 | Model | SCM-S1  |
 | Vendor  | Blaupunkt  |

--- a/devices/SJCGQ11LM.md
+++ b/devices/SJCGQ11LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi SJCGQ11LM control via MQTT"
+description: "Integrate your Xiaomi SJCGQ11LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi SJCGQ11LM
 
 | Model | SJCGQ11LM  |
 | Vendor  | Xiaomi  |

--- a/devices/SL_110_M.md
+++ b/devices/SL_110_M.md
@@ -1,8 +1,13 @@
+---
+title: "Innr SL 110 M control via MQTT"
+description: "Integrate your Innr SL 110 M via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr SL 110 M
 
 | Model | SL 110 M  |
 | Vendor  | Innr  |

--- a/devices/SL_110_N.md
+++ b/devices/SL_110_N.md
@@ -1,8 +1,13 @@
+---
+title: "Innr SL 110 N control via MQTT"
+description: "Integrate your Innr SL 110 N via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr SL 110 N
 
 | Model | SL 110 N  |
 | Vendor  | Innr  |

--- a/devices/SL_110_W.md
+++ b/devices/SL_110_W.md
@@ -1,8 +1,13 @@
+---
+title: "Innr SL 110 W control via MQTT"
+description: "Integrate your Innr SL 110 W via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr SL 110 W
 
 | Model | SL 110 W  |
 | Vendor  | Innr  |

--- a/devices/SP600.md
+++ b/devices/SP600.md
@@ -1,8 +1,13 @@
+---
+title: "Salus SP600 control via MQTT"
+description: "Integrate your Salus SP600 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Salus SP600
 
 | Model | SP600  |
 | Vendor  | Salus  |

--- a/devices/SPZB0001.md
+++ b/devices/SPZB0001.md
@@ -1,8 +1,13 @@
+---
+title: "Eurotronic SPZB0001 control via MQTT"
+description: "Integrate your Eurotronic SPZB0001 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Eurotronic SPZB0001
 
 | Model | SPZB0001  |
 | Vendor  | Eurotronic  |

--- a/devices/SP_120.md
+++ b/devices/SP_120.md
@@ -1,8 +1,13 @@
+---
+title: "Innr SP 120 control via MQTT"
+description: "Integrate your Innr SP 120 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr SP 120
 
 | Model | SP 120  |
 | Vendor  | Innr  |

--- a/devices/ST218.md
+++ b/devices/ST218.md
@@ -1,8 +1,13 @@
+---
+title: "Stelpro ST218 control via MQTT"
+description: "Integrate your Stelpro ST218 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Stelpro ST218
 
 | Model | ST218  |
 | Vendor  | Stelpro  |

--- a/devices/ST8AU-CON.md
+++ b/devices/ST8AU-CON.md
@@ -1,8 +1,13 @@
+---
+title: "OSRAM ST8AU-CON control via MQTT"
+description: "Integrate your OSRAM ST8AU-CON via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# OSRAM ST8AU-CON
 
 | Model | ST8AU-CON  |
 | Vendor  | OSRAM  |

--- a/devices/STS-IRM-250.md
+++ b/devices/STS-IRM-250.md
@@ -1,8 +1,13 @@
+---
+title: "SmartThings STS-IRM-250 control via MQTT"
+description: "Integrate your SmartThings STS-IRM-250 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# SmartThings STS-IRM-250
 
 | Model | STS-IRM-250  |
 | Vendor  | SmartThings  |

--- a/devices/STS-PRS-251.md
+++ b/devices/STS-PRS-251.md
@@ -1,8 +1,13 @@
+---
+title: "SmartThings STS-PRS-251 control via MQTT"
+description: "Integrate your SmartThings STS-PRS-251 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# SmartThings STS-PRS-251
 
 | Model | STS-PRS-251  |
 | Vendor  | SmartThings  |

--- a/devices/STSS-MULT-001.md
+++ b/devices/STSS-MULT-001.md
@@ -1,8 +1,13 @@
+---
+title: "SmartThings STSS-MULT-001 control via MQTT"
+description: "Integrate your SmartThings STSS-MULT-001 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# SmartThings STSS-MULT-001
 
 | Model | STSS-MULT-001  |
 | Vendor  | SmartThings  |

--- a/devices/ST_110.md
+++ b/devices/ST_110.md
@@ -1,8 +1,13 @@
+---
+title: "Innr ST 110 control via MQTT"
+description: "Integrate your Innr ST 110 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr ST 110
 
 | Model | ST 110  |
 | Vendor  | Innr  |

--- a/devices/SV01.md
+++ b/devices/SV01.md
@@ -1,8 +1,13 @@
+---
+title: "Keen Home SV01 control via MQTT"
+description: "Integrate your Keen Home SV01 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Keen Home SV01
 
 | Model | SV01  |
 | Vendor  | Keen Home  |

--- a/devices/SV02.md
+++ b/devices/SV02.md
@@ -1,8 +1,13 @@
+---
+title: "Keen Home SV02 control via MQTT"
+description: "Integrate your Keen Home SV02 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Keen Home SV02
 
 | Model | SV02  |
 | Vendor  | Keen Home  |

--- a/devices/SWITCH_EDP_RE_DY.md
+++ b/devices/SWITCH_EDP_RE_DY.md
@@ -1,8 +1,13 @@
+---
+title: "EDP SWITCH EDP RE:DY control via MQTT"
+description: "Integrate your EDP SWITCH EDP RE:DY via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# EDP SWITCH EDP RE:DY
 
 | Model | SWITCH EDP RE:DY  |
 | Vendor  | EDP  |

--- a/devices/SWO-KEF1PA.md
+++ b/devices/SWO-KEF1PA.md
@@ -1,8 +1,13 @@
+---
+title: "Swann SWO-KEF1PA control via MQTT"
+description: "Integrate your Swann SWO-KEF1PA via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Swann SWO-KEF1PA
 
 | Model | SWO-KEF1PA  |
 | Vendor  | Swann  |

--- a/devices/SWO-WDS1PA.md
+++ b/devices/SWO-WDS1PA.md
@@ -1,8 +1,13 @@
+---
+title: "Swann SWO-WDS1PA control via MQTT"
+description: "Integrate your Swann SWO-WDS1PA via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Swann SWO-WDS1PA
 
 | Model | SWO-WDS1PA  |
 | Vendor  | Swann  |

--- a/devices/SZ-ESW01-AU.md
+++ b/devices/SZ-ESW01-AU.md
@@ -1,8 +1,13 @@
+---
+title: "Sercomm SZ-ESW01-AU control via MQTT"
+description: "Integrate your Sercomm SZ-ESW01-AU via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sercomm SZ-ESW01-AU
 
 | Model | SZ-ESW01-AU  |
 | Vendor  | Sercomm  |

--- a/devices/TI0001.md
+++ b/devices/TI0001.md
@@ -1,8 +1,13 @@
+---
+title: "Livolo TI0001 control via MQTT"
+description: "Integrate your Livolo TI0001 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Livolo TI0001
 
 | Model | TI0001  |
 | Vendor  | Livolo  |

--- a/devices/U86K31ND6.md
+++ b/devices/U86K31ND6.md
@@ -1,8 +1,13 @@
+---
+title: "Honyar U86K31ND6 control via MQTT"
+description: "Integrate your Honyar U86K31ND6 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Honyar U86K31ND6
 
 | Model | U86K31ND6  |
 | Vendor  | Honyar  |

--- a/devices/UC_110.md
+++ b/devices/UC_110.md
@@ -1,8 +1,13 @@
+---
+title: "Innr UC 110 control via MQTT"
+description: "Integrate your Innr UC 110 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Innr UC 110
 
 | Model | UC 110  |
 | Vendor  | Innr  |

--- a/devices/V3-BTZB.md
+++ b/devices/V3-BTZB.md
@@ -1,8 +1,13 @@
+---
+title: "Danalock V3-BTZB control via MQTT"
+description: "Integrate your Danalock V3-BTZB via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Danalock V3-BTZB
 
 | Model | V3-BTZB  |
 | Vendor  | Danalock  |

--- a/devices/WSDCGQ01LM.md
+++ b/devices/WSDCGQ01LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi WSDCGQ01LM control via MQTT"
+description: "Integrate your Xiaomi WSDCGQ01LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi WSDCGQ01LM
 
 | Model | WSDCGQ01LM  |
 | Vendor  | Xiaomi  |

--- a/devices/WSDCGQ11LM.md
+++ b/devices/WSDCGQ11LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi WSDCGQ11LM control via MQTT"
+description: "Integrate your Xiaomi WSDCGQ11LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi WSDCGQ11LM
 
 | Model | WSDCGQ11LM  |
 | Vendor  | Xiaomi  |

--- a/devices/WXKG01LM.md
+++ b/devices/WXKG01LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi WXKG01LM control via MQTT"
+description: "Integrate your Xiaomi WXKG01LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi WXKG01LM
 
 | Model | WXKG01LM  |
 | Vendor  | Xiaomi  |

--- a/devices/WXKG02LM.md
+++ b/devices/WXKG02LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi WXKG02LM control via MQTT"
+description: "Integrate your Xiaomi WXKG02LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi WXKG02LM
 
 | Model | WXKG02LM  |
 | Vendor  | Xiaomi  |

--- a/devices/WXKG03LM.md
+++ b/devices/WXKG03LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi WXKG03LM control via MQTT"
+description: "Integrate your Xiaomi WXKG03LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi WXKG03LM
 
 | Model | WXKG03LM  |
 | Vendor  | Xiaomi  |

--- a/devices/WXKG11LM.md
+++ b/devices/WXKG11LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi WXKG11LM control via MQTT"
+description: "Integrate your Xiaomi WXKG11LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi WXKG11LM
 
 | Model | WXKG11LM  |
 | Vendor  | Xiaomi  |

--- a/devices/WXKG12LM.md
+++ b/devices/WXKG12LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi WXKG12LM control via MQTT"
+description: "Integrate your Xiaomi WXKG12LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi WXKG12LM
 
 | Model | WXKG12LM  |
 | Vendor  | Xiaomi  |

--- a/devices/XVV-Mega23M12.md
+++ b/devices/XVV-Mega23M12.md
@@ -1,8 +1,13 @@
+---
+title: "Dresden Elektronik XVV-Mega23M12 control via MQTT"
+description: "Integrate your Dresden Elektronik XVV-Mega23M12 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Dresden Elektronik XVV-Mega23M12
 
 | Model | XVV-Mega23M12  |
 | Vendor  | Dresden Elektronik  |

--- a/devices/XY12S-15.md
+++ b/devices/XY12S-15.md
@@ -1,8 +1,13 @@
+---
+title: "Nue / 3A XY12S-15 control via MQTT"
+description: "Integrate your Nue / 3A XY12S-15 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Nue / 3A XY12S-15
 
 | Model | XY12S-15  |
 | Vendor  | Nue / 3A  |

--- a/devices/YMF40.md
+++ b/devices/YMF40.md
@@ -1,8 +1,13 @@
+---
+title: "Yale YMF40 control via MQTT"
+description: "Integrate your Yale YMF40 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Yale YMF40
 
 | Model | YMF40  |
 | Vendor  | Yale  |

--- a/devices/YRD226HA2619.md
+++ b/devices/YRD226HA2619.md
@@ -1,8 +1,13 @@
+---
+title: "Yale YRD226HA2619 control via MQTT"
+description: "Integrate your Yale YRD226HA2619 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Yale YRD226HA2619
 
 | Model | YRD226HA2619  |
 | Vendor  | Yale  |

--- a/devices/YRD256HA20BP.md
+++ b/devices/YRD256HA20BP.md
@@ -1,8 +1,13 @@
+---
+title: "Yale YRD256HA20BP control via MQTT"
+description: "Integrate your Yale YRD256HA20BP via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Yale YRD256HA20BP
 
 | Model | YRD256HA20BP  |
 | Vendor  | Yale  |

--- a/devices/YRD426NRSC.md
+++ b/devices/YRD426NRSC.md
@@ -1,8 +1,13 @@
+---
+title: "Yale YRD426NRSC control via MQTT"
+description: "Integrate your Yale YRD426NRSC via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Yale YRD426NRSC
 
 | Model | YRD426NRSC  |
 | Vendor  | Yale  |

--- a/devices/Z01-A19NAE26.md
+++ b/devices/Z01-A19NAE26.md
@@ -1,8 +1,13 @@
+---
+title: "Sengled Z01-A19NAE26 control via MQTT"
+description: "Integrate your Sengled Z01-A19NAE26 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sengled Z01-A19NAE26
 
 | Model | Z01-A19NAE26  |
 | Vendor  | Sengled  |

--- a/devices/Z01-CIA19NAE26.md
+++ b/devices/Z01-CIA19NAE26.md
@@ -1,8 +1,13 @@
+---
+title: "Sengled Z01-CIA19NAE26 control via MQTT"
+description: "Integrate your Sengled Z01-CIA19NAE26 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sengled Z01-CIA19NAE26
 
 | Model | Z01-CIA19NAE26  |
 | Vendor  | Sengled  |

--- a/devices/Z809A.md
+++ b/devices/Z809A.md
@@ -1,8 +1,13 @@
+---
+title: "Netvox Z809A control via MQTT"
+description: "Integrate your Netvox Z809A via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Netvox Z809A
 
 | Model | Z809A  |
 | Vendor  | Netvox  |

--- a/devices/Z809AF.md
+++ b/devices/Z809AF.md
@@ -1,8 +1,13 @@
+---
+title: "Ninja Blocks Z809AF control via MQTT"
+description: "Integrate your Ninja Blocks Z809AF via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Ninja Blocks Z809AF
 
 | Model | Z809AF  |
 | Vendor  | Ninja Blocks  |

--- a/devices/ZCTS-808.md
+++ b/devices/ZCTS-808.md
@@ -1,8 +1,13 @@
+---
+title: "Trust ZCTS-808 control via MQTT"
+description: "Integrate your Trust ZCTS-808 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Trust ZCTS-808
 
 | Model | ZCTS-808  |
 | Vendor  | Trust  |

--- a/devices/ZG9101SAC-HP.md
+++ b/devices/ZG9101SAC-HP.md
@@ -1,8 +1,13 @@
+---
+title: "Sunricher ZG9101SAC-HP control via MQTT"
+description: "Integrate your Sunricher ZG9101SAC-HP via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Sunricher ZG9101SAC-HP
 
 | Model | ZG9101SAC-HP  |
 | Vendor  | Sunricher  |

--- a/devices/ZGRC-KEY-013.md
+++ b/devices/ZGRC-KEY-013.md
@@ -1,8 +1,13 @@
+---
+title: "RGB Genie ZGRC-KEY-013 control via MQTT"
+description: "Integrate your RGB Genie ZGRC-KEY-013 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# RGB Genie ZGRC-KEY-013
 
 | Model | ZGRC-KEY-013  |
 | Vendor  | RGB Genie  |

--- a/devices/ZLED-2709.md
+++ b/devices/ZLED-2709.md
@@ -1,8 +1,13 @@
+---
+title: "Trust ZLED-2709 control via MQTT"
+description: "Integrate your Trust ZLED-2709 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Trust ZLED-2709
 
 | Model | ZLED-2709  |
 | Vendor  | Trust  |

--- a/devices/ZM350STW1TCF.md
+++ b/devices/ZM350STW1TCF.md
@@ -1,8 +1,13 @@
+---
+title: "Leedarson ZM350STW1TCF control via MQTT"
+description: "Integrate your Leedarson ZM350STW1TCF via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Leedarson ZM350STW1TCF
 
 | Model | ZM350STW1TCF  |
 | Vendor  | Leedarson  |

--- a/devices/ZNCLDJ11LM.md
+++ b/devices/ZNCLDJ11LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi ZNCLDJ11LM control via MQTT"
+description: "Integrate your Xiaomi ZNCLDJ11LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi ZNCLDJ11LM
 
 | Model | ZNCLDJ11LM  |
 | Vendor  | Xiaomi  |

--- a/devices/ZNCZ02LM.md
+++ b/devices/ZNCZ02LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi ZNCZ02LM control via MQTT"
+description: "Integrate your Xiaomi ZNCZ02LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi ZNCZ02LM
 
 | Model | ZNCZ02LM  |
 | Vendor  | Xiaomi  |

--- a/devices/ZNLDP12LM.md
+++ b/devices/ZNLDP12LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi ZNLDP12LM control via MQTT"
+description: "Integrate your Xiaomi ZNLDP12LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi ZNLDP12LM
 
 | Model | ZNLDP12LM  |
 | Vendor  | Xiaomi  |

--- a/devices/ZNMS12LM.md
+++ b/devices/ZNMS12LM.md
@@ -1,8 +1,13 @@
+---
+title: "Xiaomi ZNMS12LM control via MQTT"
+description: "Integrate your Xiaomi ZNMS12LM via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Xiaomi ZNMS12LM
 
 | Model | ZNMS12LM  |
 | Vendor  | Xiaomi  |

--- a/devices/ZPIR-8000.md
+++ b/devices/ZPIR-8000.md
@@ -1,8 +1,13 @@
+---
+title: "Trust ZPIR-8000 control via MQTT"
+description: "Integrate your Trust ZPIR-8000 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Trust ZPIR-8000
 
 | Model | ZPIR-8000  |
 | Vendor  | Trust  |

--- a/devices/ZYCT-202.md
+++ b/devices/ZYCT-202.md
@@ -1,8 +1,13 @@
+---
+title: "Trust ZYCT-202 control via MQTT"
+description: "Integrate your Trust ZYCT-202 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Trust ZYCT-202
 
 | Model | ZYCT-202  |
 | Vendor  | Trust  |

--- a/devices/ZigUP.md
+++ b/devices/ZigUP.md
@@ -1,8 +1,13 @@
+---
+title: "Custom devices (DiY) ZigUP control via MQTT"
+description: "Integrate your Custom devices (DiY) ZigUP via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Custom devices (DiY) ZigUP
 
 | Model | ZigUP  |
 | Vendor  | Custom devices (DiY)  |

--- a/docgen/device_page.js
+++ b/docgen/device_page.js
@@ -19,7 +19,7 @@ description: "Integrate your ${device.vendor} ${device.model} via Zigbee2mqtt wi
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device ${device.vendor} ${device.model}
+# ${device.vendor} ${device.model}
 
 | Model | ${device.model}  |
 | Vendor  | ${device.vendor}  |

--- a/docgen/device_page.js
+++ b/docgen/device_page.js
@@ -10,11 +10,16 @@ const homeassistant = new HomeassistantExtension(null, null, null, null);
 function generate(device) {
     const image = utils.getImage(device.model);
 
-    return `
+    return `---
+title: "${device.vendor} ${device.model} control via MQTT"
+description: "Integrate your ${device.vendor} ${device.model} via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
+
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docgen/device_page_notes.js)*
 
-# Device
+# Device ${device.vendor} ${device.model}
 
 | Model | ${device.model}  |
 | Vendor  | ${device.vendor}  |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "2.2"
+services:
+  site:
+    image: jekyll/jekyll:latest
+    command: bundle exec jekyll serve --host 0.0.0.0
+    working_dir: /srv/jekyll
+    environment:
+      - VIRTUAL_HOST=z2m.127.0.0.1.nip.io
+      - "VIRTUAL_PORT=4000"
+      - "JEKYLL_ENV=production"
+      - PAGES_REPO_NWO=Koenkk/zigbee2mqtt.io
+    volumes:
+      - $PWD/:/srv/jekyll
+      - $PWD/.bundle:/usr/local/bundle
+    networks:
+      - localhost
+
+networks:
+  localhost:
+     external: true

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-Agent: *
+
+Sitemap: https://www.zigbee2mqtt.io/sitemap.xml


### PR DESCRIPTION
documentation and device information through google is hard to find. 
The repository is ranked mainly on github, not the site. The main reason is meta tags. 

I recommend to close the repository from indexing https://github.com/Koenkk/zigbee2mqtt.io , you can do this by simply removing the master branch, and transfer the content for example to gh-pages. 

Then Google will rank the pages of the documentation site.