### PR TITLE
[WIP] Move device configuration to devices page

### DIFF
--- a/docs/devices/046677476816.md
+++ b/docs/devices/046677476816.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/100.110.39.md
+++ b/docs/devices/100.110.39.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/100.424.11.md
+++ b/docs/devices/100.424.11.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/100.425.90.md
+++ b/docs/devices/100.425.90.md
@@ -17,7 +17,10 @@ description: "Integrate your Paul Neuhaus 100.425.90 via Zigbee2mqtt with whatev
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/12031.md
+++ b/docs/devices/12031.md
@@ -17,7 +17,10 @@ description: "Integrate your Lupus 12031 via Zigbee2mqtt with whatever smart hom
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/12050.md
+++ b/docs/devices/12050.md
@@ -17,7 +17,10 @@ description: "Integrate your Lupus 12050 via Zigbee2mqtt with whatever smart hom
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/1613V.md
+++ b/docs/devices/1613V.md
@@ -17,7 +17,10 @@ description: "Integrate your Hive 1613V via Zigbee2mqtt with whatever smart home
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/1741830P7.md
+++ b/docs/devices/1741830P7.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/17436_30_P7.md
+++ b/docs/devices/17436_30_P7.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/1TST-EU.md
+++ b/docs/devices/1TST-EU.md
@@ -17,7 +17,10 @@ description: "Integrate your eCozy 1TST-EU via Zigbee2mqtt with whatever smart h
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/22670.md
+++ b/docs/devices/22670.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/2430-100.md
+++ b/docs/devices/2430-100.md
@@ -17,7 +17,10 @@ description: "Integrate your Gira 2430-100 via Zigbee2mqtt with whatever smart h
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/2AJZ4KPFT.md
+++ b/docs/devices/2AJZ4KPFT.md
@@ -31,6 +31,10 @@ e.g. `1` would add 1 degree to the temperature reported by the device; default `
 * `humidity_precision`: Controls the precision of `humidity` values, e.g. `0`, `1` or `2`; default `2`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/2AJZ4KPKEY.md
+++ b/docs/devices/2AJZ4KPKEY.md
@@ -17,7 +17,10 @@ description: "Integrate your Konke 2AJZ4KPKEY via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/316GLEDRF.md
+++ b/docs/devices/316GLEDRF.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/3210-L.md
+++ b/docs/devices/3210-L.md
@@ -17,7 +17,10 @@ description: "Integrate your Iris 3210-L via Zigbee2mqtt with whatever smart hom
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/3216131P5.md
+++ b/docs/devices/3216131P5.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/3216231P5.md
+++ b/docs/devices/3216231P5.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/3216331P5.md
+++ b/docs/devices/3216331P5.md
@@ -36,6 +36,10 @@ by pressing and holding the reset button on the bottom of the remote (next to th
 [This may not always work](https://github.com/Koenkk/zigbee2mqtt/issues/296#issuecomment-416923751).
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ### Device type specific configuration
 *[How to use device type specific configuration](../configuration/device_specific_configuration.md)*
 

--- a/docs/devices/3216431P5.md
+++ b/docs/devices/3216431P5.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/324131092621.md
+++ b/docs/devices/324131092621.md
@@ -39,6 +39,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/3261030P7.md
+++ b/docs/devices/3261030P7.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/3261331P7.md
+++ b/docs/devices/3261331P7.md
@@ -35,7 +35,6 @@ This may also be possible with the
 by pressing and holding the reset button on the bottom of the remote (next to the battery).
 [This may not always work](https://github.com/Koenkk/zigbee2mqtt/issues/296#issuecomment-416923751).
 
-
 ### Device type specific configuration
 *[How to use device type specific configuration](../configuration/device_specific_configuration.md)*
 
@@ -43,6 +42,11 @@ by pressing and holding the reset button on the bottom of the remote (next to th
 * `transition`: Controls the transition time (in seconds) of brightness,
 color temperature (if applicable) and color (if applicable) changes. Defaults to `0` (no transition).
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
+
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 
 ## Manual Home Assistant configuration

--- a/docs/devices/3300-S.md
+++ b/docs/devices/3300-S.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/3305-S.md
+++ b/docs/devices/3305-S.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/3306431P7.md
+++ b/docs/devices/3306431P7.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/3310-S.md
+++ b/docs/devices/3310-S.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/3315-G.md
+++ b/docs/devices/3315-G.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/3315-S.md
+++ b/docs/devices/3315-S.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/3320-L.md
+++ b/docs/devices/3320-L.md
@@ -17,7 +17,10 @@ description: "Integrate your Iris 3320-L via Zigbee2mqtt with whatever smart hom
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/3321-S.md
+++ b/docs/devices/3321-S.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/3325-S.md
+++ b/docs/devices/3325-S.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/3326-L.md
+++ b/docs/devices/3326-L.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/3RSS008Z.md
+++ b/docs/devices/3RSS008Z.md
@@ -17,7 +17,10 @@ description: "Integrate your Third Reality 3RSS008Z via Zigbee2mqtt with whateve
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/4033930P7.md
+++ b/docs/devices/4033930P7.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/404000_404005_404012.md
+++ b/docs/devices/404000_404005_404012.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/404006_404008_404004.md
+++ b/docs/devices/404006_404008_404004.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/4052899926110.md
+++ b/docs/devices/4052899926110.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/4052899926158.md
+++ b/docs/devices/4052899926158.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/4058075036147.md
+++ b/docs/devices/4058075036147.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/4058075036185.md
+++ b/docs/devices/4058075036185.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/4058075816718.md
+++ b/docs/devices/4058075816718.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/4058075816794.md
+++ b/docs/devices/4058075816794.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/4090130P7.md
+++ b/docs/devices/4090130P7.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/4090531P7.md
+++ b/docs/devices/4090531P7.md
@@ -36,6 +36,10 @@ by pressing and holding the reset button on the bottom of the remote (next to th
 [This may not always work](https://github.com/Koenkk/zigbee2mqtt/issues/296#issuecomment-416923751).
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ### Device type specific configuration
 *[How to use device type specific configuration](../configuration/device_specific_configuration.md)*
 

--- a/docs/devices/4096730U7.md
+++ b/docs/devices/4096730U7.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/421786.md
+++ b/docs/devices/421786.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/421792.md
+++ b/docs/devices/421792.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/4256251-RZHAC.md
+++ b/docs/devices/4256251-RZHAC.md
@@ -24,6 +24,10 @@ Although Home Assistant integration through [MQTT discovery](../integration/home
 manual integration is possbile with the following configuration:
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 {% raw %}
 ```yaml
 switch:

--- a/docs/devices/433714.md
+++ b/docs/devices/433714.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/45852GE.md
+++ b/docs/devices/45852GE.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/45853GE.md
+++ b/docs/devices/45853GE.md
@@ -17,7 +17,10 @@ description: "Integrate your GE 45853GE via Zigbee2mqtt with whatever smart home
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/45856GE.md
+++ b/docs/devices/45856GE.md
@@ -17,7 +17,10 @@ description: "Integrate your GE 45856GE via Zigbee2mqtt with whatever smart home
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/45857GE.md
+++ b/docs/devices/45857GE.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/464800.md
+++ b/docs/devices/464800.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/4713407.md
+++ b/docs/devices/4713407.md
@@ -33,6 +33,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/50043.md
+++ b/docs/devices/50043.md
@@ -17,7 +17,10 @@ description: "Integrate your Paulmann 50043 via Zigbee2mqtt with whatever smart 
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/50045.md
+++ b/docs/devices/50045.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/50049.md
+++ b/docs/devices/50049.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/50064.md
+++ b/docs/devices/50064.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/511.10.md
+++ b/docs/devices/511.10.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/53170161.md
+++ b/docs/devices/53170161.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/67200BL.md
+++ b/docs/devices/67200BL.md
@@ -17,7 +17,10 @@ description: "Integrate your Anchor 67200BL via Zigbee2mqtt with whatever smart 
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/7099860PH.md
+++ b/docs/devices/7099860PH.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/7146060PH.md
+++ b/docs/devices/7146060PH.md
@@ -51,6 +51,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/71831.md
+++ b/docs/devices/71831.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/7199960PH.md
+++ b/docs/devices/7199960PH.md
@@ -64,6 +64,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/72922-A.md
+++ b/docs/devices/72922-A.md
@@ -17,7 +17,10 @@ description: "Integrate your Sylvania 72922-A via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/7299355PH.md
+++ b/docs/devices/7299355PH.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/7299760PH.md
+++ b/docs/devices/7299760PH.md
@@ -64,6 +64,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/73693.md
+++ b/docs/devices/73693.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/73739.md
+++ b/docs/devices/73739.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/73740.md
+++ b/docs/devices/73740.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/73741.md
+++ b/docs/devices/73741.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/73742.md
+++ b/docs/devices/73742.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/74282.md
+++ b/docs/devices/74282.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/74283.md
+++ b/docs/devices/74283.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/74580.md
+++ b/docs/devices/74580.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/74696.md
+++ b/docs/devices/74696.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/81809.md
+++ b/docs/devices/81809.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/81825.md
+++ b/docs/devices/81825.md
@@ -17,7 +17,10 @@ description: "Integrate your AduroSmart 81825 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/8718696170625.md
+++ b/docs/devices/8718696170625.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/8718696449691.md
+++ b/docs/devices/8718696449691.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/8718696485880.md
+++ b/docs/devices/8718696485880.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/8718696548738.md
+++ b/docs/devices/8718696548738.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/8718696598283.md
+++ b/docs/devices/8718696598283.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/8718696695203.md
+++ b/docs/devices/8718696695203.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/900008-WW.md
+++ b/docs/devices/900008-WW.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/915005106701.md
+++ b/docs/devices/915005106701.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/915005587401.md
+++ b/docs/devices/915005587401.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/915005733701.md
+++ b/docs/devices/915005733701.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/9290002579A.md
+++ b/docs/devices/9290002579A.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/9290011370.md
+++ b/docs/devices/9290011370.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/9290011370B.md
+++ b/docs/devices/9290011370B.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/9290011998B.md
+++ b/docs/devices/9290011998B.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/9290012573A.md
+++ b/docs/devices/9290012573A.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/9290012607.md
+++ b/docs/devices/9290012607.md
@@ -34,6 +34,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ### Motion sensitivity
 The motion sensitivity can be changed by publishing to `zigbee2mqtt/[DEVICE_ID]/set`
 `{"motion_sensitivity": "SENSITIVITY"}` where `SENSITVITIY` is one of the following

--- a/docs/devices/9290018187B.md
+++ b/docs/devices/9290018187B.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/9290018195.md
+++ b/docs/devices/9290018195.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/9290019758.md
+++ b/docs/devices/9290019758.md
@@ -38,6 +38,10 @@ The motion sensitivity can be changed by publishing to `zigbee2mqtt/[DEVICE_ID]/
 values: `low`,  `medium`,  `high` (default).
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/9290022166.md
+++ b/docs/devices/9290022166.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/9290022167.md
+++ b/docs/devices/9290022167.md
@@ -45,6 +45,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/99432.md
+++ b/docs/devices/99432.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/A6121.md
+++ b/docs/devices/A6121.md
@@ -17,7 +17,10 @@ description: "Integrate your Xiaomi A6121 via Zigbee2mqtt with whatever smart ho
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/A806S-Q1R.md
+++ b/docs/devices/A806S-Q1R.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AA68199.md
+++ b/docs/devices/AA68199.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AA69697.md
+++ b/docs/devices/AA69697.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AA70155.md
+++ b/docs/devices/AA70155.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AB3257001NJ.md
+++ b/docs/devices/AB3257001NJ.md
@@ -22,6 +22,10 @@ description: "Integrate your OSRAM AB3257001NJ via Zigbee2mqtt with whatever sma
 For the OSRAM Smart+ plug (AB3257001NJ) hold the on/off button until your hear a click (+- 10 seconds).
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AB32840.md
+++ b/docs/devices/AB32840.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AB35996.md
+++ b/docs/devices/AB35996.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AB401130055.md
+++ b/docs/devices/AB401130055.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AC01353010G.md
+++ b/docs/devices/AC01353010G.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AC0251100NJ.md
+++ b/docs/devices/AC0251100NJ.md
@@ -24,6 +24,10 @@ to Reset the Device. Hold the Middle and Arrow Up Buttons for 3 Seconds to conne
 If the Switch is connected hold Middle and Arrow Up Buttons for 3 Seconds to disconnect.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AC0363900NJ.md
+++ b/docs/devices/AC0363900NJ.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AC03641.md
+++ b/docs/devices/AC03641.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AC03642.md
+++ b/docs/devices/AC03642.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AC03645.md
+++ b/docs/devices/AC03645.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AC03647.md
+++ b/docs/devices/AC03647.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AC03648.md
+++ b/docs/devices/AC03648.md
@@ -23,6 +23,10 @@ Follow instruction from [Manual reset](http://belkin.force.com/Articles/articles
 After resetting the bulb will automatically connect.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ### Device type specific configuration
 *[How to use device type specific configuration](../configuration/device_specific_configuration.md)*
 

--- a/docs/devices/AC08559.md
+++ b/docs/devices/AC08559.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AC08560.md
+++ b/docs/devices/AC08560.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AC08562.md
+++ b/docs/devices/AC08562.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AIRAM-CTR.U.md
+++ b/docs/devices/AIRAM-CTR.U.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AV2010_22.md
+++ b/docs/devices/AV2010_22.md
@@ -26,6 +26,10 @@ If not set, the timeout is `90` seconds.
 When set to `0` no `occupancy: false` is send.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/AV2010_25.md
+++ b/docs/devices/AV2010_25.md
@@ -17,7 +17,10 @@ description: "Integrate your Bitron AV2010/25 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/AV2010_32.md
+++ b/docs/devices/AV2010_32.md
@@ -17,7 +17,10 @@ description: "Integrate your Bitron AV2010/32 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/AV2010_34.md
+++ b/docs/devices/AV2010_34.md
@@ -17,7 +17,10 @@ description: "Integrate your Bitron AV2010/34 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/B00TN589ZG.md
+++ b/docs/devices/B00TN589ZG.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/B07KG5KF5R.md
+++ b/docs/devices/B07KG5KF5R.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/BY_165.md
+++ b/docs/devices/BY_165.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/BY_185_C.md
+++ b/docs/devices/BY_185_C.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/BY_285_C.md
+++ b/docs/devices/BY_285_C.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/CC2530.ROUTER.md
+++ b/docs/devices/CC2530.ROUTER.md
@@ -29,6 +29,10 @@ To reset it into pairing mode power-cycle it three times as follows:
 5) power on and wait for it to join your network
     
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/CR701-YZ.md
+++ b/docs/devices/CR701-YZ.md
@@ -17,7 +17,10 @@ description: "Integrate your Oujiabao CR701-YZ via Zigbee2mqtt with whatever sma
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/D1.md
+++ b/docs/devices/D1.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/D1531.md
+++ b/docs/devices/D1531.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/D1532.md
+++ b/docs/devices/D1532.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/D1542.md
+++ b/docs/devices/D1542.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/D1821.md
+++ b/docs/devices/D1821.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/DIYRUZ_R4_5.md
+++ b/docs/devices/DIYRUZ_R4_5.md
@@ -17,7 +17,10 @@ description: "Integrate your Custom devices (DiY) DIYRuZ_R4_5 via Zigbee2mqtt wi
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/DIYRuZ_KEYPAD20.md
+++ b/docs/devices/DIYRuZ_KEYPAD20.md
@@ -17,7 +17,10 @@ description: "Integrate your Custom devices (DiY) DIYRuZ_KEYPAD20 via Zigbee2mqt
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/DJT11LM.md
+++ b/docs/devices/DJT11LM.md
@@ -25,6 +25,10 @@ Then press the button again every 2 seconds (maximum 20 times).
 *NOTE: When you fail to pair a device, try replacing the battery, this could solve the problem.*
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/DL_110_N.md
+++ b/docs/devices/DL_110_N.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/DL_110_W.md
+++ b/docs/devices/DL_110_W.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/DNCKATSW001.md
+++ b/docs/devices/DNCKATSW001.md
@@ -17,7 +17,10 @@ description: "Integrate your Custom devices (DiY) DNCKATSW001 via Zigbee2mqtt wi
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/DNCKATSW002.md
+++ b/docs/devices/DNCKATSW002.md
@@ -17,7 +17,10 @@ description: "Integrate your Custom devices (DiY) DNCKATSW002 via Zigbee2mqtt wi
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/DNCKATSW003.md
+++ b/docs/devices/DNCKATSW003.md
@@ -17,7 +17,10 @@ description: "Integrate your Custom devices (DiY) DNCKATSW003 via Zigbee2mqtt wi
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/DNCKATSW004.md
+++ b/docs/devices/DNCKATSW004.md
@@ -17,7 +17,10 @@ description: "Integrate your Custom devices (DiY) DNCKATSW004 via Zigbee2mqtt wi
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/DTB190502A1.md
+++ b/docs/devices/DTB190502A1.md
@@ -17,7 +17,10 @@ description: "Integrate your Custom devices (DiY) DTB190502A1 via Zigbee2mqtt wi
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/DZ4743-00B.md
+++ b/docs/devices/DZ4743-00B.md
@@ -17,7 +17,10 @@ description: "Integrate your Lingan DZ4743-00B via Zigbee2mqtt with whatever sma
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/E11-G13.md
+++ b/docs/devices/E11-G13.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/E11-G23_E11-G33.md
+++ b/docs/devices/E11-G23_E11-G33.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/E11-N1EA.md
+++ b/docs/devices/E11-N1EA.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/E12-N14.md
+++ b/docs/devices/E12-N14.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/E1524_E1810.md
+++ b/docs/devices/E1524_E1810.md
@@ -34,6 +34,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/E1525.md
+++ b/docs/devices/E1525.md
@@ -21,6 +21,10 @@ description: "Integrate your IKEA E1525 via Zigbee2mqtt with whatever smart home
 Pair the sensor to Zigbee2mqtt by pressing the pair button 4 times in a row. The red light on the front side should flash a few times and the turn off. After a few seconds it turns back on and pulsate. When connected, the light turns off.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/E1603_E1702.md
+++ b/docs/devices/E1603_E1702.md
@@ -28,6 +28,10 @@ paperclip until the white light starts fading. Hold onto the button for a
 few more seconds, then release. After this, the outlet will automatically connect.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/E1743.md
+++ b/docs/devices/E1743.md
@@ -39,6 +39,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/E1746.md
+++ b/docs/devices/E1746.md
@@ -23,6 +23,10 @@ Push the reset button of the device with a paperclip for 5 seconds.
 While pairing the LED is flashing/dimming slowly. Once the pairing is finished, the LED stays on.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/E1757_E1926.md
+++ b/docs/devices/E1757_E1926.md
@@ -26,6 +26,10 @@ To factory reset the blinds and enable pairing mode, press and hold both buttons
 on the blind for 5 seconds and wait for the LED to turn on.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/E1ACA4ABE38A.md
+++ b/docs/devices/E1ACA4ABE38A.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/F-MLT-US-2.md
+++ b/docs/devices/F-MLT-US-2.md
@@ -17,7 +17,10 @@ description: "Integrate your SmartThings F-MLT-US-2 via Zigbee2mqtt with whateve
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/F-WTR-UK-V2.md
+++ b/docs/devices/F-WTR-UK-V2.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/F7C033.md
+++ b/docs/devices/F7C033.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/GD-CZ-006.md
+++ b/docs/devices/GD-CZ-006.md
@@ -48,6 +48,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/GL-B-001Z.md
+++ b/docs/devices/GL-B-001Z.md
@@ -48,6 +48,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/GL-B-007Z.md
+++ b/docs/devices/GL-B-007Z.md
@@ -48,6 +48,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/GL-B-008Z.md
+++ b/docs/devices/GL-B-008Z.md
@@ -48,6 +48,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/GL-C-006_GL-C-009.md
+++ b/docs/devices/GL-C-006_GL-C-009.md
@@ -48,6 +48,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/GL-C-008.md
+++ b/docs/devices/GL-C-008.md
@@ -54,6 +54,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/GL-D-003Z.md
+++ b/docs/devices/GL-D-003Z.md
@@ -48,6 +48,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/GL-FL-004TZ.md
+++ b/docs/devices/GL-FL-004TZ.md
@@ -48,6 +48,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/GL-G-001Z.md
+++ b/docs/devices/GL-G-001Z.md
@@ -48,6 +48,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/GL-S-003Z.md
+++ b/docs/devices/GL-S-003Z.md
@@ -48,6 +48,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/GL-S-004Z.md
+++ b/docs/devices/GL-S-004Z.md
@@ -48,6 +48,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/GL-S-007Z.md
+++ b/docs/devices/GL-S-007Z.md
@@ -48,6 +48,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/GLSK3ZB-1711.md
+++ b/docs/devices/GLSK3ZB-1711.md
@@ -17,7 +17,10 @@ description: "Integrate your Hej GLSK3ZB-1711 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/GLSK3ZB-1712.md
+++ b/docs/devices/GLSK3ZB-1712.md
@@ -17,7 +17,10 @@ description: "Integrate your Hej GLSK3ZB-1712 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/GLSK3ZB-1713.md
+++ b/docs/devices/GLSK3ZB-1713.md
@@ -17,7 +17,10 @@ description: "Integrate your Hej GLSK3ZB-1713 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/GLSK6ZB-1714.md
+++ b/docs/devices/GLSK6ZB-1714.md
@@ -17,7 +17,10 @@ description: "Integrate your Hej GLSK6ZB-1714 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/GLSK6ZB-1715.md
+++ b/docs/devices/GLSK6ZB-1715.md
@@ -17,7 +17,10 @@ description: "Integrate your Hej GLSK6ZB-1715 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/GLSK6ZB-1716.md
+++ b/docs/devices/GLSK6ZB-1716.md
@@ -17,7 +17,10 @@ description: "Integrate your Hej GLSK6ZB-1716 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/GR-ZB01-W.md
+++ b/docs/devices/GR-ZB01-W.md
@@ -17,7 +17,10 @@ description: "Integrate your AXIS GR-ZB01-W via Zigbee2mqtt with whatever smart 
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HALIGHTDIMWWB22.md
+++ b/docs/devices/HALIGHTDIMWWB22.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/HALIGHTDIMWWE27.md
+++ b/docs/devices/HALIGHTDIMWWE27.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/HEIMAN-M1.md
+++ b/docs/devices/HEIMAN-M1.md
@@ -17,7 +17,10 @@ description: "Integrate your HEIMAN HEIMAN-M1 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HGZB-01A.md
+++ b/docs/devices/HGZB-01A.md
@@ -17,7 +17,10 @@ description: "Integrate your Nue / 3A HGZB-01A via Zigbee2mqtt with whatever sma
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HGZB-02A.md
+++ b/docs/devices/HGZB-02A.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/HGZB-02S.md
+++ b/docs/devices/HGZB-02S.md
@@ -17,7 +17,10 @@ description: "Integrate your Nue / 3A HGZB-02S via Zigbee2mqtt with whatever sma
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HGZB-042.md
+++ b/docs/devices/HGZB-042.md
@@ -17,7 +17,10 @@ description: "Integrate your Nue / 3A HGZB-042 via Zigbee2mqtt with whatever sma
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HGZB-043.md
+++ b/docs/devices/HGZB-043.md
@@ -17,7 +17,10 @@ description: "Integrate your Nue / 3A HGZB-043 via Zigbee2mqtt with whatever sma
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HGZB-045.md
+++ b/docs/devices/HGZB-045.md
@@ -17,7 +17,10 @@ description: "Integrate your Nue / 3A HGZB-045 via Zigbee2mqtt with whatever sma
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HGZB-04D.md
+++ b/docs/devices/HGZB-04D.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/HGZB-06A.md
+++ b/docs/devices/HGZB-06A.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/HGZB-07A.md
+++ b/docs/devices/HGZB-07A.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/HGZB-1S.md
+++ b/docs/devices/HGZB-1S.md
@@ -17,7 +17,10 @@ description: "Integrate your Nue / 3A HGZB-1S via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HGZB-20-DE.md
+++ b/docs/devices/HGZB-20-DE.md
@@ -17,7 +17,10 @@ description: "Integrate your Smart Home Pty HGZB-20-DE via Zigbee2mqtt with what
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HGZB-41.md
+++ b/docs/devices/HGZB-41.md
@@ -17,7 +17,10 @@ description: "Integrate your Nue / 3A HGZB-41 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HGZB-42-UK___HGZB-41.md
+++ b/docs/devices/HGZB-42-UK___HGZB-41.md
@@ -17,7 +17,10 @@ description: "Integrate your Nue / 3A HGZB-42-UK / HGZB-41 via Zigbee2mqtt with 
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HGZB-42.md
+++ b/docs/devices/HGZB-42.md
@@ -17,7 +17,10 @@ description: "Integrate your Nue / 3A HGZB-42 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HGZB-43.md
+++ b/docs/devices/HGZB-43.md
@@ -17,7 +17,10 @@ description: "Integrate your Nue / 3A HGZB-43 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HLC610-Z.md
+++ b/docs/devices/HLC610-Z.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/HLC821-Z-SC.md
+++ b/docs/devices/HLC821-Z-SC.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/HLD812-Z-SC.md
+++ b/docs/devices/HLD812-Z-SC.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/HS1-WL-E.md
+++ b/docs/devices/HS1-WL-E.md
@@ -17,7 +17,10 @@ description: "Integrate your HEIMAN HS1-WL-E via Zigbee2mqtt with whatever smart
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HS1CA-E.md
+++ b/docs/devices/HS1CA-E.md
@@ -17,7 +17,10 @@ description: "Integrate your HEIMAN HS1CA-E via Zigbee2mqtt with whatever smart 
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HS1CA-M.md
+++ b/docs/devices/HS1CA-M.md
@@ -17,7 +17,10 @@ description: "Integrate your HEIMAN HS1CA-M via Zigbee2mqtt with whatever smart 
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HS1CG-M.md
+++ b/docs/devices/HS1CG-M.md
@@ -17,7 +17,10 @@ description: "Integrate your HEIMAN HS1CG-M via Zigbee2mqtt with whatever smart 
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HS1DS-E.md
+++ b/docs/devices/HS1DS-E.md
@@ -17,7 +17,10 @@ description: "Integrate your HEIMAN HS1DS-E via Zigbee2mqtt with whatever smart 
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HS1DS_HS3DS.md
+++ b/docs/devices/HS1DS_HS3DS.md
@@ -17,7 +17,10 @@ description: "Integrate your HEIMAN HS1DS/HS3DS via Zigbee2mqtt with whatever sm
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HS1RC-M.md
+++ b/docs/devices/HS1RC-M.md
@@ -17,7 +17,10 @@ description: "Integrate your HEIMAN HS1RC-M via Zigbee2mqtt with whatever smart 
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HS1SA.md
+++ b/docs/devices/HS1SA.md
@@ -17,7 +17,10 @@ description: "Integrate your HEIMAN HS1SA via Zigbee2mqtt with whatever smart ho
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HS1WL_HS3WL.md
+++ b/docs/devices/HS1WL_HS3WL.md
@@ -17,7 +17,10 @@ description: "Integrate your HEIMAN HS1WL/HS3WL via Zigbee2mqtt with whatever sm
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HS2SK.md
+++ b/docs/devices/HS2SK.md
@@ -17,7 +17,10 @@ description: "Integrate your HEIMAN HS2SK via Zigbee2mqtt with whatever smart ho
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HS2WD-E.md
+++ b/docs/devices/HS2WD-E.md
@@ -18,6 +18,10 @@ description: "Integrate your HEIMAN HS2WD-E via Zigbee2mqtt with whatever smart 
 ## Notes
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ### Triggering the alarm
 The alarm can be trigged by publishing to `zigbee2mqtt/[DEVICE_ID]/set` message
 `{"warning": {"duration": 10, "mode": "emergency", "strobe": false}}`.

--- a/docs/devices/HS3CG.md
+++ b/docs/devices/HS3CG.md
@@ -17,7 +17,10 @@ description: "Integrate your HEIMAN HS3CG via Zigbee2mqtt with whatever smart ho
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HS3MS.md
+++ b/docs/devices/HS3MS.md
@@ -17,7 +17,10 @@ description: "Integrate your HEIMAN HS3MS via Zigbee2mqtt with whatever smart ho
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HS3SA.md
+++ b/docs/devices/HS3SA.md
@@ -17,7 +17,10 @@ description: "Integrate your HEIMAN HS3SA via Zigbee2mqtt with whatever smart ho
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/HV-GSCXZB269.md
+++ b/docs/devices/HV-GSCXZB269.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/HV-GSCXZB279_HV-GSCXZB229.md
+++ b/docs/devices/HV-GSCXZB279_HV-GSCXZB229.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/ICPSHC24-10EU-IL-1.md
+++ b/docs/devices/ICPSHC24-10EU-IL-1.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/ICPSHC24-30EU-IL-1.md
+++ b/docs/devices/ICPSHC24-30EU-IL-1.md
@@ -32,6 +32,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/ICTC-G-1.md
+++ b/docs/devices/ICTC-G-1.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/ICZB-IW11D.md
+++ b/docs/devices/ICZB-IW11D.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/IM-Z3.0-DIM.md
+++ b/docs/devices/IM-Z3.0-DIM.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/IM6001-BTP01.md
+++ b/docs/devices/IM6001-BTP01.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/IM6001-MPP01.md
+++ b/docs/devices/IM6001-MPP01.md
@@ -23,6 +23,10 @@ When pairing, make sure to keep the sensor awake for 20 seconds by openinig and 
 every second.
     
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/IM6001-MTP01.md
+++ b/docs/devices/IM6001-MTP01.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/IM6001-OTP05.md
+++ b/docs/devices/IM6001-OTP05.md
@@ -17,7 +17,10 @@ description: "Integrate your SmartThings IM6001-OTP05 via Zigbee2mqtt with whate
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/IM6001-WLP01.md
+++ b/docs/devices/IM6001-WLP01.md
@@ -17,7 +17,10 @@ description: "Integrate your SmartThings IM6001-WLP01 via Zigbee2mqtt with whate
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/ISW-ZPR1-WP13.md
+++ b/docs/devices/ISW-ZPR1-WP13.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/J1.md
+++ b/docs/devices/J1.md
@@ -17,6 +17,11 @@ description: "Integrate your Ubisys J1 via Zigbee2mqtt with whatever smart home
 
 ## Notes
 
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ### Configuration of device attributes
 By publishing to `zigbee2mqtt/[DEVICE_ID]/set` various device attributes can be configured:
 ```json

--- a/docs/devices/JTQJ-BF-01LM_BW.md
+++ b/docs/devices/JTQJ-BF-01LM_BW.md
@@ -23,6 +23,10 @@ Plug the device in and wait for around 5mins, while it performs its self-tests. 
 Now the device is ready for pairing. To initiate pairing quickly press the button three times in a row.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/JTYJ-GD-01LM_BW.md
+++ b/docs/devices/JTYJ-GD-01LM_BW.md
@@ -24,6 +24,10 @@ Press the button 3 times in a row and wait until the sensor is successfully inte
 *NOTE: When you fail to pair a device, try replacing the battery, this could solve the problem.*
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/K2RGBW01.md
+++ b/docs/devices/K2RGBW01.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/KS-SM001.md
+++ b/docs/devices/KS-SM001.md
@@ -17,7 +17,10 @@ description: "Integrate your Ksentry Electronics KS-SM001 via Zigbee2mqtt with w
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/L1527.md
+++ b/docs/devices/L1527.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/L1528.md
+++ b/docs/devices/L1528.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/L1529.md
+++ b/docs/devices/L1529.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/L1531.md
+++ b/docs/devices/L1531.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LED1536G5.md
+++ b/docs/devices/LED1536G5.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LED1537R6.md
+++ b/docs/devices/LED1537R6.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LED1545G12.md
+++ b/docs/devices/LED1545G12.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LED1546G12.md
+++ b/docs/devices/LED1546G12.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LED1622G12.md
+++ b/docs/devices/LED1622G12.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LED1623G12.md
+++ b/docs/devices/LED1623G12.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LED1624G9.md
+++ b/docs/devices/LED1624G9.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LED1649C5.md
+++ b/docs/devices/LED1649C5.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LED1650R5.md
+++ b/docs/devices/LED1650R5.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LED1732G11.md
+++ b/docs/devices/LED1732G11.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LED1733G7.md
+++ b/docs/devices/LED1733G7.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LED1736G9.md
+++ b/docs/devices/LED1736G9.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LED1837R5.md
+++ b/docs/devices/LED1837R5.md
@@ -37,6 +37,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LLKZMK11LM.md
+++ b/docs/devices/LLKZMK11LM.md
@@ -17,12 +17,14 @@ description: "Integrate your Xiaomi LLKZMK11LM via Zigbee2mqtt with whatever sma
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:
-
 
 {% raw %}
 ```yaml

--- a/docs/devices/LTFY004.md
+++ b/docs/devices/LTFY004.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LVS-SM10ZW.md
+++ b/docs/devices/LVS-SM10ZW.md
@@ -17,7 +17,10 @@ description: "Integrate your LivingWise LVS-SM10ZW via Zigbee2mqtt with whatever
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/LVS-SN10ZW_SN11.md
+++ b/docs/devices/LVS-SN10ZW_SN11.md
@@ -17,7 +17,10 @@ description: "Integrate your LivingWise LVS-SN10ZW_SN11 via Zigbee2mqtt with wha
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/LVS-ZB15R.md
+++ b/docs/devices/LVS-ZB15R.md
@@ -17,7 +17,10 @@ description: "Integrate your LivingWise LVS-ZB15R via Zigbee2mqtt with whatever 
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/LVS-ZB15S.md
+++ b/docs/devices/LVS-ZB15S.md
@@ -17,7 +17,10 @@ description: "Integrate your LivingWise LVS-ZB15S via Zigbee2mqtt with whatever 
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/LVS-ZB500D.md
+++ b/docs/devices/LVS-ZB500D.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LXZB-02A.md
+++ b/docs/devices/LXZB-02A.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/LZL4BWHL01.md
+++ b/docs/devices/LZL4BWHL01.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/M350STW1.md
+++ b/docs/devices/M350STW1.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/MCCGQ01LM.md
+++ b/docs/devices/MCCGQ01LM.md
@@ -27,6 +27,10 @@ This keeps the device awake, otherwise pairing will **fail!**.
 *NOTE: When you fail to pair a device, try replacing the battery, this could solve the problem.*
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/MCCGQ11LM.md
+++ b/docs/devices/MCCGQ11LM.md
@@ -25,6 +25,10 @@ blue light blinks three times, release the reset button (the blue light will bli
 *NOTE: When you fail to pair a device, try replacing the battery, this could solve the problem.*
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/MCT-340_E.md
+++ b/docs/devices/MCT-340_E.md
@@ -17,7 +17,10 @@ description: "Integrate your Visonic MCT-340 E via Zigbee2mqtt with whatever sma
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/MCT-350_SMA.md
+++ b/docs/devices/MCT-350_SMA.md
@@ -17,7 +17,10 @@ description: "Integrate your Visonic MCT-350 SMA via Zigbee2mqtt with whatever s
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/MEAZON_BIZY_PLUG.md
+++ b/docs/devices/MEAZON_BIZY_PLUG.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/MEAZON_DINRAIL.md
+++ b/docs/devices/MEAZON_DINRAIL.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/MFKZQ01LM.md
+++ b/docs/devices/MFKZQ01LM.md
@@ -24,6 +24,10 @@ description: "Integrate your Xiaomi MFKZQ01LM via Zigbee2mqtt with whatever smar
 *NOTE: When you fail to pair a device, try replacing the battery, this could solve the problem.*
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/MG-AUWS01.md
+++ b/docs/devices/MG-AUWS01.md
@@ -17,7 +17,10 @@ description: "Integrate your Nue / 3A MG-AUWS01 via Zigbee2mqtt with whatever sm
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/MLI-404011.md
+++ b/docs/devices/MLI-404011.md
@@ -33,6 +33,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/Mega23M12.md
+++ b/docs/devices/Mega23M12.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/N2G-SP.md
+++ b/docs/devices/N2G-SP.md
@@ -17,7 +17,10 @@ description: "Integrate your NET2GRID N2G-SP via Zigbee2mqtt with whatever smart
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/NCZ-3011-HA.md
+++ b/docs/devices/NCZ-3011-HA.md
@@ -31,6 +31,10 @@ e.g. `1` would add 1 degree to the temperature reported by the device; default `
 * `humidity_precision`: Controls the precision of `humidity` values, e.g. `0`, `1` or `2`; default `2`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/NCZ-3041-HA.md
+++ b/docs/devices/NCZ-3041-HA.md
@@ -31,6 +31,10 @@ e.g. `1` would add 1 degree to the temperature reported by the device; default `
 * `humidity_precision`: Controls the precision of `humidity` values, e.g. `0`, `1` or `2`; default `2`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/NCZ-3043-HA.md
+++ b/docs/devices/NCZ-3043-HA.md
@@ -31,6 +31,10 @@ e.g. `1` would add 1 degree to the temperature reported by the device; default `
 * `humidity_precision`: Controls the precision of `humidity` values, e.g. `0`, `1` or `2`; default `2`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/NCZ-3045-HA.md
+++ b/docs/devices/NCZ-3045-HA.md
@@ -31,6 +31,10 @@ e.g. `1` would add 1 degree to the temperature reported by the device; default `
 * `humidity_precision`: Controls the precision of `humidity` values, e.g. `0`, `1` or `2`; default `2`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/NL08-0800.md
+++ b/docs/devices/NL08-0800.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/PLUG_EDP_RE_DY.md
+++ b/docs/devices/PLUG_EDP_RE_DY.md
@@ -22,6 +22,10 @@ description: "Integrate your EDP PLUG EDP RE:DY via Zigbee2mqtt with whatever sm
 Factory reset the plug (hold the switch button for >10sec). After resetting the switch will automatically connect.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/PL_110.md
+++ b/docs/devices/PL_110.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/PM-C140-ZB.md
+++ b/docs/devices/PM-C140-ZB.md
@@ -17,7 +17,10 @@ description: "Integrate your Dawon DNS PM-C140-ZB via Zigbee2mqtt with whatever 
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/PP-WHT-US.md
+++ b/docs/devices/PP-WHT-US.md
@@ -42,6 +42,11 @@ Save the file and restart zigbee2mqtt.
 ## Power measurements
 This device only support power measurements with an up-to-date firmware on the plug which can only be done via the original hub. In case of an older firmware you will only see 0 values in the measurements. Discussion: https://github.com/Koenkk/zigbee2mqtt/issues/809
 
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/PSB19-SW27.md
+++ b/docs/devices/PSB19-SW27.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/PSM-29ZBSR.md
+++ b/docs/devices/PSM-29ZBSR.md
@@ -17,7 +17,10 @@ description: "Integrate your Climax PSM-29ZBSR via Zigbee2mqtt with whatever sma
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/PSS-23ZBS.md
+++ b/docs/devices/PSS-23ZBS.md
@@ -17,7 +17,10 @@ description: "Integrate your Climax PSS-23ZBS via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/QBCZ11LM.md
+++ b/docs/devices/QBCZ11LM.md
@@ -17,7 +17,10 @@ description: "Integrate your Xiaomi QBCZ11LM via Zigbee2mqtt with whatever smart
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/QBKG03LM.md
+++ b/docs/devices/QBKG03LM.md
@@ -33,6 +33,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/QBKG04LM.md
+++ b/docs/devices/QBKG04LM.md
@@ -23,6 +23,10 @@ Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/QBKG11LM.md
+++ b/docs/devices/QBKG11LM.md
@@ -23,6 +23,10 @@ Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/QBKG12LM.md
+++ b/docs/devices/QBKG12LM.md
@@ -23,6 +23,10 @@ Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RADON_TriTech_ZB.md
+++ b/docs/devices/RADON_TriTech_ZB.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RB_145.md
+++ b/docs/devices/RB_145.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RB_165.md
+++ b/docs/devices/RB_165.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RB_175_W.md
+++ b/docs/devices/RB_175_W.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RB_178_T.md
+++ b/docs/devices/RB_178_T.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RB_185_C.md
+++ b/docs/devices/RB_185_C.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RB_245.md
+++ b/docs/devices/RB_245.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RB_248_T.md
+++ b/docs/devices/RB_248_T.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RB_250_C.md
+++ b/docs/devices/RB_250_C.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RB_265.md
+++ b/docs/devices/RB_265.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RB_278_T.md
+++ b/docs/devices/RB_278_T.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RB_285_C.md
+++ b/docs/devices/RB_285_C.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RF_263.md
+++ b/docs/devices/RF_263.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RF_265.md
+++ b/docs/devices/RF_265.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RH3040.md
+++ b/docs/devices/RH3040.md
@@ -17,7 +17,10 @@ description: "Integrate your TUYATEC RH3040 via Zigbee2mqtt with whatever smart 
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/ROB_200-004-0.md
+++ b/docs/devices/ROB_200-004-0.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RS_122.md
+++ b/docs/devices/RS_122.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RS_125.md
+++ b/docs/devices/RS_125.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RS_128_T.md
+++ b/docs/devices/RS_128_T.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RS_225.md
+++ b/docs/devices/RS_225.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RS_228_T.md
+++ b/docs/devices/RS_228_T.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RTCGQ01LM.md
+++ b/docs/devices/RTCGQ01LM.md
@@ -48,6 +48,10 @@ To work around this, a
 is needed.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/RTCGQ11LM.md
+++ b/docs/devices/RTCGQ11LM.md
@@ -28,6 +28,8 @@ blue light blinks three times, release the reset button (the blue light will bli
 ### Device type specific configuration
 *[How to use device type specific configuration](../configuration/device_specific_configuration.md)*
 
+* `illuminance_calibration`: Allows to manually calibrate illuminance values,
+e.g. `95` would take 95% to the illuminance reported by the device; default `100`.
 * `no_occupancy_since`: Timeout (in seconds) after `no_occupancy_since` is send.
 This indicates the time since last occupancy was detected.
 For example `no_occupancy_since: [10, 60]` will send a `{"no_occupancy_since": 10}` after 10 seconds
@@ -46,12 +48,8 @@ To work around this, a
 is needed.
 
 
-### Device type specific configuration
-*[How to use device type specific configuration](../configuration/device_specific_configuration.md)*
-
-
-* `illuminance_calibration`: Allows to manually calibrate illuminance values,
-e.g. `95` would take 95% to the illuminance reported by the device; default `100`.
+### Device specific configuration
+This devices does not have any device specific configuration.
 
 
 ## Manual Home Assistant configuration

--- a/docs/devices/S1.md
+++ b/docs/devices/S1.md
@@ -17,7 +17,10 @@ description: "Integrate your Ubisys S1 via Zigbee2mqtt with whatever smart home
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/S2.md
+++ b/docs/devices/S2.md
@@ -17,7 +17,10 @@ description: "Integrate your Ubisys S2 via Zigbee2mqtt with whatever smart home
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/SCM-5ZBS.md
+++ b/docs/devices/SCM-5ZBS.md
@@ -17,7 +17,10 @@ description: "Integrate your Climax SCM-5ZBS via Zigbee2mqtt with whatever smart
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/SCM-S1.md
+++ b/docs/devices/SCM-S1.md
@@ -17,7 +17,10 @@ description: "Integrate your Blaupunkt SCM-S1 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/SJCGQ11LM.md
+++ b/docs/devices/SJCGQ11LM.md
@@ -23,6 +23,10 @@ Press and hold water logo on the device for +- 10 seconds until the blue light b
 three times, release the water logo (the blue light will blink once more) and wait.
     
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/SL_110_M.md
+++ b/docs/devices/SL_110_M.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/SL_110_N.md
+++ b/docs/devices/SL_110_N.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/SL_110_W.md
+++ b/docs/devices/SL_110_W.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/SP600.md
+++ b/docs/devices/SP600.md
@@ -17,7 +17,10 @@ description: "Integrate your Salus SP600 via Zigbee2mqtt with whatever smart hom
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/SPZB0001.md
+++ b/docs/devices/SPZB0001.md
@@ -17,7 +17,10 @@ description: "Integrate your Eurotronic SPZB0001 via Zigbee2mqtt with whatever s
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/SP_120.md
+++ b/docs/devices/SP_120.md
@@ -17,7 +17,10 @@ description: "Integrate your Innr SP 120 via Zigbee2mqtt with whatever smart hom
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/ST218.md
+++ b/docs/devices/ST218.md
@@ -17,7 +17,10 @@ description: "Integrate your Stelpro ST218 via Zigbee2mqtt with whatever smart h
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/ST8AU-CON.md
+++ b/docs/devices/ST8AU-CON.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/STS-IRM-250.md
+++ b/docs/devices/STS-IRM-250.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/STS-PRS-251.md
+++ b/docs/devices/STS-PRS-251.md
@@ -17,7 +17,10 @@ description: "Integrate your SmartThings STS-PRS-251 via Zigbee2mqtt with whatev
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/STSS-MULT-001.md
+++ b/docs/devices/STSS-MULT-001.md
@@ -17,7 +17,10 @@ description: "Integrate your SmartThings STSS-MULT-001 via Zigbee2mqtt with what
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/ST_110.md
+++ b/docs/devices/ST_110.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/SV01.md
+++ b/docs/devices/SV01.md
@@ -33,6 +33,10 @@ e.g. `1` would add 1 degree to the temperature reported by the device; default `
 e.g. `1` would add 1 to the pressure reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/SV02.md
+++ b/docs/devices/SV02.md
@@ -33,6 +33,10 @@ e.g. `1` would add 1 degree to the temperature reported by the device; default `
 e.g. `1` would add 1 to the pressure reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/SWITCH_EDP_RE_DY.md
+++ b/docs/devices/SWITCH_EDP_RE_DY.md
@@ -17,7 +17,10 @@ description: "Integrate your EDP SWITCH EDP RE:DY via Zigbee2mqtt with whatever 
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/SWO-KEF1PA.md
+++ b/docs/devices/SWO-KEF1PA.md
@@ -17,7 +17,10 @@ description: "Integrate your Swann SWO-KEF1PA via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/SWO-WDS1PA.md
+++ b/docs/devices/SWO-WDS1PA.md
@@ -17,7 +17,10 @@ description: "Integrate your Swann SWO-WDS1PA via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/SZ-ESW01-AU.md
+++ b/docs/devices/SZ-ESW01-AU.md
@@ -17,9 +17,14 @@ description: "Integrate your Sercomm SZ-ESW01-AU via Zigbee2mqtt with whatever s
 
 ## Notes
 
-Pairing
 
+### Pairing
 Press and hold the pairing button while plugging in the device.
+
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/T1820.md
+++ b/docs/devices/T1820.md
@@ -28,6 +28,10 @@ What works is to use (very) short “ons” and a little bit longer “offs”.
 Start with bulb on, then off, and then 6 “ons”, where you kill the light as soon as the bulb shows signs of turning on.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ### Device type specific configuration
 *[How to use device type specific configuration](../configuration/device_specific_configuration.md)*
 

--- a/docs/devices/TH1123ZB.md
+++ b/docs/devices/TH1123ZB.md
@@ -17,7 +17,10 @@ description: "Integrate your Sinope TH1123ZB via Zigbee2mqtt with whatever smart
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/TI0001.md
+++ b/docs/devices/TI0001.md
@@ -17,6 +17,7 @@ description: "Integrate your Livolo TI0001 via Zigbee2mqtt with whatever smart h
 
 ## Notes
 
+### Pairing
 These devices can only use channel #26. These devices are locked to the manufacturer's network key (ext_pan_id).
 Your configuration file [data/configuration.yaml](../configuration/configuration) must contain the following:
 
@@ -34,6 +35,11 @@ If you decided to create a new network, you should specify another 'pan_id'.
 advanced:
   pan_id: 6756
 ```
+
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/TT001ZAV20.md
+++ b/docs/devices/TT001ZAV20.md
@@ -31,6 +31,10 @@ e.g. `1` would add 1 degree to the temperature reported by the device; default `
 * `humidity_precision`: Controls the precision of `humidity` values, e.g. `0`, `1` or `2`; default `2`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/U86K31ND6.md
+++ b/docs/devices/U86K31ND6.md
@@ -17,7 +17,10 @@ description: "Integrate your Honyar U86K31ND6 via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/UC_110.md
+++ b/docs/devices/UC_110.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/V3-BTZB.md
+++ b/docs/devices/V3-BTZB.md
@@ -17,7 +17,10 @@ description: "Integrate your Danalock V3-BTZB via Zigbee2mqtt with whatever smar
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/WSDCGQ01LM.md
+++ b/docs/devices/WSDCGQ01LM.md
@@ -40,6 +40,10 @@ e.g. `1` would add 1 degree to the temperature reported by the device; default `
 * `humidity_precision`: Controls the precision of `humidity` values, e.g. `0`, `1` or `2`; default `2`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/WSDCGQ11LM.md
+++ b/docs/devices/WSDCGQ11LM.md
@@ -43,6 +43,10 @@ e.g. `1` would add 1 degree to the temperature reported by the device; default `
 e.g. `1` would add 1 to the pressure reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/WXKG01LM.md
+++ b/docs/devices/WXKG01LM.md
@@ -38,6 +38,10 @@ click to be identified as a long click. If you are experiencing this you can try
 experimenting with this option (e.g. `long_timeout: 2000`).
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/WXKG02LM.md
+++ b/docs/devices/WXKG02LM.md
@@ -23,6 +23,10 @@ Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/WXKG03LM.md
+++ b/docs/devices/WXKG03LM.md
@@ -23,6 +23,10 @@ Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possible with the following configuration:

--- a/docs/devices/WXKG11LM.md
+++ b/docs/devices/WXKG11LM.md
@@ -25,6 +25,10 @@ blue light blinks three times, release the reset button (the blue light will bli
 *NOTE: When you fail to pair a device, try replacing the battery, this could solve the problem.*
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/WXKG12LM.md
+++ b/docs/devices/WXKG12LM.md
@@ -25,6 +25,10 @@ blue light blinks three times, release the reset button (the blue light will bli
 *NOTE: When you fail to pair a device, try replacing the battery, this could solve the problem.*
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/XVV-Mega23M12.md
+++ b/docs/devices/XVV-Mega23M12.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/XY12S-15.md
+++ b/docs/devices/XY12S-15.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/YMF40.md
+++ b/docs/devices/YMF40.md
@@ -17,7 +17,10 @@ description: "Integrate your Yale YMF40 via Zigbee2mqtt with whatever smart home
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/YRD226HA2619.md
+++ b/docs/devices/YRD226HA2619.md
@@ -17,7 +17,10 @@ description: "Integrate your Yale YRD226HA2619 via Zigbee2mqtt with whatever sma
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/YRD256HA20BP.md
+++ b/docs/devices/YRD256HA20BP.md
@@ -17,7 +17,10 @@ description: "Integrate your Yale YRD256HA20BP via Zigbee2mqtt with whatever sma
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/YRD426NRSC.md
+++ b/docs/devices/YRD426NRSC.md
@@ -17,7 +17,10 @@ description: "Integrate your Yale YRD426NRSC via Zigbee2mqtt with whatever smart
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/Z01-A19NAE26.md
+++ b/docs/devices/Z01-A19NAE26.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/Z01-A60EAE27.md
+++ b/docs/devices/Z01-A60EAE27.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/Z01-CIA19NAE26.md
+++ b/docs/devices/Z01-CIA19NAE26.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/Z3-1BRL.md
+++ b/docs/devices/Z3-1BRL.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/Z809A.md
+++ b/docs/devices/Z809A.md
@@ -27,6 +27,10 @@ will rapidly flash green.
 - After fast flashes, Z809A will reboot, and the restore is completed. The socket will automatically connect now.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/Z809AF.md
+++ b/docs/devices/Z809AF.md
@@ -17,7 +17,10 @@ description: "Integrate your Ninja Blocks Z809AF via Zigbee2mqtt with whatever s
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/ZA806SQ1TCF.md
+++ b/docs/devices/ZA806SQ1TCF.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/ZCTS-808.md
+++ b/docs/devices/ZCTS-808.md
@@ -24,6 +24,10 @@ keep opening and closing the sensor (pull/insert the sensor parts next to eachot
 otherwise device will fall asleep before it gets fully configured and will not send state changes.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/ZG9101SAC-HP.md
+++ b/docs/devices/ZG9101SAC-HP.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/ZGRC-KEY-013.md
+++ b/docs/devices/ZGRC-KEY-013.md
@@ -17,7 +17,10 @@ description: "Integrate your RGB Genie ZGRC-KEY-013 via Zigbee2mqtt with whateve
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/ZLED-2709.md
+++ b/docs/devices/ZLED-2709.md
@@ -33,6 +33,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/ZM-CSW002-D.md
+++ b/docs/devices/ZM-CSW002-D.md
@@ -17,7 +17,10 @@ description: "Integrate your Zemismart ZM-CSW002-D via Zigbee2mqtt with whatever
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/ZM350STW1TCF.md
+++ b/docs/devices/ZM350STW1TCF.md
@@ -27,6 +27,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/ZNCLDJ11LM.md
+++ b/docs/devices/ZNCLDJ11LM.md
@@ -17,7 +17,10 @@ description: "Integrate your Xiaomi ZNCLDJ11LM via Zigbee2mqtt with whatever sma
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/ZNCZ02LM.md
+++ b/docs/devices/ZNCZ02LM.md
@@ -23,6 +23,10 @@ Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/ZNCZ03LM.md
+++ b/docs/devices/ZNCZ03LM.md
@@ -17,7 +17,10 @@ description: "Integrate your Xiaomi ZNCZ03LM via Zigbee2mqtt with whatever smart
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/ZNLDP12LM.md
+++ b/docs/devices/ZNLDP12LM.md
@@ -31,6 +31,10 @@ color temperature (if applicable) and color (if applicable) changes. Defaults to
 Note that this value is overridden if a `transition` value is present in the MQTT command payload.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/ZNMS12LM.md
+++ b/docs/devices/ZNMS12LM.md
@@ -17,7 +17,10 @@ description: "Integrate your Xiaomi ZNMS12LM via Zigbee2mqtt with whatever smart
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/ZNMS13LM.md
+++ b/docs/devices/ZNMS13LM.md
@@ -17,7 +17,10 @@ description: "Integrate your Xiaomi ZNMS13LM via Zigbee2mqtt with whatever smart
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/ZPIR-8000.md
+++ b/docs/devices/ZPIR-8000.md
@@ -17,7 +17,10 @@ description: "Integrate your Trust ZPIR-8000 via Zigbee2mqtt with whatever smart
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/ZYCT-202.md
+++ b/docs/devices/ZYCT-202.md
@@ -24,6 +24,10 @@ To establish a connection keep the remote within 2 meters from the hub.
 Press and hold the smart group button (button with two bulbs) and wait until the lights, below the channels, flash.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/Zen-01-W.md
+++ b/docs/devices/Zen-01-W.md
@@ -28,6 +28,10 @@ e.g. `0`, `1` or `2`; default `2`.
 e.g. `1` would add 1 degree to the temperature reported by the device; default `0`.
 
 
+### Device specific configuration
+This devices does not have any device specific configuration.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possbile with the following configuration:

--- a/docs/devices/ZigUP.md
+++ b/docs/devices/ZigUP.md
@@ -17,7 +17,10 @@ description: "Integrate your Custom devices (DiY) ZigUP via Zigbee2mqtt with wha
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/ptvo.switch.md
+++ b/docs/devices/ptvo.switch.md
@@ -17,7 +17,10 @@ description: "Integrate your Custom devices (DiY) ptvo.switch via Zigbee2mqtt wi
 
 ## Notes
 
-None
+
+### Device specific configuration
+This devices does not have any device specific configuration.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,


### PR DESCRIPTION
- [ ] `npm run docgen` generates changes on master, move those to the proper location.
- [ ] Add 'Device specific configuration' section to 'notes' section for all devices.
- [ ] Move device configuration to per-device page from MQTT Topics and message structure page