### PR TITLE
Update docs for Salus SP600

### DIFF
--- a/docs/devices/SP600.md
+++ b/docs/devices/SP600.md
@@ -50,6 +50,14 @@ sensor:
   - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
+    unit_of_measurement: "kWh"
+    icon: "mdi:power-plug"
+    value_template: "{{ value_json.energy }}"
+
+sensor:
+  - platform: "mqtt"
+    state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
+    availability_topic: "zigbee2mqtt/bridge/state"
     icon: "mdi:signal"
     unit_of_measurement: "lqi"
     value_template: "{{ value_json.linkquality }}"


### PR DESCRIPTION
The Salus SP600 has a `Simple Metering` cluster with the `Current Summation Delivered` [attribute available](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/converters/fromZigbee.js#L1338-L1342). This can be used in Home Assistant to display an energy sensor.

https://github.com/Koenkk/zigbee2mqtt/pull/3551