### PR TITLE
Added debounce recommendation for some use cases

### DIFF
--- a/docs/devices/MCCGQ11LM.md
+++ b/docs/devices/MCCGQ11LM.md
@@ -22,6 +22,19 @@ description: "Integrate your Xiaomi MCCGQ11LM via Zigbee2mqtt with whatever smar
 Press and hold the reset button on the device for +- 5 seconds (until the blue light starts blinking).
 After this the device will automatically join.
 
+## Recommendation
+If the contact is being made via a horizontal slide (e.g. the sensor is placed at the top of a sliding door), the sensor may provide three or more messages with conflicting states. To get around this issue, consider using the `debounce` option in your device specific configuration.
+
+E.g. (devices.yaml)
+
+{% raw %}
+```yaml
+'0xabc457fffe679xyz':
+    friendly_name: my_sensor
+    debounce: 1
+```
+{% endraw %}
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,


### PR DESCRIPTION
This sensor spits multiple messages if used on the top of a horizontal sliding door. The magnet slides into place and will change the state whilst doing so. The debounce option allows the user to accurately receive the correct state.