### PR TITLE
Delete transition and duplicate binding text

### DIFF
--- a/docs/devices/324131092621.md
+++ b/docs/devices/324131092621.md
@@ -34,19 +34,6 @@ Hue dimmer switch can also be used to factory reset Ikea Trådfri light bulbs us
 If you want to bind the dimmer to a (Hue) lamp you'll have to *[bind it to the lamp through MQTT](../information/binding.html)* and unbind it from the coordinator. Use the dimmer as source and coordinator as target for that.
 
 
-### Device type specific configuration
-*[How to use device type specific configuration](../information/configuration.md)*
-
-
-* `transition`: Controls the transition time (in seconds) of on/off, brightness,
-color temperature (if applicable) and color (if applicable) changes. Defaults to `0` (no transition).
-Note that this value is overridden if a `transition` value is present in the MQTT command payload.
-
-
-### Binding
-If you want to bind the dimmer to a (Hue) lamp you'll have to *[bind it to the lamp through MQTT](../information/binding.html)* and unbind it from the coordinator. Use the dimmer as source and coordinator as target for that.
-
-
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possible with the following configuration:


### PR DESCRIPTION
Binding was listed twice. Transition is irrelevant since this is a switch sensor, not a light. The light needs the transition setting on it.