### PR TITLE
Update flashing_the_cc2531.md

### DIFF
--- a/docs/information/flashing_the_cc2531.md
+++ b/docs/information/flashing_the_cc2531.md
@@ -30,7 +30,7 @@ The following additional hardware is required in order to flash the CC2531:
 Credits to [@Frans-Willem](https://github.com/frans-Willem) for majority of instructions.
 
 1. Install prerequisites for [CC-Tool](https://github.com/dashesy/cc-tool) using a package manager (e.g. [Homebrew](https://brew.sh/) for macOS)
-* Ubuntu/Debian: dh-autoreconf, libusb-1.0, libboost-all-dev
+* Ubuntu/Debian: dh-autoreconf, libusb-1.0, libboost-all-dev, libglib2.0-dev
 * Fedora: dh-autoreconf, boost-devel, libusb1-devel, gcc-c++
 * Archlinux: dh-autoreconf, libusb, boost
 * macOS: brew install autoconf automake libusb boost pkgconfig libtool


### PR DESCRIPTION
It worked on Debian only after installing `libglib2.0-dev` as proposed [here](https://github.com/nfc-tools/libnfc/issues/373#issuecomment-280785351). 