### PR TITLE
Update docs for QBKG22LM, QBKG25LM

### DIFF
--- a/docgen/device_page_notes.js
+++ b/docgen/device_page_notes.js
@@ -1464,7 +1464,7 @@ See [link](https://github.com/Koenkk/zigbee2mqtt/issues/2077#issuecomment-538691
 ### Power outage memory
 This option allows the device to restore the last on/off state when it's reconnected to power.
 To set this option publish to \`zigbee2mqtt/[FRIENDLY_NAME]/set\` payload \`{"power_outage_memory": true}\` (or \`false\`).
-Now toggle the plug/swich once with the button on it, from now on it will restore its state when reconnecting to power.
+Now toggle the plug/switch once with the button on it, from now on it will restore its state when reconnecting to power.
 `,
     },
     {

--- a/docgen/device_page_notes.js
+++ b/docgen/device_page_notes.js
@@ -1095,6 +1095,8 @@ The \`strength\` value, which is reported every 300 seconds after vibration is d
 ### Pairing
 Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
+
+You may have to unpair the switch from an existing coordinator before the pairing process will start.
 `,
     },
     {
@@ -1404,20 +1406,22 @@ Where:
 `,
     },
     {
-        model: ['QBKG03LM', 'QBKG04LM', 'QBKG12LM', 'QBKG11LM'],
+        model: ['QBKG03LM', 'QBKG04LM', 'QBKG12LM', 'QBKG11LM', 'QBKG21LM', 'QBKG22LM', 'QBKG25LM'],
         note: `
 ### Decoupled mode
 Decoupled mode allows to turn wired switch into wireless button with separately controlled relay.
 This might be useful to assign some custom actions to buttons and control relay remotely.
-This command also allows to redefine which button controls which relay for the double switch.
+This command also allows to redefine which button controls which relay for the double switch (not supported for QBKG25LM).
 
-Special topics should be used: \`zigbee2mqtt/[FRIENDLY_NAME]/system/set\` to modify operation mode.
+Topic \`zigbee2mqtt/[FRIENDLY_NAME]/system/set\` should be used to modify operation mode.
+
+**NOTE:** For QBKG25LM instead of \`system\` use \`left\`, \`center\` or \`right\` and leave out the \`button\` property in the payload.
 
 Payload:
 \`\`\`js
 {
   "operation_mode": {
-    "button": "single"|"left"|"right",
+    "button": "single"|"left"|"right", // Always use single for a single switch
     "state": "VALUE"
   }
 }
@@ -1425,9 +1429,9 @@ Payload:
 
 Values                | Description
 ----------------------|---------------------------------------------------------
-\`control_relay\`       | Button directly controls relay (for single switch)
-\`control_left_relay\`  | Button directly controls left relay (for double switch)
-\`control_right_relay\` | Button directly controls right relay (for double switch)
+\`control_relay\`       | Button directly controls relay (for single switch and QBKG25LM)
+\`control_left_relay\`  | Button directly controls left relay (for double switch, not supported for QBKG25LM)
+\`control_right_relay\` | Button directly controls right relay (for double switch, not supported for QBKG25LM)
 \`decoupled\`           | Button doesn't control any relay
 
 \`zigbee2mqtt/[FRIENDLY_NAME]/system/get\` to read current mode.
@@ -1436,15 +1440,12 @@ Payload:
 \`\`\`js
 {
   "operation_mode": {
-    "button": "single"|"left"|"right"
+    "button": "single"|"left"|"right" // Always use single for a single switch
   }
 }
 \`\`\`
 
-Response will be sent to \`zigbee2mqtt/[FRIENDLY_NAME]\`:
-\`\`\`json
-{"operation_mode_right":"control_right_relay"}
-\`\`\`
+Response will be sent to \`zigbee2mqtt/[FRIENDLY_NAME]\`, example: \`{"operation_mode_right":"control_right_relay"}\`
 `,
     },
     {
@@ -1458,12 +1459,20 @@ See [link](https://github.com/Koenkk/zigbee2mqtt/issues/2077#issuecomment-538691
 `,
     },
     {
-        model: ['ZNCZ02LM', 'ZNCZ04LM', 'QBCZ11LM'],
+        model: ['ZNCZ02LM', 'ZNCZ04LM', 'QBCZ11LM', 'QBKG25LM'],
         note: `
 ### Power outage memory
 This option allows the device to restore the last on/off state when it's reconnected to power.
 To set this option publish to \`zigbee2mqtt/[FRIENDLY_NAME]/set\` payload \`{"power_outage_memory": true}\` (or \`false\`).
-Now toggle the plug once with the button on it, from now on it will restore its state when reconnecting to power.
+Now toggle the plug/swich once with the button on it, from now on it will restore its state when reconnecting to power.
+`,
+    },
+    {
+        model: ['QBKG25LM'],
+        note: `
+### Do not disturb mode
+This option allows to turn off the indicator lights between 21:00 and 09:00.
+To set this option publish to \`zigbee2mqtt/[FRIENDLY_NAME]/set\` payload \`{"do_not_disturb": true}\` (or \`false\`).
 `,
     },
     {

--- a/docs/devices/QBCZ11LM.md
+++ b/docs/devices/QBCZ11LM.md
@@ -21,7 +21,7 @@ description: "Integrate your Xiaomi QBCZ11LM via Zigbee2mqtt with whatever smart
 ### Power outage memory
 This option allows the device to restore the last on/off state when it's reconnected to power.
 To set this option publish to `zigbee2mqtt/[FRIENDLY_NAME]/set` payload `{"power_outage_memory": true}` (or `false`).
-Now toggle the plug once with the button on it, from now on it will restore its state when reconnecting to power.
+Now toggle the plug/swich once with the button on it, from now on it will restore its state when reconnecting to power.
 
 
 ## Manual Home Assistant configuration

--- a/docs/devices/QBKG03LM.md
+++ b/docs/devices/QBKG03LM.md
@@ -35,6 +35,8 @@ devices:
 Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
+You may have to unpair the switch from an existing coordinator before the pairing process will start.
+
 
 ### Device type specific configuration
 *[How to use device type specific configuration](../information/configuration.md)*
@@ -51,15 +53,17 @@ e.g. `1` would add 1 degree to the temperature reported by the device; default `
 ### Decoupled mode
 Decoupled mode allows to turn wired switch into wireless button with separately controlled relay.
 This might be useful to assign some custom actions to buttons and control relay remotely.
-This command also allows to redefine which button controls which relay for the double switch.
+This command also allows to redefine which button controls which relay for the double switch (not supported for QBKG25LM).
 
-Special topics should be used: `zigbee2mqtt/[FRIENDLY_NAME]/system/set` to modify operation mode.
+Topic `zigbee2mqtt/[FRIENDLY_NAME]/system/set` should be used to modify operation mode.
+
+**NOTE:** For QBKG25LM instead of `system` use `left`, `center` or `right` and leave out the `button` property in the payload.
 
 Payload:
 ```js
 {
   "operation_mode": {
-    "button": "single"|"left"|"right",
+    "button": "single"|"left"|"right", // Always use single for a single switch
     "state": "VALUE"
   }
 }
@@ -67,9 +71,9 @@ Payload:
 
 Values                | Description
 ----------------------|---------------------------------------------------------
-`control_relay`       | Button directly controls relay (for single switch)
-`control_left_relay`  | Button directly controls left relay (for double switch)
-`control_right_relay` | Button directly controls right relay (for double switch)
+`control_relay`       | Button directly controls relay (for single switch and QBKG25LM)
+`control_left_relay`  | Button directly controls left relay (for double switch, not supported for QBKG25LM)
+`control_right_relay` | Button directly controls right relay (for double switch, not supported for QBKG25LM)
 `decoupled`           | Button doesn't control any relay
 
 `zigbee2mqtt/[FRIENDLY_NAME]/system/get` to read current mode.
@@ -78,15 +82,12 @@ Payload:
 ```js
 {
   "operation_mode": {
-    "button": "single"|"left"|"right"
+    "button": "single"|"left"|"right" // Always use single for a single switch
   }
 }
 ```
 
-Response will be sent to `zigbee2mqtt/[FRIENDLY_NAME]`:
-```json
-{"operation_mode_right":"control_right_relay"}
-```
+Response will be sent to `zigbee2mqtt/[FRIENDLY_NAME]`, example: `{"operation_mode_right":"control_right_relay"}`
 
 
 ## Manual Home Assistant configuration

--- a/docs/devices/QBKG04LM.md
+++ b/docs/devices/QBKG04LM.md
@@ -35,19 +35,23 @@ devices:
 Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
+You may have to unpair the switch from an existing coordinator before the pairing process will start.
+
 
 ### Decoupled mode
 Decoupled mode allows to turn wired switch into wireless button with separately controlled relay.
 This might be useful to assign some custom actions to buttons and control relay remotely.
-This command also allows to redefine which button controls which relay for the double switch.
+This command also allows to redefine which button controls which relay for the double switch (not supported for QBKG25LM).
 
-Special topics should be used: `zigbee2mqtt/[FRIENDLY_NAME]/system/set` to modify operation mode.
+Topic `zigbee2mqtt/[FRIENDLY_NAME]/system/set` should be used to modify operation mode.
+
+**NOTE:** For QBKG25LM instead of `system` use `left`, `center` or `right` and leave out the `button` property in the payload.
 
 Payload:
 ```js
 {
   "operation_mode": {
-    "button": "single"|"left"|"right",
+    "button": "single"|"left"|"right", // Always use single for a single switch
     "state": "VALUE"
   }
 }
@@ -55,9 +59,9 @@ Payload:
 
 Values                | Description
 ----------------------|---------------------------------------------------------
-`control_relay`       | Button directly controls relay (for single switch)
-`control_left_relay`  | Button directly controls left relay (for double switch)
-`control_right_relay` | Button directly controls right relay (for double switch)
+`control_relay`       | Button directly controls relay (for single switch and QBKG25LM)
+`control_left_relay`  | Button directly controls left relay (for double switch, not supported for QBKG25LM)
+`control_right_relay` | Button directly controls right relay (for double switch, not supported for QBKG25LM)
 `decoupled`           | Button doesn't control any relay
 
 `zigbee2mqtt/[FRIENDLY_NAME]/system/get` to read current mode.
@@ -66,15 +70,12 @@ Payload:
 ```js
 {
   "operation_mode": {
-    "button": "single"|"left"|"right"
+    "button": "single"|"left"|"right" // Always use single for a single switch
   }
 }
 ```
 
-Response will be sent to `zigbee2mqtt/[FRIENDLY_NAME]`:
-```json
-{"operation_mode_right":"control_right_relay"}
-```
+Response will be sent to `zigbee2mqtt/[FRIENDLY_NAME]`, example: `{"operation_mode_right":"control_right_relay"}`
 
 
 ## Manual Home Assistant configuration

--- a/docs/devices/QBKG11LM.md
+++ b/docs/devices/QBKG11LM.md
@@ -35,19 +35,23 @@ devices:
 Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
+You may have to unpair the switch from an existing coordinator before the pairing process will start.
+
 
 ### Decoupled mode
 Decoupled mode allows to turn wired switch into wireless button with separately controlled relay.
 This might be useful to assign some custom actions to buttons and control relay remotely.
-This command also allows to redefine which button controls which relay for the double switch.
+This command also allows to redefine which button controls which relay for the double switch (not supported for QBKG25LM).
 
-Special topics should be used: `zigbee2mqtt/[FRIENDLY_NAME]/system/set` to modify operation mode.
+Topic `zigbee2mqtt/[FRIENDLY_NAME]/system/set` should be used to modify operation mode.
+
+**NOTE:** For QBKG25LM instead of `system` use `left`, `center` or `right` and leave out the `button` property in the payload.
 
 Payload:
 ```js
 {
   "operation_mode": {
-    "button": "single"|"left"|"right",
+    "button": "single"|"left"|"right", // Always use single for a single switch
     "state": "VALUE"
   }
 }
@@ -55,9 +59,9 @@ Payload:
 
 Values                | Description
 ----------------------|---------------------------------------------------------
-`control_relay`       | Button directly controls relay (for single switch)
-`control_left_relay`  | Button directly controls left relay (for double switch)
-`control_right_relay` | Button directly controls right relay (for double switch)
+`control_relay`       | Button directly controls relay (for single switch and QBKG25LM)
+`control_left_relay`  | Button directly controls left relay (for double switch, not supported for QBKG25LM)
+`control_right_relay` | Button directly controls right relay (for double switch, not supported for QBKG25LM)
 `decoupled`           | Button doesn't control any relay
 
 `zigbee2mqtt/[FRIENDLY_NAME]/system/get` to read current mode.
@@ -66,15 +70,12 @@ Payload:
 ```js
 {
   "operation_mode": {
-    "button": "single"|"left"|"right"
+    "button": "single"|"left"|"right" // Always use single for a single switch
   }
 }
 ```
 
-Response will be sent to `zigbee2mqtt/[FRIENDLY_NAME]`:
-```json
-{"operation_mode_right":"control_right_relay"}
-```
+Response will be sent to `zigbee2mqtt/[FRIENDLY_NAME]`, example: `{"operation_mode_right":"control_right_relay"}`
 
 
 ## Manual Home Assistant configuration

--- a/docs/devices/QBKG12LM.md
+++ b/docs/devices/QBKG12LM.md
@@ -35,6 +35,8 @@ devices:
 Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
+You may have to unpair the switch from an existing coordinator before the pairing process will start.
+
 
 ### Device type specific configuration
 *[How to use device type specific configuration](../information/configuration.md)*
@@ -51,15 +53,17 @@ e.g. `1` would add 1 degree to the temperature reported by the device; default `
 ### Decoupled mode
 Decoupled mode allows to turn wired switch into wireless button with separately controlled relay.
 This might be useful to assign some custom actions to buttons and control relay remotely.
-This command also allows to redefine which button controls which relay for the double switch.
+This command also allows to redefine which button controls which relay for the double switch (not supported for QBKG25LM).
 
-Special topics should be used: `zigbee2mqtt/[FRIENDLY_NAME]/system/set` to modify operation mode.
+Topic `zigbee2mqtt/[FRIENDLY_NAME]/system/set` should be used to modify operation mode.
+
+**NOTE:** For QBKG25LM instead of `system` use `left`, `center` or `right` and leave out the `button` property in the payload.
 
 Payload:
 ```js
 {
   "operation_mode": {
-    "button": "single"|"left"|"right",
+    "button": "single"|"left"|"right", // Always use single for a single switch
     "state": "VALUE"
   }
 }
@@ -67,9 +71,9 @@ Payload:
 
 Values                | Description
 ----------------------|---------------------------------------------------------
-`control_relay`       | Button directly controls relay (for single switch)
-`control_left_relay`  | Button directly controls left relay (for double switch)
-`control_right_relay` | Button directly controls right relay (for double switch)
+`control_relay`       | Button directly controls relay (for single switch and QBKG25LM)
+`control_left_relay`  | Button directly controls left relay (for double switch, not supported for QBKG25LM)
+`control_right_relay` | Button directly controls right relay (for double switch, not supported for QBKG25LM)
 `decoupled`           | Button doesn't control any relay
 
 `zigbee2mqtt/[FRIENDLY_NAME]/system/get` to read current mode.
@@ -78,15 +82,12 @@ Payload:
 ```js
 {
   "operation_mode": {
-    "button": "single"|"left"|"right"
+    "button": "single"|"left"|"right" // Always use single for a single switch
   }
 }
 ```
 
-Response will be sent to `zigbee2mqtt/[FRIENDLY_NAME]`:
-```json
-{"operation_mode_right":"control_right_relay"}
-```
+Response will be sent to `zigbee2mqtt/[FRIENDLY_NAME]`, example: `{"operation_mode_right":"control_right_relay"}`
 
 
 ## Manual Home Assistant configuration

--- a/docs/devices/QBKG21LM.md
+++ b/docs/devices/QBKG21LM.md
@@ -31,6 +31,46 @@ devices:
 ```
 
 
+### Decoupled mode
+Decoupled mode allows to turn wired switch into wireless button with separately controlled relay.
+This might be useful to assign some custom actions to buttons and control relay remotely.
+This command also allows to redefine which button controls which relay for the double switch (not supported for QBKG25LM).
+
+Topic `zigbee2mqtt/[FRIENDLY_NAME]/system/set` should be used to modify operation mode.
+
+**NOTE:** For QBKG25LM instead of `system` use `left`, `center` or `right` and leave out the `button` property in the payload.
+
+Payload:
+```js
+{
+  "operation_mode": {
+    "button": "single"|"left"|"right", // Always use single for a single switch
+    "state": "VALUE"
+  }
+}
+```
+
+Values                | Description
+----------------------|---------------------------------------------------------
+`control_relay`       | Button directly controls relay (for single switch and QBKG25LM)
+`control_left_relay`  | Button directly controls left relay (for double switch, not supported for QBKG25LM)
+`control_right_relay` | Button directly controls right relay (for double switch, not supported for QBKG25LM)
+`decoupled`           | Button doesn't control any relay
+
+`zigbee2mqtt/[FRIENDLY_NAME]/system/get` to read current mode.
+
+Payload:
+```js
+{
+  "operation_mode": {
+    "button": "single"|"left"|"right" // Always use single for a single switch
+  }
+}
+```
+
+Response will be sent to `zigbee2mqtt/[FRIENDLY_NAME]`, example: `{"operation_mode_right":"control_right_relay"}`
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possible with the following configuration:

--- a/docs/devices/QBKG24LM.md
+++ b/docs/devices/QBKG24LM.md
@@ -22,6 +22,8 @@ description: "Integrate your Xiaomi QBKG24LM via Zigbee2mqtt with whatever smart
 Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
+You may have to unpair the switch from an existing coordinator before the pairing process will start.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/QBKG25LM.md
+++ b/docs/devices/QBKG25LM.md
@@ -12,7 +12,7 @@ description: "Integrate your Xiaomi QBKG25LM via Zigbee2mqtt with whatever smart
 | Model | QBKG25LM  |
 | Vendor  | Xiaomi  |
 | Description | Aqara D1 3 gang smart wall switch (no neutral wire) |
-| Supports | on/off, action, power measurement |
+| Supports | on/off, action |
 | Picture | ![Xiaomi QBKG25LM](../images/devices/QBKG25LM.jpg) |
 
 ## Notes
@@ -21,6 +21,33 @@ description: "Integrate your Xiaomi QBKG25LM via Zigbee2mqtt with whatever smart
 ### Pairing
 Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
+
+
+### Device type specific configuration
+*[How to use device type specific configuration](../information/configuration.md)*
+
+* `power_outage_memory`: Whether or not to preserve switch state during a power outage.
+* `do_not_disturb`: Turns off indicator lights between 9pm and 9am.
+
+
+### Decoupled mode
+Decoupled mode allows to turn wired switch into wireless button with separately controlled relay.
+This might be useful to assign some custom actions to buttons and control relay remotely.
+This command also allows to redefine which button controls which relay for the double switch.
+
+Special topics should be used: `zigbee2mqtt/[FRIENDLY_NAME]/left|center|right/set` to modify operation mode.
+
+Payload:
+```js
+{
+  "operation_mode": "VALUE"
+}
+```
+
+Values                | Description
+----------------------|---------------------------------------------------------
+`control_relay`       | Button controls relay
+`decoupled`           | Button doesn't control any relay
 
 
 ## Manual Home Assistant configuration
@@ -63,14 +90,6 @@ sensor:
     availability_topic: "zigbee2mqtt/bridge/state"
     icon: "mdi:gesture-double-tap"
     value_template: "{{ value_json.action }}"
-
-sensor:
-  - platform: "mqtt"
-    state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
-    availability_topic: "zigbee2mqtt/bridge/state"
-    unit_of_measurement: "W"
-    icon: "mdi:flash"
-    value_template: "{{ value_json.power }}"
 
 sensor:
   - platform: "mqtt"

--- a/docs/devices/QBKG25LM.md
+++ b/docs/devices/QBKG25LM.md
@@ -12,7 +12,7 @@ description: "Integrate your Xiaomi QBKG25LM via Zigbee2mqtt with whatever smart
 | Model | QBKG25LM  |
 | Vendor  | Xiaomi  |
 | Description | Aqara D1 3 gang smart wall switch (no neutral wire) |
-| Supports | on/off, action |
+| Supports | on/off, action, power measurement |
 | Picture | ![Xiaomi QBKG25LM](../images/devices/QBKG25LM.jpg) |
 
 ## Notes
@@ -22,32 +22,58 @@ description: "Integrate your Xiaomi QBKG25LM via Zigbee2mqtt with whatever smart
 Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
-
-### Device type specific configuration
-*[How to use device type specific configuration](../information/configuration.md)*
-
-* `power_outage_memory`: Whether or not to preserve switch state during a power outage.
-* `do_not_disturb`: Turns off indicator lights between 9pm and 9am.
+You may have to unpair the switch from an existing coordinator before the pairing process will start.
 
 
 ### Decoupled mode
 Decoupled mode allows to turn wired switch into wireless button with separately controlled relay.
 This might be useful to assign some custom actions to buttons and control relay remotely.
-This command also allows to redefine which button controls which relay for the double switch.
+This command also allows to redefine which button controls which relay for the double switch (not supported for QBKG25LM).
 
-Special topics should be used: `zigbee2mqtt/[FRIENDLY_NAME]/left|center|right/set` to modify operation mode.
+Topic `zigbee2mqtt/[FRIENDLY_NAME]/system/set` should be used to modify operation mode.
+
+**NOTE:** For QBKG25LM instead of `system` use `left`, `center` or `right` and leave out the `button` property in the payload.
 
 Payload:
 ```js
 {
-  "operation_mode": "VALUE"
+  "operation_mode": {
+    "button": "single"|"left"|"right", // Always use single for a single switch
+    "state": "VALUE"
+  }
 }
 ```
 
 Values                | Description
 ----------------------|---------------------------------------------------------
-`control_relay`       | Button controls relay
+`control_relay`       | Button directly controls relay (for single switch and QBKG25LM)
+`control_left_relay`  | Button directly controls left relay (for double switch, not supported for QBKG25LM)
+`control_right_relay` | Button directly controls right relay (for double switch, not supported for QBKG25LM)
 `decoupled`           | Button doesn't control any relay
+
+`zigbee2mqtt/[FRIENDLY_NAME]/system/get` to read current mode.
+
+Payload:
+```js
+{
+  "operation_mode": {
+    "button": "single"|"left"|"right" // Always use single for a single switch
+  }
+}
+```
+
+Response will be sent to `zigbee2mqtt/[FRIENDLY_NAME]`, example: `{"operation_mode_right":"control_right_relay"}`
+
+
+### Power outage memory
+This option allows the device to restore the last on/off state when it's reconnected to power.
+To set this option publish to `zigbee2mqtt/[FRIENDLY_NAME]/set` payload `{"power_outage_memory": true}` (or `false`).
+Now toggle the plug/swich once with the button on it, from now on it will restore its state when reconnecting to power.
+
+
+### Do not disturb mode
+This option allows to turn off the indicator lights between 21:00 and 09:00.
+To set this option publish to `zigbee2mqtt/[FRIENDLY_NAME]/set` payload `{"do_not_disturb": true}` (or `false`).
 
 
 ## Manual Home Assistant configuration
@@ -90,6 +116,14 @@ sensor:
     availability_topic: "zigbee2mqtt/bridge/state"
     icon: "mdi:gesture-double-tap"
     value_template: "{{ value_json.action }}"
+
+sensor:
+  - platform: "mqtt"
+    state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
+    availability_topic: "zigbee2mqtt/bridge/state"
+    unit_of_measurement: "W"
+    icon: "mdi:flash"
+    value_template: "{{ value_json.power }}"
 
 sensor:
   - platform: "mqtt"

--- a/docs/devices/WXKG02LM.md
+++ b/docs/devices/WXKG02LM.md
@@ -35,6 +35,8 @@ devices:
 Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
+You may have to unpair the switch from an existing coordinator before the pairing process will start.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/WXKG03LM.md
+++ b/docs/devices/WXKG03LM.md
@@ -35,6 +35,8 @@ devices:
 Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
+You may have to unpair the switch from an existing coordinator before the pairing process will start.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/WXKG06LM.md
+++ b/docs/devices/WXKG06LM.md
@@ -35,6 +35,8 @@ devices:
 Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
+You may have to unpair the switch from an existing coordinator before the pairing process will start.
+
 
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,

--- a/docs/devices/ZNCZ02LM.md
+++ b/docs/devices/ZNCZ02LM.md
@@ -22,11 +22,13 @@ description: "Integrate your Xiaomi ZNCZ02LM via Zigbee2mqtt with whatever smart
 Press and hold the button on the device for +- 10 seconds
 (until the blue light starts blinking and stops blinking), release and wait.
 
+You may have to unpair the switch from an existing coordinator before the pairing process will start.
+
 
 ### Power outage memory
 This option allows the device to restore the last on/off state when it's reconnected to power.
 To set this option publish to `zigbee2mqtt/[FRIENDLY_NAME]/set` payload `{"power_outage_memory": true}` (or `false`).
-Now toggle the plug once with the button on it, from now on it will restore its state when reconnecting to power.
+Now toggle the plug/swich once with the button on it, from now on it will restore its state when reconnecting to power.
 
 
 ## Manual Home Assistant configuration
@@ -68,14 +70,6 @@ sensor:
     unit_of_measurement: "kWh"
     value_template: "{{ value_json.consumption }}"
     icon: "mdi:flash"
-
-sensor:
-  - platform: "mqtt"
-    state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
-    availability_topic: "zigbee2mqtt/bridge/state"
-    unit_of_measurement: "V"
-    value_template: "{{ value_json.voltage }}"
-    icon: "mdi:alpha-v"
 
 sensor:
   - platform: "mqtt"

--- a/docs/devices/ZNCZ04LM.md
+++ b/docs/devices/ZNCZ04LM.md
@@ -21,7 +21,7 @@ description: "Integrate your Xiaomi ZNCZ04LM via Zigbee2mqtt with whatever smart
 ### Power outage memory
 This option allows the device to restore the last on/off state when it's reconnected to power.
 To set this option publish to `zigbee2mqtt/[FRIENDLY_NAME]/set` payload `{"power_outage_memory": true}` (or `false`).
-Now toggle the plug once with the button on it, from now on it will restore its state when reconnecting to power.
+Now toggle the plug/swich once with the button on it, from now on it will restore its state when reconnecting to power.
 
 
 ## Manual Home Assistant configuration

--- a/docs/information/supported_devices.md
+++ b/docs/information/supported_devices.md
@@ -1513,8 +1513,8 @@ In case you own a Zigbee device which is **NOT** listed here, please see
 | [QBKG12LM](../devices/QBKG12LM.md) | Xiaomi Aqara double key wired wall switch (on/off, power measurement, temperature) | ![../images/devices/QBKG12LM.jpg](../images/devices/QBKG12LM.jpg) |
 | [WXKG07LM](../devices/WXKG07LM.md) | Xiaomi Aqara D1 double key wireless wall switch (action) | ![../images/devices/WXKG07LM.jpg](../images/devices/WXKG07LM.jpg) |
 | [QBKG21LM](../devices/QBKG21LM.md) | Xiaomi Aqara D1 single gang smart wall switch (no neutral wire) (on/off, action) | ![../images/devices/QBKG21LM.jpg](../images/devices/QBKG21LM.jpg) |
-| [QBKG22LM](../devices/QBKG22LM.md) | Xiaomi Aqara D1 2 gang smart wall switch (no neutral wire) (on/off, action, power measurement) | ![../images/devices/QBKG22LM.jpg](../images/devices/QBKG22LM.jpg) |
-| [QBKG25LM](../devices/QBKG25LM.md) | Xiaomi Aqara D1 3 gang smart wall switch (no neutral wire) (on/off, action, power measurement) | ![../images/devices/QBKG25LM.jpg](../images/devices/QBKG25LM.jpg) |
+| [QBKG22LM](../devices/QBKG22LM.md) | Xiaomi Aqara D1 2 gang smart wall switch (no neutral wire) (on/off, action) | ![../images/devices/QBKG22LM.jpg](../images/devices/QBKG22LM.jpg) |
+| [QBKG25LM](../devices/QBKG25LM.md) | Xiaomi Aqara D1 3 gang smart wall switch (no neutral wire) (on/off, action) | ![../images/devices/QBKG25LM.jpg](../images/devices/QBKG25LM.jpg) |
 | [QBKG23LM](../devices/QBKG23LM.md) | Xiaomi Aqara D1 1 gang smart wall switch (with neutral wire) (on/off, power measurement) | ![../images/devices/QBKG23LM.jpg](../images/devices/QBKG23LM.jpg) |
 | [QBKG24LM](../devices/QBKG24LM.md) | Xiaomi Aqara D1 2 gang smart wall switch (with neutral wire) (on/off, power measurement) | ![../images/devices/QBKG24LM.jpg](../images/devices/QBKG24LM.jpg) |
 | [WSDCGQ01LM](../devices/WSDCGQ01LM.md) | Xiaomi MiJia temperature & humidity sensor (temperature and humidity) | ![../images/devices/WSDCGQ01LM.jpg](../images/devices/WSDCGQ01LM.jpg) |

--- a/docs/information/supported_devices.md
+++ b/docs/information/supported_devices.md
@@ -1513,8 +1513,8 @@ In case you own a Zigbee device which is **NOT** listed here, please see
 | [QBKG12LM](../devices/QBKG12LM.md) | Xiaomi Aqara double key wired wall switch (on/off, power measurement, temperature) | ![../images/devices/QBKG12LM.jpg](../images/devices/QBKG12LM.jpg) |
 | [WXKG07LM](../devices/WXKG07LM.md) | Xiaomi Aqara D1 double key wireless wall switch (action) | ![../images/devices/WXKG07LM.jpg](../images/devices/WXKG07LM.jpg) |
 | [QBKG21LM](../devices/QBKG21LM.md) | Xiaomi Aqara D1 single gang smart wall switch (no neutral wire) (on/off, action) | ![../images/devices/QBKG21LM.jpg](../images/devices/QBKG21LM.jpg) |
-| [QBKG22LM](../devices/QBKG22LM.md) | Xiaomi Aqara D1 2 gang smart wall switch (no neutral wire) (on/off, action) | ![../images/devices/QBKG22LM.jpg](../images/devices/QBKG22LM.jpg) |
-| [QBKG25LM](../devices/QBKG25LM.md) | Xiaomi Aqara D1 3 gang smart wall switch (no neutral wire) (on/off, action) | ![../images/devices/QBKG25LM.jpg](../images/devices/QBKG25LM.jpg) |
+| [QBKG22LM](../devices/QBKG22LM.md) | Xiaomi Aqara D1 2 gang smart wall switch (no neutral wire) (on/off, action, power measurement) | ![../images/devices/QBKG22LM.jpg](../images/devices/QBKG22LM.jpg) |
+| [QBKG25LM](../devices/QBKG25LM.md) | Xiaomi Aqara D1 3 gang smart wall switch (no neutral wire) (on/off, action, power measurement) | ![../images/devices/QBKG25LM.jpg](../images/devices/QBKG25LM.jpg) |
 | [QBKG23LM](../devices/QBKG23LM.md) | Xiaomi Aqara D1 1 gang smart wall switch (with neutral wire) (on/off, power measurement) | ![../images/devices/QBKG23LM.jpg](../images/devices/QBKG23LM.jpg) |
 | [QBKG24LM](../devices/QBKG24LM.md) | Xiaomi Aqara D1 2 gang smart wall switch (with neutral wire) (on/off, power measurement) | ![../images/devices/QBKG24LM.jpg](../images/devices/QBKG24LM.jpg) |
 | [WSDCGQ01LM](../devices/WSDCGQ01LM.md) | Xiaomi MiJia temperature & humidity sensor (temperature and humidity) | ![../images/devices/WSDCGQ01LM.jpg](../images/devices/WSDCGQ01LM.jpg) |


### PR DESCRIPTION
- Remove mention of temperature/power measurement (these switches don't seem to have support for that)
- Add `decoupled_mode` instructions
- (for QBKG25LM) add `power_outage_memory` and `do_not_disturb` device
  type specific configuration

Related to Koenkk/zigbee-herdsman-converters#1435