### PR TITLE
Add voltage to ZNCZ02LM manual config

### DIFF
--- a/docs/devices/ZNCZ02LM.md
+++ b/docs/devices/ZNCZ02LM.md
@@ -73,6 +73,14 @@ sensor:
   - platform: "mqtt"
     state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     availability_topic: "zigbee2mqtt/bridge/state"
+    unit_of_measurement: "V"
+    value_template: "{{ value_json.voltage }}"
+    icon: "mdi:alpha-v"
+
+sensor:
+  - platform: "mqtt"
+    state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
+    availability_topic: "zigbee2mqtt/bridge/state"
     icon: "mdi:signal"
     unit_of_measurement: "lqi"
     value_template: "{{ value_json.linkquality }}"


### PR DESCRIPTION
Updating the docs for manual addition of ZNCZ02LM as per Koenkk/zigbee2mqtt#3991