### PR TITLE
Adding an explainer for the `color_temp` property.

### DIFF
--- a/docs/information/mqtt_topics_and_message_structure.md
+++ b/docs/information/mqtt_topics_and_message_structure.md
@@ -194,7 +194,12 @@ Publishing messages to this topic allows you to control your Zigbee devices via 
 {
   "state": "ON", // Or "OFF", "TOGGLE"
   "brightness": 255, // Value between 0 and 255
+
+  // Color temperature in Reciprocal MegaKelvin, a.k.a. Mirek scale.
+  // Mirek = 1,000,000 / Color Temperature in Kelvin
+  // Values typically between 50 and 400. The higher the value, the warmer the color.
   "color_temp": 155,
+
   "color": {
     // XY color
     "x": 0.123,


### PR DESCRIPTION
As I'm migrating from other platforms, which present color temperature in Kelvin, I was a little confounded by what unit the `color_temp` value is in, until I dipped into the source.

Adding some additional comments above it in the [MQTT Topics](https://www.zigbee2mqtt.io/information/mqtt_topics_and_message_structure.html#zigbee2mqttfriendly_nameset) page to hopefully assist others in making sense of it