### PR TITLE
Add OSRAM bulb to reporting support table

### DIFF
--- a/docs/information/report.md
+++ b/docs/information/report.md
@@ -26,6 +26,7 @@ In order for this feature to work, the device has to support it. As devices from
 | Trådfri(2)      | Y         | Y          | Y     | N                 |
 | Innr            | Y         | Y          | Y     | Y                 |
 | GLEDOPTO        | N         | N          | N     | N                 |
+| OSRAM           | Y         | Y          | N     | N                 | 
 
 1. Zigbee2mqtt will manual poll for change if a binding updates the bulb.
 2. The color/brightness of a Trådfri bulb can be changed while the state=off, it also reports back the change.


### PR DESCRIPTION
Corrected PR, with further testing it looks like the osram bulbs do not report color or color_temp changes :(

The colors are also a bit off when setting the color using rgb vs hue/sat