### PR TITLE
fix missing alias in Home Assistant integration instructions

### DIFF
--- a/docs/integration/home_assistant.md
+++ b/docs/integration/home_assistant.md
@@ -273,6 +273,7 @@ automation:
       - service: switch.turn_off
         entity_id: switch.zigbee2mqtt_main_join
   - id: "zigbee2mqtt_create_notification_on_successfull_interview"
+    alias: Zigbee Device Joined Notification
     trigger:
       platform: mqtt
       topic: 'zigbee2mqtt/bridge/log'


### PR DESCRIPTION
One of the automations in the HA integration instructions is missing an alias, which causes HA to give it a name like 'automation 13'.