### PR TITLE
Fixed typo(2): /dev/ttyAMC0 => /dev/ttyACM0

### DIFF
--- a/docs/information/zigbee2mqtt_fails_to_start.md
+++ b/docs/information/zigbee2mqtt_fails_to_start.md
@@ -11,7 +11,7 @@ total 0
 lrwxrwxrwx. 1 root root 13 Oct 19 19:26 usb-Texas_Instruments_TI_CC2531_USB_CDC___0X00124B0018ED3DDF-if00 -> ../../ttyACM0
 ```
 
-In this example the correct `port` would be `/dev/ttyAMC0`.
+In this example the correct `port` would be `/dev/ttyACM0`.
 
 ## Verify that the user you run Zigbee2mqtt as has write access to the port
 This can be tested by executing: `test -w [PORT] && echo success || echo failure` (e.g. `test -w /dev/ttyACM0 && echo success || echo failure`).


### PR DESCRIPTION
Same typo as previous, but other file...