### PR TITLE
Update configuration.md

### DIFF
--- a/docs/information/configuration.md
+++ b/docs/information/configuration.md
@@ -131,7 +131,7 @@ advanced:
   # Optional: Home Assistant discovery topic (default: shown below)
   homeassistant_discovery_topic: 'homeassistant'
   # Optional: Home Assistant status topic (default: shown below)
-  homeassistant_status_topic: 'hass/status'
+  homeassistant_status_topic: 'homeassistant/status'
   # Optional: Home Assistant legacy triggers (default: shown below), when enabled:
   # - Zigbee2mqt will send an empty 'action' or 'click' after one has been send
   # - A 'sensor_action' and 'sensor_click' will be discoverd


### PR DESCRIPTION
Homeassistant automatically pushes status messages to topic homeassistant/status, but the default configuration.yaml in the zigbee2mqtt docs suggest topic hass/status.

Homeassistant doc... 

https://www.home-assistant.io/docs/mqtt/birth_will/

This pr aligns to the zigbee2mqtt doc to match.