### PR TITLE
Some MCCGQ11LM (Aqara door sensors) only work with a single short button press for pairing.

### DIFF
--- a/docs/devices/MCCGQ11LM.md
+++ b/docs/devices/MCCGQ11LM.md
@@ -20,7 +20,7 @@ description: "Integrate your Xiaomi MCCGQ11LM via Zigbee2mqtt with whatever smar
 
 ### Pairing
 Press and hold the reset button on the device for +- 5 seconds (until the blue light starts blinking).
-After this the device will automatically join.
+After this the device will automatically join. If this doesn't work, try with a single short button press.
 
 
 ### Recommendation


### PR DESCRIPTION
This did it for the 8 I just bought. The 5 button press didn't.