### PR TITLE
Add note about USB3 ports and UNIFLASH

### DIFF
--- a/docs/information/flashing_via_uniflash.md
+++ b/docs/information/flashing_via_uniflash.md
@@ -2,6 +2,8 @@
 
 UNIFLASH can be used to flash certain Texas Instruments MCUs (e.g. CC26X2R1 and CC1352P-2). It runs on Windows, macOS and Linux.
 
+**n.b.** UNIFLASH sometimes needs to update the programmer firmware, and this can fail if the device is connected to a USB 3 port. If this occurs, switch to a USB 2 port.
+
 **Note for flashing on Linux:** Uniflash does not work well on some distributions. specifically, Fedora 31 may have some issue. Combinations that are verified to be working are:
 - *Ubuntu 18.4 (LTS)*:
   - fresh install


### PR DESCRIPTION
Somewhat anecdotal, but both times I have tried to flash my CC1352 board it has failed until I switched to a USB 2 port. I thought this was worth noting here as a potential problem.