### PR TITLE
Add pairing notes for Eurotronic SPZB0001

### DIFF
--- a/docgen/device_page_notes.js
+++ b/docgen/device_page_notes.js
@@ -771,6 +771,12 @@ Discussion: https://github.com/Koenkk/zigbee2mqtt/issues/809
     {
         model: ['SPZB0001'],
         note: `
+### Pairing
+If you are having trouble pairing, reset the device.
+- hold boost, +, and - (a count from 1 to 10 will be on the display)
+- release ones 'rES' is displayed
+- hit boot once after 'Jin' is displayed
+
 ### Controlling
 *Current heating setpoint*
 \`\`\`json


### PR DESCRIPTION
Both my test units required a reset before they would pair.

Both units shipped with firmware '20191014 22190930'