### PR TITLE
Update to further clarify the difference seen by hass.io and docker users

### DIFF
--- a/docs/how_tos/how_to_support_new_devices.md
+++ b/docs/how_tos/how_to_support_new_devices.md
@@ -24,7 +24,7 @@ zigbee2mqtt:warn  2019-11-09T12:19:56: Device '0x00158d0001dc126a' with Zigbee m
 ### 2. Adding your device
 The next step is the to add an entry of your device to `node_modules/zigbee-herdsman-converters/devices.js`. In order to provide support for E.G. the `lumi.sens` from step 1 you would add:
 
-*NOTE: For Hass.io and Docker users this process is a little bit different, see below*
+*NOTE: For installations using the official Hass.io addon and Docker users, devices.js and the other necessary files are accessed differently. This process is explained below for [Hass.io](https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html#hassio-addon) and [Docker](https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html#docker).*
 
 ```js
 {


### PR DESCRIPTION
The previous stating only gave a vague warning--vague enough that I accidentally ignored it and struggled to find and edit devices.js and homeassistant.js. By expanding this and noting how the "process is a little bit different" it will hopefully clarify it for future readers.

This is a minor change, but hopefully to avoid others not realizing the difference in installations between standalone, docker, and hass.io add-on.