### PR TITLE
Add pairing instructions for TS0601 Thermostat

### DIFF
--- a/docs/devices/TS0601_thermostat.md
+++ b/docs/devices/TS0601_thermostat.md
@@ -19,6 +19,18 @@ description: "Integrate your TuYa TS0601_thermostat via Zigbee2MQTT with whateve
 ## Notes
 
 
+### Pairing
+
+While pairing, keep the valve close to the CC2531 USB sniffer.
+
+1. *Turn the display on*: Short press home (:house:).
+2. *Enter settings*: Long press home (:house:) for 3sec.
+3. *Select WiFi settings*: Press the plus button (:heavy_plus_sign:) button 4 times to see the digital **`5`** on the right hand side and the blinking WiFi logo.
+4. *Enter WiFi settings*: Press home (:house:) once again. Now only WiFi logo is showing without blinking.
+5. *Enable pairing mode*: Long press home (:house:). WiFi logo is now blinking.
+6. *Keep display on*: Touch home (:house:) every few seconds.
+
+
 ### Local temperature
 If you'd like to force device to send local_temperature you can use this mqtt command:
 * `topic`: zigbee2mqtt/FRIENDLY_NAME/set/local_temperature_calibration

--- a/docs/devices/TS0601_thermostat.md
+++ b/docs/devices/TS0601_thermostat.md
@@ -21,7 +21,7 @@ description: "Integrate your TuYa TS0601_thermostat via Zigbee2MQTT with whateve
 
 ### Pairing
 
-While pairing, keep the valve close to the CC2531 USB sniffer.
+While pairing, keep the valve close to the coordinator.
 
 1. *Turn the display on*: Short press home (:house:).
 2. *Enter settings*: Long press home (:house:) for 3sec.


### PR DESCRIPTION
Following the instructions in https://github.com/Koenkk/zigbee2mqtt/issues/3821#issuecomment-665960350 I was able to pair my own Moes Smart Valve/Thermostat (Tuya TS0601). Thus, I added the explanation here to help others as well.