### PR TITLE
Fixing number of HA ways to respond

### DIFF
--- a/docs/integration/home_assistant.md
+++ b/docs/integration/home_assistant.md
@@ -64,7 +64,7 @@ it is equal to the Zigbee2mqtt `friendly_name`. Is updated if the Zigbee2mqtt `f
 - Home Assistant `friendly_name` (`customize.yaml`): overrides the name in the Home Assistant web interface.
 
 ## Responding to button clicks
-To respond to button clicks (e.g. WXKG01LM) you can use one of the following two Home Assistant configurations.
+To respond to button clicks (e.g. WXKG01LM) you can use one of the following three Home Assistant configurations.
 
 ### Via MQTT device trigger (recommended)
 [MQTT device trigger](https://www.home-assistant.io/integrations/device_trigger.mqtt/) is the recommended way to respond to button clicks.


### PR DESCRIPTION
There was a commit that added a third method ( https://github.com/Koenkk/zigbee2mqtt.io/commit/0ecbb46b9d0f6a4eed209c790166a909665e4525 ) but the number wasn't changed.

(I"m a bit worried about this change. In the beginning of this file there is a text `NOTE 1: This file has been generated, do not edit this file manually!`, but I can't find the source how this file is generated )