### PR TITLE
Small doc change for the E26 version of IKEA LED1736G9

### DIFF
--- a/docs/devices/LED1736G9.md
+++ b/docs/devices/LED1736G9.md
@@ -11,7 +11,7 @@ description: "Integrate your IKEA LED1736G9 via Zigbee2mqtt with whatever smart 
 
 | Model | LED1736G9  |
 | Vendor  | IKEA  |
-| Description | TRADFRI LED bulb E27 806 lumen, dimmable, white spectrum, clear |
+| Description | TRADFRI LED bulb E26/E27 806 lumen, dimmable, white spectrum, clear |
 | Supports | on/off, brightness, color temperature |
 | Picture | ![IKEA LED1736G9](../images/devices/LED1736G9.jpg) |
 


### PR DESCRIPTION
(related PR at https://github.com/Koenkk/zigbee-herdsman-converters/pull/1137)