### PR TITLE
Update WXKG01LM with a legacy notice

### DIFF
--- a/docs/devices/WXKG01LM.md
+++ b/docs/devices/WXKG01LM.md
@@ -26,6 +26,20 @@ After this the device will automatically join. If this doesn't work, try with a 
 ### Binding
 This device does **not** support binding.
 
+### Legacy integration
+This device supports the deprecated `click` and also the newer `action` format. 
+By default (for backwards compatibility purposes) the deprecated version is enabled until Zigbee2Mqtt 2.0. 
+For new users it is recommended to **disable** this for more consistency and easier integration with newer Versions.
+To disable the legacy version add the following to your `configuration.yaml`:
+
+{% raw %}
+```yaml
+'0xabc457fffe679xyz':
+    friendly_name: my_remote
+    legacy: false
+```
+{% endraw %}
+
 
 ### Device type specific configuration
 *[How to use device type specific configuration](../information/configuration.md)*


### PR DESCRIPTION
With the PR Koenkk/zigbee-herdsman-converters#1399 many devices received the newer `action` format in favour of `click`. This information should be represented in the documentation so that the users can move over to the newer format. 
The provided format is a suggestion and if it seems appropriate I will also provide changes for the other devices.
Affected Devices:
WXKG01LM, WXKG11LM, WXKG12LM, WXKG06LM, WXKG02LM, QBKG04LM, WXKG07LM, QBKG21LM, QBKG22LM, ptvo.switch, DIYRuZ_R8_8,HGZB-1S, HGZB-02S, HGZB-045, AV2010/34, HS1EB, AIRAM-CTR.U, ICZB-KPD14S, ICZB-KPD18S, ZGRC-KEY-013, N2G-SP, 6ARCZABZH, MEAZON_BIZY_PLUG, MEAZON_DINRAIL, 2AJZ4KPKEY, TERNCY-PP01, TERNCY-SD01