### PR TITLE
Update 9290012607.md

### DIFF
--- a/docs/devices/9290012607.md
+++ b/docs/devices/9290012607.md
@@ -23,6 +23,8 @@ Press and hold the setup button on the rear of the device for +- 10 seconds (unt
 to initiate pairing. Please note that the pairing indicator light is below the main sensor
 (as oppose to the obvious indicator above the main sensor).
 
+This specific device has been reported to have issues repairing to a zigbee network after upgrading from a CC2531 to a CC2652 controller (Zigbee 1.2 to 3.0). (Re)pairing may only work after pairing the device to another network and channel first (has been tested with a philips hue 2.0 hub in this instance) before pairing it back to the zigbee2mqtt network again.
+
 
 ### Device type specific configuration
 *[How to use device type specific configuration](../information/configuration.md)*


### PR DESCRIPTION
I had problems pairing my 9290012607 back to my zigbee network after upgrading from a cc2530 stick to a zzh stick. Only the pan_id was changed in the config. 

The motion sensor would seem to pair just fine at first glance, and it would show up in the zigbee network map. However, no motion events were triggered, and both philips motion sensors I have, would keep showing device_announced messages in the logs. I then tried to repair the motion sensors after stopping zigbee2mqtt, removing the devices from data/database.db, starting zigbee2mqtt and pairing the sensor again and setting allow pair to true. This would end up with the same result. I tried this about 5 times, also changing the batteries on the sensor, keeping them close to the controller when pairing, to no avail.

After I connected the hue motion sensors to my unused philips hue hub, and then connecting them to the zigbee2mqtt network, everything suddenly worked fine.
(The logs now showed attributeReport messages after the device_announced message. These were missing before, even though usually attributeReport messages normally show when I delete a device from the database.db file, restart zigbee2mqtt, and then re-pair the device. A method which worked for all my other Zigbee devices).

The philips hue motion sensor was the only device in my network having this problem. All other devices (xiaomi door sensors, ikea buttons & bulbs, osram smart plug, eurotronic thermostat, etc) would pair fine (sometimes after having to delete them from database.db manually).