### PR TITLE
Fix incorrect sensor config in documentation of Philips sensor.

### DIFF
--- a/docs/devices/9290012607.md
+++ b/docs/devices/9290012607.md
@@ -86,7 +86,7 @@ sensor:
     availability_topic: "zigbee2mqtt/bridge/state"
     unit_of_measurement: "lx"
     device_class: "illuminance"
-    value_template: "{{ value_json.illuminance }}"
+    value_template: "{{ value_json.illuminance_lux }}"
 
 sensor:
   - platform: "mqtt"

--- a/docs/devices/9290019758.md
+++ b/docs/devices/9290019758.md
@@ -86,7 +86,7 @@ sensor:
     availability_topic: "zigbee2mqtt/bridge/state"
     unit_of_measurement: "lx"
     device_class: "illuminance"
-    value_template: "{{ value_json.illuminance }}"
+    value_template: "{{ value_json.illuminance_lux }}"
 
 sensor:
   - platform: "mqtt"


### PR DESCRIPTION
Signed-off-by: Tianyu Liu <info@jamesvillage.dev>
The extraction of json file of Philips sensor is not correct.
In the current version, the extracted illuminance is way too high (something like 20000-40000 during day time), the correct way of extraction should be illuminance_lux. 