### PR TITLE
Update repairing URL

### DIFF
--- a/docs/information/flashing_the_cc2531.md
+++ b/docs/information/flashing_the_cc2531.md
@@ -4,7 +4,7 @@
 The firmware can be flashed with multiple devices. The easiest but most expensive option is with the *CC Debugger* from Texas Instruments, which is described on this page. However, you can also use a *Raspberry Pi* or a MCU like the *Arduino Uno* or the cheap *ESP8266* with four dupont cables and optionally a downloader cable. Information about these methods can be found here: [Alternative firmware flashing methods](../information/alternative_flashing_methods.md).
 
 
-*NOTE: In case you are already running a Zigbee network: reflashing does not require repairing of all devices, see [What does and does not require repairing of all devices?](../information/what_does_and_doesnt_require_repairing.md)*
+*NOTE: In case you are already running a Zigbee network: reflashing does not require repairing of all devices, see [What does and does not require repairing of all devices?](../information/FAQ.html#what-does-and-does-not-require-repairing-of-all-devices)*
 
 ## Required hardware
 The following additional hardware is required in order to flash the CC2531:


### PR DESCRIPTION
Update the "What does and does not require repairing of all devices?" from [../information/what_does_and_doesnt_require_repairing.md](https://www.zigbee2mqtt.io/information/what_does_and_doesnt_require_repairing.md) to [../information/FAQ.html#what-does-and-does-not-require-repairing-of-all-devices](https://www.zigbee2mqtt.io/information/FAQ.html#what-does-and-does-not-require-repairing-of-all-devices).