### PR TITLE
Reorganise home page links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,10 +10,27 @@ Welcome to the Zigbee2mqtt documentation! Besides the documentation, you can als
 
 ### Getting started
 * [What do I need?](getting_started/what_do_i_need.md)
-* [Flashing the CC2531 USB stick](getting_started/flashing_the_cc2531.md)
 * [Running Zigbee2mqtt](getting_started/running_zigbee2mqtt.md)
-* [Pairing devices](getting_started/pairing_devices.md)
+
+### Devices
 * [Supported devices](information/supported_devices.md)
+* [Pairing devices](getting_started/pairing_devices.md)
+* [How to support new devices](how_tos/how_to_support_new_devices.md)
+
+
+### Adapters
+* [Supported adapters](information/supported_adapters.md)
+* [Flashing the CC2531 USB stick](getting_started/flashing_the_cc2531.md)
+* [How to create a CC2530 router](how_tos/how_to_create_a_cc2530_router.md)
+* [How to connect to a remote adapter](how_tos/how_to_connect_to_a_remote_adapter.md)
+
+
+### Running Zigbee2mqtt on ...
+* [bare-metal Linux](getting_started/running_zigbee2mqtt.md)
+* [Docker](information/docker.md)
+* [Hass.io (official Zigbee2mqtt add-on)](https://github.com/danielwelch/hassio-zigbee2mqtt)
+* [Virtual environment](information/virtual_environment.md)
+* [Windows](information/windows.md)
 
 ### Information
 * [3D cases](information/3d_cases.md)
@@ -22,29 +39,16 @@ Welcome to the Zigbee2mqtt documentation! Besides the documentation, you can als
 * [Configuration](information/configuration.md)
 * [Debug](information/debug.md)
 * [FAQ](information/FAQ.md)
+* [How to improve network range](how_tos/how_to_improve_network_range.md)
+* [How to secure your Zigbee network](how_tos/how_to_secure_network.md)
+* [How to sniff Zigbee traffic](how_tos/how_to_sniff_zigbee_traffic.md)
+* [How to switch to the dev branch](how_tos/how-to-switch-to-dev-branch.md)
 * [Groups](information/groups.md)
 * [MQTT topics and message structure](information/mqtt_topics_and_message_structure.md)
 * [OTA updates](information/ota_updates.md)
 * [Report](information/report.md)
-* [Supported adapters](information/supported_adapters.md)
 * [Touchlink](information/touchlink.md)
 * [Zigbee network](information/zigbee_network.md)
-
-### Running Zigbee2mqtt on ...
-Besides running Zigbee2mqtt on [bare-metal Linux](getting_started/running_zigbee2mqtt.md) it can also run on:
-* [Docker](information/docker.md)
-* [Hass.io (official Zigbee2mqtt add-on)](https://github.com/danielwelch/hassio-zigbee2mqtt)
-* [Virtual environment](information/virtual_environment.md)
-* [Windows](information/windows.md)
-
-### How tos
-* [How to create a CC2530 router](how_tos/how_to_create_a_cc2530_router.md)
-* [How to connect to a remote adapter](how_tos/how_to_connect_to_a_remote_adapter.md)
-* [How to improve network range](how_tos/how_to_improve_network_range.md)
-* [How to secure your Zigbee network](how_tos/how_to_secure_network.md)
-* [How to sniff Zigbee traffic](how_tos/how_to_sniff_zigbee_traffic.md)
-* [How to support new devices](how_tos/how_to_support_new_devices.md)
-* [How to switch to the dev branch](how_tos/how-to-switch-to-dev-branch.md)
 
 ### Integration
 * [Admin Panel for Node-Red](https://github.com/ben423423n32j14e/zigbee2mqttadminpanel) or [node-red-contrib-zigbee2mqtt ](https://flows.nodered.org/node/node-red-contrib-zigbee2mqtt)


### PR DESCRIPTION
I have found the homepage links to be a bit difficult to navigate at first. The link to running Zigbee2mqtt on bare-metal linux was difficult to see at first because my eyes jumped straight to the bullet points. The other categories appear to be overlapping so I have tried to simplify this.

All good if you don't agree with the changes, this is just a suggestion. Feel free to decline the pull request or amend. Thank you