### PR TITLE
Add pairing instructions for Lutron LZL4BWHL01

### DIFF
--- a/docs/devices/LZL4BWHL01.md
+++ b/docs/devices/LZL4BWHL01.md
@@ -21,7 +21,7 @@ description: "Integrate your Lutron LZL4BWHL01 via Zigbee2mqtt with whatever sma
 ### Pairing
 Factory reset the Lutron Connected Bulb Remote by pressing and holding the remote's top and bottom buttons for approximately 15 seconds. The light on the remote will blink rapidly to indicate that the remote has been reset.
 
-After resetting the remote will automatically attempt to join a network.
+After resetting the remote can be paired to a network by pressing and holding the top button for approximately 2 seconds.
 
 #### Using the Connected Bulb Remote to reset a connected light bulb (Hue, Cree, GE Link)
 Connected light bulbs can be reset with the Lutron Connected Bulb Remote by bringing the remote close (~3 inches) to the light bulb and pressing and holding the remote's 2nd and bottom buttons. The light bulb will flash and the remote's LED will turn on. Continue to hold both buttons until the remote's LED turns off.

--- a/docs/devices/LZL4BWHL01.md
+++ b/docs/devices/LZL4BWHL01.md
@@ -18,6 +18,18 @@ description: "Integrate your Lutron LZL4BWHL01 via Zigbee2mqtt with whatever sma
 ## Notes
 
 
+### Pairing
+Factory reset the Lutron Connected Bulb Remote by pressing and holding the remote's top and bottom buttons for approximately 15 seconds. The light on the remote will blink rapidly to indicate that the remote has been reset.
+
+After resetting the remote will automatically attempt to join a network.
+
+#### Using the Connected Bulb Remote to reset a connected light bulb (Hue, Cree, GE Link)
+Connected light bulbs can be reset with the Lutron Connected Bulb Remote by bringing the remote close (~3 inches) to the light bulb and pressing and holding the remote's 2nd and bottom buttons. The light bulb will flash and the remote's LED will turn on. Continue to hold both buttons until the remote's LED turns off.
+
+After resetting the bulb will automatically attempt to join a network.
+
+This method should work for Philips Hue bulbs, IKEA TRADFRI bulbs, GE Link bulbs, Connected Cree bulbs, and EcoSmart SMART bulbs.
+
 ### Device type specific configuration
 *[How to use device type specific configuration](../information/configuration.md)*
 


### PR DESCRIPTION
Add pairing and bulb reset instructions for Lutron LZL4BWHL01 Connected Bulb Remote.