### PR TITLE
Fixes incorrect label for E1603/E1702 notes

### DIFF
--- a/docgen/device_page_notes.js
+++ b/docgen/device_page_notes.js
@@ -264,7 +264,7 @@ See [IKEA TRADFRI wireless dimmer (ICTC-G-1) not pairing](https://github.com/Koe
 `,
     },
     {
-        model: ['E1603'],
+        model: ['E1603/E1702'],
         note: `
 ### Pairing
 To factory reset the TRADFRI control outlet, press and hold the reset button


### PR DESCRIPTION
Page for E1603/E1702 is missing the notes due to the fact that the devide is identified as `E1603/E1702` when notes indicate `E1603`.