### PR TITLE
Add Wattle HCSMOKEDETECT as white label device

### DIFF
--- a/docs/devices/HS1SA-M.md
+++ b/docs/devices/HS1SA-M.md
@@ -14,6 +14,7 @@ description: "Integrate your HEIMAN HS1SA-M via Zigbee2mqtt with whatever smart 
 | Description | Smoke detector |
 | Supports | smoke |
 | Picture | ![HEIMAN HS1SA-M](../images/devices/HS1SA-M.jpg) |
+| White-label | Wattle HCSMOKEDETECT |
 
 ## Notes
 


### PR DESCRIPTION
Another white label version of the HEIMAN smoke detector.
Note that I could not get the ruby stuff running, so it is untested...