### PR TITLE
New binding behaviour of IKEA remote control

### DIFF
--- a/docs/devices/E1524_E1810.md
+++ b/docs/devices/E1524_E1810.md
@@ -25,7 +25,11 @@ The red light on the remote will now flash a few times.
 
 
 ### Binding
-This device does not support binding (limitation of the device). A workaround is to first
+The remote can be bound to groups using [binding](../information/binding) since firmware 2.3.014.
+It can only be bound to 1 group at a time.
+
+#### Note
+This device with old firmware < 2.3.014 does not support binding (limitation of the device). A workaround is to first
 get the group ID where the remote is sending it's commands to and add bulbs to the
 same group ([discussion](https://github.com/Koenkk/zigbee2mqtt/issues/782#issuecomment-514526256)).
 


### PR DESCRIPTION
Changes due to issue IKEA E1524/E1810 remote control / new behaviour after firmware update #2325 in zigbee2mqtt repo

Since some people have trouble with binding of Enddevices to groups as I saw in serveral comments, I would propose to enhance the binding docu with an example.