### PR TITLE
Removed deprecated 'hide_entity' from Home Assistant config sample

### DIFF
--- a/docs/integration/home_assistant.md
+++ b/docs/integration/home_assistant.md
@@ -225,7 +225,6 @@ automation:
   # Automation to start timer when enable join is turned on
   - id: zigbee_join_enabled
     alias: Zigbee Join Enabled
-    hide_entity: true
     trigger:
       platform: state
       entity_id: switch.zigbee2mqtt_main_join
@@ -236,7 +235,6 @@ automation:
   # Automation to stop timer when switch turned off and turn off switch when timer finished
   - id: zigbee_join_disabled
     alias: Zigbee Join Disabled
-    hide_entity: true
     trigger:
       - platform: event
         event_type: timer.finished


### PR DESCRIPTION
New version of Home Assistant 0.105 deprecates `hide_entity` configuration option (it will be removed in 0.107) https://www.home-assistant.io/blog/2020/02/05/release-105/

This PR updates code sample. 

The current version of code samples such warnings in `home-assistant.log` when is run on Home Assistant 0.105.1

```
2020-02-06 11:06:59 WARNING (MainThread) [homeassistant.components.automation] The 'hide_entity' option (with value 'True') is deprecated, please remove it from your configuration. This option will become invalid in version 0.107
```