### PR TITLE
Update WV704R0A0902 to mention Clipsal branding

### DIFF
--- a/docs/devices/WV704R0A0902.md
+++ b/docs/devices/WV704R0A0902.md
@@ -1,19 +1,19 @@
 ---
-title: "Schneider Electric iTRV control via MQTT"
-description: "Integrate your Schneider Electric Smart Radiator Thermostat (iTRV) via Zigbee2mqtt with whatever smart home
+title: "Schneider Electric Wiser Smart Thermostat"
+description: "Integrate your Schneider Electric Wiser Smart Radiator Thermostat (iTRV) via Zigbee2mqtt with whatever smart home
  infrastructure you are using without the vendors bridge or gateway."
 ---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docs/devices/WV704R0A0902.md)*
 
-# Schneider Electric Smart Radiator Thermostat (iTRV)
+# Schneider Electric Wiser Smart Radiator Thermostat (iTRV)
 
 | Model | WV704R0A0902  |
-| Vendor  | Schneider Electric (Drayton Wiser,  Eberle Wiser) |
-| Description | Smart Radiator Thermostat with twist-top boost |
+| Vendor  | Schneider Electric (Drayton,  Eberle, and Clipsal) |
+| Description | Wiser Smart Radiator Thermostat with twist-top boost |
 | Supports | temperature, battery, keypad lock, heating demand, boost |
-| Picture | ![Schneider Electric iTRV](../images/devices/WV704R0A0902.jpg) |
+| Picture | ![Schneider Electric Wiser Smart Thermostat](../images/devices/WV704R0A0902.jpg) |
 
 ## Device pairing/installation
 To put the TRV in installation mode twist and hold the cap in the  **+** direction 


### PR DESCRIPTION
Update docs to also mention Clipsal (AU) branding in addition to Eberle (DE/AT) and Drayton (UK).

Also also call it 'Wiser Smart Thermostat' as in a few places as all brands refer to it as that.