### PR TITLE
Replace Hass.io

### DIFF
--- a/docs/getting_started/running_zigbee2mqtt.md
+++ b/docs/getting_started/running_zigbee2mqtt.md
@@ -3,7 +3,7 @@
 # Running Zigbee2MQTT
 These instructions explain how to run Zigbee2MQTT on bare-metal Linux.
 
-You can also run Zigbee2MQTT in a [Docker container](../information/docker.md), as the [Hass.io Zigbee2MQTT add-on](https://github.com/danielwelch/hassio-zigbee2mqtt), in a [Python Virtual Enviroment](../information/virtual_environment.md) or even on [Windows](../information/windows.md).
+You can also run Zigbee2MQTT in a [Docker container](../information/docker.md), as the [Home Assistant Zigbee2MQTT add-on](https://github.com/danielwelch/hassio-zigbee2mqtt), in a [Python Virtual Enviroment](../information/virtual_environment.md) or even on [Windows](../information/windows.md).
 
 For the sake of simplicity this guide assumes running on a Raspberry Pi 3 with Raspbian Stretch Lite, but will work on any Linux machine.
 


### PR DESCRIPTION
Hass.io was renamed to Home Assistant.