### PR TITLE
Remove duplicate pairing instructions

### DIFF
--- a/docs/devices/BASICZBR3.md
+++ b/docs/devices/BASICZBR3.md
@@ -22,10 +22,6 @@ description: "Integrate your SONOFF BASICZBR3 via Zigbee2mqtt with whatever smar
 If brand new, when powered on it will attempt to pair to Zigbee2mqtt automatically. If not (or if has been paired before and needs to be re-paired) - press and hold the (relay) button on the top for about 5 seconds until the relay cliks and the red LED flashes several times. The device will then go into pairing mode and the blue LED will begin to flash. When connected, the blue LED will turn on solid. It should then be connected to Zigbee2mqtt. Pressing the button should activate the relay on/off as normal, and the red LED will be on/off.
 
 
-### Pairing
-If brand new, when powered on it will attempt to pair to Zigbee2mqtt automatically. If not (or if has been paired before and needs to be re-paired) - press and hold the (relay) button on the top for about 5 seconds until the relay cliks and the red LED flashes several times. The device will then go into pairing mode and the blue LED will begin to flash. When connected, the blue LED will turn on solid. It should then be connected to Zigbee2mqtt. Pressing the button should activate the relay on/off as normal, and the red LED will be on/off.
-
-
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possible with the following configuration:


### PR DESCRIPTION
The [SONOFF BASICZBR3 documentation](https://www.zigbee2mqtt.io/devices/BASICZBR3.html) currently has duplicate pairing instructions - this PR removes one of those.