### PR TITLE
Update HS1SA-M.md

### DIFF
--- a/docs/devices/HS1SA-M.md
+++ b/docs/devices/HS1SA-M.md
@@ -28,6 +28,7 @@ There are 3 versions of this device: Standalone, Zigbee and Z-wave. These are vi
 Supported:
 - **HS1SA-M : Zigbee**
 - **HS1SA-N : Zigbee**
+- **HS1SA-E : Zigbee 3.0**
 
 Unsupported:
 - HS1SA : Standalone


### PR DESCRIPTION
HS1SA-E is the Zigbee 3.0 version of the device and is supported in the dev version of zigbee2mqtt (as of 2020-07-03)