### PR TITLE
Wrap the Home Assistant config example with Jekyll raw tags

### DIFF
--- a/integration/home_assistant.md
+++ b/integration/home_assistant.md
@@ -18,6 +18,8 @@ This allows Zigbee2mqtt to automatically add devices to Home Assistant.
 To achieve the best possible integration (including MQTT discovery):
 - In your **Zigbee2mqtt** `configuration.yaml` set `homeassistant: true`
 - In your **Home Assistant** `configuration.yaml`:
+
+{% raw %}
 ```yaml
 mqtt:
   discovery: true
@@ -29,6 +31,7 @@ mqtt:
     topic: 'hass/status'
     payload: 'offline'
 ```
+{% endraw %}
 
 Mind you that if you want to use the embedded broker of Home Assistant you
 have to [follow this guide](https://www.home-assistant.io/docs/mqtt/broker#embedded-broker).


### PR DESCRIPTION
The first YAML config example in HA docs https://www.zigbee2mqtt.io/integration/home_assistant.html is rendered with incorrect indentation
![image](https://user-images.githubusercontent.com/1623257/61598235-be19cd80-ac1a-11e9-84d4-c228121669c4.png), so I've wrapped this block with raw tags to force Jekkyl preserving the indentation.
