### PR TITLE
Update how_to_support_new_devices_on_hassio.md

### DIFF
--- a/docs/how_tos/how_to_support_new_devices_on_hassio.md
+++ b/docs/how_tos/how_to_support_new_devices_on_hassio.md
@@ -40,7 +40,8 @@ While the procedure above is very useful for adding / debugging support for devi
 `"zigbee_shepherd_devices": true`
 
 3. Add custom `devices.js` to the config path of the add-on.\
-This path is `/share/zigbee2mqtt` by default, and controlled with the `data_path` option in the config of the add-on.
+This path is `/share/zigbee2mqtt` by default, and controlled with the `data_path` option in the config of the add-on.\
+Be careful to get a `devices.js` matching your current zigbee-sheperd version. Either use the one of your current installation or fetch the one from the [master branch on github](https://github.com/Koenkk/zigbee-shepherd-converters/blob/master/devices.js).
 
 4. Restart the add-on.
 


### PR DESCRIPTION
Hi, I'm using zigbee2mqtt on my Raspy Hassio Installation. I'm not running in development mode, therefore it is not that easy to get access to the docker container running zigbee2mqtt.

If I want to add a new unknown device, I have to find the original `devices.js` which is a dependency to the github repo, so its a little bit confusing at first.

After adding a new unknown device I noticed that the aquara temperature sensor stopped working, returning always the same temperature and crashing zigbee2mqtt after pressing the button on it:
```
zigbee2mqtt_0x00158d0002581b83"],"name":"0x00158d0002581b83","sw_version":"Zigbee2mqtt 1.5.1","model":"Aqara wireless switch (with gyroscope) (WXKG12LM)","manufacturer":"Xiaomi"},"availability_topic":"zigbee2mqtt/bridge/state"}'
/zigbee2mqtt-1.5.1/lib/extension/deviceReceive.js:109
                if (c.cid === cid) {
                      ^
TypeError: Cannot read property 'cid' of undefined
    at mappedDevice.fromZigbee.filter (/zigbee2mqtt-1.5.1/lib/extension/deviceReceive.js:109:23)
    at Array.filter (<anonymous>)
    at DeviceReceive.onZigbeeMessage (/zigbee2mqtt-1.5.1/lib/extension/deviceReceive.js:105:52)
    at extensions.filter.forEach (/zigbee2mqtt-1.5.1/lib/controller.js:143:31)
    at Array.forEach (<anonymous>)
    at Controller.onZigbeeMessage (/zigbee2mqtt-1.5.1/lib/controller.js:143:14)
    at Zigbee.onMessage (/zigbee2mqtt-1.5.1/lib/zigbee.js:275:18)
    at ZShepherd.emit (events.js:198:13)
    at ZShepherd.<anonymous> (/zigbee2mqtt-1.5.1/node_modules/zigbee-herdsman/dist/lib/shepherd.js:125:14)
    at ZShepherd.emit (events.js:198:13)
```

Using the current master of zigbee-sheperd-converters `devices.js` with the current zigbee2mqtt version (1.5.1.2) seems to crash it in combination with some devices. Everything beside the temperature sensor worked like a charm.
Reverting it to the original version used in zigbee2mqtt and adding my new device there works.

This may not be a bug in a future version but mentioning to use the current version in the documentation and adding a direct link to the repository might be helpful.
In my case I also thought I can simply add only the new device to my `devices.js` and it might be patched in later. A link to the full file would be also helpful for me.