### PR TITLE
Fix typo on nginx proxy configuration

### DIFF
--- a/docs/information/frontend.md
+++ b/docs/information/frontend.md
@@ -27,7 +27,7 @@ server {
 
 server {
     listen      443 ssl http2;
-    listen      [::]:443 sll http2;
+    listen      [::]:443 ssl http2;
 
     # In case you want to use basic authentication:
     auth_basic "Login";


### PR DESCRIPTION
Tiny typo on the listen stanza for IPv6, it should read `ssl` instead of `sll`