### PR TITLE
Add filament bulb to documentation

### DIFF
--- a/docs/devices/9290022409.md
+++ b/docs/devices/9290022409.md
@@ -1,0 +1,74 @@
+---
+title: "Philips 9290022409 control via MQTT"
+description: "Integrate your Philips 9290022409 via Zigbee2mqtt with whatever smart home
+ infrastructure you are using without the vendors bridge or gateway."
+---
+
+*To contribute to this page, edit the following
+[file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docs/devices/9290022409.md)*
+
+# Philips 9290022409
+
+| Model | 9290022409  |
+| Vendor  | Philips  |
+| Description | Hue Filament Standard A60/E27 Bluetooth |
+| Supports | on/off, brightness, power-on behavior |
+| Picture | ![Philips 9290022409](../images/devices/9290022409.jpg) |
+
+## Notes
+
+
+### Pairing
+Factory resetting a Hue bulb can be accomplished in 3 ways.
+After resetting the bulb will automatically connect.
+
+Multiple resets might be necessary for successful interview
+
+**Hue bridge**
+When the bulb is still connected to the Hue bridge, you can simply factory reset the bulb
+by removing it from the bridge via the Hue app.
+
+**Hue dimmer switch**
+[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+
+**TRADFRI remote control**
+This may also be possible with the
+[Tradfri Remote Control](https://www.ikea.com/us/en/images/products/tradfri-remote-control__0489469_PE623665_S4.JPG)
+by pressing and holding the reset button on the bottom of the remote (next to the battery).
+[This may not always work](https://github.com/Koenkk/zigbee2mqtt/issues/296#issuecomment-416923751).
+
+
+### Device type specific configuration
+*[How to use device type specific configuration](../configuration/device_specific_configuration.md)*
+
+
+* `transition`: Controls the transition time (in seconds) of brightness,
+color temperature (if applicable) and color (if applicable) changes. Defaults to `0` (no transition).
+Note that this value is overridden if a `transition` value is present in the MQTT command payload.
+
+
+## Manual Home Assistant configuration
+Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
+manual integration is possbile with the following configuration:
+
+
+{% raw %}
+```yaml
+light:
+  - platform: "mqtt"
+    state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
+    availability_topic: "zigbee2mqtt/bridge/state"
+    brightness: true
+    schema: "json"
+    command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set"
+
+sensor:
+  - platform: "mqtt"
+    state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
+    availability_topic: "zigbee2mqtt/bridge/state"
+    unit_of_measurement: "-"
+    value_template: "{{ value_json.linkquality }}"
+```
+{% endraw %}
+
+


### PR DESCRIPTION
Was already supported by zigbee2mqtt, but no documentation was avaliable, nor was it listed as supported