### PR TITLE
Fix minor typo in IKEA ICTC-G-1 docs

### DIFF
--- a/docs/devices/ICTC-G-1.md
+++ b/docs/devices/ICTC-G-1.md
@@ -31,7 +31,7 @@ See [IKEA TRADFRI wireless dimmer (ICTC-G-1) not pairing](https://github.com/Koe
 ### Legacy integration
 By default (for backwards compatibility purposes) the legacy integration is enabled.
 For new users it is recommended to **disable** this as it has several problems.
-To disable the legac integration add the following to your `configuration.yaml`:
+To disable the legacy integration add the following to your `configuration.yaml`:
 
 {% raw %}
 ```yaml
@@ -129,7 +129,7 @@ binary_sensor:
     availability_topic: "zigbee2mqtt/bridge/state"
     payload_on: true
     payload_off: false
-    value_template: "{{ value_json.update_available}}"
+    value_template: "{{ value_json.update_available }}"
 ```
 {% endraw %}
 


### PR DESCRIPTION
Noticed today that "legac" was missing the ending "y" in one occurrence in the IKEA ICTC-G-1 docs, so this is to address that.