### PR TITLE
Update E1743.md

### DIFF
--- a/docs/devices/E1743.md
+++ b/docs/devices/E1743.md
@@ -27,13 +27,7 @@ If you want to bind it to a different group you first have to unbind it from gro
 
 
 ### Pairing
-Factory reset the light bulb ([video](https://www.youtube.com/watch?v=npxOrPxVfe0)).
-After resetting the bulb will automatically connect.
-
-While pairing, keep the bulb close the the CC2531 USB sniffer.
-
-What works is to use (very) short “on’s” and a little bit longer “off’s”.
-Start with bulb on, then off, and then 6 “on’s”, where you kill the light as soon as the bulb shows signs of turning on.
+Pair the switch to Zigbee2mqtt by pressing the pair button (found under the back cover next to the battery) 4 times in a row. The red light on the front side should flash a few times and the turn off (it's more visible to see the light from the back). After a few seconds it turns back on and pulsate. When connected, the light turns off.
 
 
 ## Manual Home Assistant configuration


### PR DESCRIPTION
Updated pair instructions as it was using the "bulb" instructions, which is incorrect - have copied the excellent instruction from E1525 motion sensor which is very accurate, with a couple extra notes for the switch sensor.