### PR TITLE
Update supported_devices to list best-on-top

### DIFF
--- a/docs/information/supported_adapters.md
+++ b/docs/information/supported_adapters.md
@@ -2,66 +2,7 @@
 
 Zigbee2MQTT officially supports the following adapters:
 
-### Texas Instruments CC2531
-![CC2531](../images/cc2531.jpg)
-
-- USB connected Zigbee adapter with PCB antenna.
-- Cheap but not very powerful (+- $5), may not be powerfull enough for larger networks (20+ devices).
-- Limited range, ~30m line of sight
-- Requires additional hardware to be flashed (CC debugger and downloader cable)
-- Coordinator firmware: [Zigbee 1.2 (recommended)](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_Home_1.2/bin) and [Zigbee 3.0](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.0.x/bin)
-- Router firmware: [Zigbee 1.2](https://github.com/Koenkk/Z-Stack-firmware/tree/master/router/CC2531/bin), can be re-paired pressing the S2 button for 5 seconds.
-- Can be bought on [AliExpress](https://www.aliexpress.com/wholesale?catId=0&initiative_id=SB_20191108075039&SearchText=cc2531)
-- [How to flash with CC debugger](../information/flashing_the_cc2531.md) or [alternative flashing methods](./alternative_flashing_methods.md)
-
-### Electrolama zig-a-zig-ah! (zzh!)
-![zzh](../images/zzh.jpg)
-
-- USB connnected Zigbee adapter
-- **Very powerful**, will easily handle networks of 100+ devices.
-- Very good range (due to external antenna)
-- Can be bought on [Tindie](https://www.tindie.com/products/electrolama/zzh-cc2652r-multiprotocol-rf-stick/#product-reviews)
-- Coordinator firmware: [Zigbee 3.0](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.x.0/bin) (use **CC26X2R1_*.zip**)
-- [Flashing guide](https://electrolama.com/projects/zig-a-zig-ah/#flash-firmware) (requires no additional hardware to flash)
-- When migrating from another dongle (e.g. CC2531), make sure to modify your `pan_id` in your [configuration](configuration.md), otherwise Zigbee2MQTT won't start.
-
-### slaesh's CC2652RB stick
-![slaesh's CC2652RB stick](../images/slaeshs_cc2652rb_stick.jpg)
-
-- USB connnected Zigbee adapter
-- **Very powerful**, will easily handle networks of 100+ devices.
-- Very good range (due to external antenna, SMA female connector)
-- Can be bought on [Tindie](https://www.tindie.com/products/slaesh/cc2652-zigbee-coordinator-or-openthread-router/#product-reviews)
-- Coordinator firmware: [Zigbee 3.0](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.x.0/bin) (use **CC2652RB_*.zip**)
-- [Flashing guide](https://slae.sh/projects/cc2652/#flashing) (requires no additional hardware to flash)
-- When migrating from another dongle (e.g. CC2531), make sure to modify your `pan_id` in your [configuration](configuration.md), otherwise Zigbee2MQTT won't start.
-
-### Texas Instruments CC2530 (optionally with a CC2591 or CC2592 RF frontend)
-![CC2530](../images/cc2530.jpg)
-
-- Serial connected Zigbee adapter with most of the times and external atenna.
-- Cheap but not very powerful (+- $10), may not be powerfull enough for larger networks (20+ devices).
-- Good range, ~50-60m line of sight, sensitivity can be increased when used together with a CC2591 or CC2592
-- Requires additional hardware to be flashed (CC debugger)
-- Coordinator firmware: [Zigbee 1.2 (recommended)](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_Home_1.2/bin) and [Zigbee 3.0](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.0.x/bin)
-- Router firmware: [Zigbee 1.2](https://github.com/Koenkk/Z-Stack-firmware/tree/master/router/CC2530/bin), can be re-paired if you power on/power off the device three times (power on, wait 2 seconds, power off, repeat this cycle three times)
-- Can be bought on e.g. AliExpress: [CC2530](http://www.aliexpress.com/wholesale?catId=0&initiative_id=SB_20181213104041&SearchText=cc2530), [CC2530 + CC2591](http://www.aliexpress.com/wholesale?catId=0&initiative_id=SB_20181213104521&SearchText=cc2530+cc2591), [GBAN GB2530](http://www.gban.cn/en/product_show.asp?id=43)
-- Complete dongle preflashed (coordinator or router) can be bought on [Tindie](https://www.tindie.com/products/GiovanniCas/cc2530-cc2592-zigbee-dongle/)
-- How to flash: see flashing section of [How to create a CC2530 router](../how_tos/how_to_create_a_cc2530_router.md) or [alternative flashing methods](./alternative_flashing_methods.md)
-- [Connecting the CC2530](./connecting_cc2530.md)
-
-### Texas Instruments CC2538 with CC2592 RF Amplifier
-![CC2538](../images/cc2538.jpg)
-
-- Serial connected Zigbee adapter with external antenna.
-- Cheap but needs specific PCBs to be used as coordinator (+- $5 bare chip)
-- **Very powerful** and capable to handle **+150 devices directly connected**.
-- Very good range, ~800m line of sight, sensitivity is due to the onboard CC2592 Power Amplifier (20db)
-- Requires JTAG programmer to be flashed
-- Coordinator firmware: [Zigbee 3.0](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.0.x/bin)
-- Bare module can be bought on [AliExpress](https://www.aliexpress.com/wholesale?catId=0&initiative_id=SB_20191108075039&SearchText=cc2538)
-- Complete dongle preflashed can be bought on [Tindie](https://www.tindie.com/products/GiovanniCas/cc2538-cc2592-zigbee-dongle-new-zb30/)
-- [How to flash](./flashing_the_cc2538.md)
+## Recommended
 
 ### Texas Instruments LAUNCHXL-CC26X2R1
 ![CC26X2R1](../images/cc26x2r1.jpg)
@@ -93,6 +34,73 @@ Zigbee2MQTT officially supports the following adapters:
 - [Flash via UNIFLASH](./flashing_via_uniflash.md)
 - When migrating from another dongle (e.g. CC2531), make sure to modify your `pan_id` in your [configuration](configuration.md), otherwise Zigbee2MQTT won't start.
 - This device has two serial devices built in. Make sure you put the right serial device in the [configuration](configuration.md) or use auto detect if you only have one Texas Instruments CC devices connected to your system.
+
+### Texas Instruments CC2538 with CC2592 RF Amplifier
+![CC2538](../images/cc2538.jpg)
+
+- Serial connected Zigbee adapter with external antenna.
+- Cheap but needs specific PCBs to be used as coordinator (+- $5 bare chip)
+- **Very powerful** and capable to handle **+150 devices directly connected**.
+- Very good range, ~800m line of sight, sensitivity is due to the onboard CC2592 Power Amplifier (20db)
+- Requires JTAG programmer to be flashed
+- Coordinator firmware: [Zigbee 3.0](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.0.x/bin)
+- Bare module can be bought on [AliExpress](https://www.aliexpress.com/wholesale?catId=0&initiative_id=SB_20191108075039&SearchText=cc2538)
+- Complete dongle preflashed can be bought on [Tindie](https://www.tindie.com/products/GiovanniCas/cc2538-cc2592-zigbee-dongle-new-zb30/)
+- [How to flash](./flashing_the_cc2538.md)
+
+### Texas Instruments CC2530 (optionally with a CC2591 or CC2592 RF frontend)
+![CC2530](../images/cc2530.jpg)
+
+- Serial connected Zigbee adapter with most of the times and external atenna.
+- Cheap but not very powerful (+- $10), may not be powerfull enough for larger networks (20+ devices).
+- Good range, ~50-60m line of sight, sensitivity can be increased when used together with a CC2591 or CC2592
+- Requires additional hardware to be flashed (CC debugger)
+- Coordinator firmware: [Zigbee 1.2 (recommended)](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_Home_1.2/bin) and [Zigbee 3.0](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.0.x/bin)
+- Router firmware: [Zigbee 1.2](https://github.com/Koenkk/Z-Stack-firmware/tree/master/router/CC2530/bin), can be re-paired if you power on/power off the device three times (power on, wait 2 seconds, power off, repeat this cycle three times)
+- Can be bought on e.g. AliExpress: [CC2530](http://www.aliexpress.com/wholesale?catId=0&initiative_id=SB_20181213104041&SearchText=cc2530), [CC2530 + CC2591](http://www.aliexpress.com/wholesale?catId=0&initiative_id=SB_20181213104521&SearchText=cc2530+cc2591), [GBAN GB2530](http://www.gban.cn/en/product_show.asp?id=43)
+- Complete dongle preflashed (coordinator or router) can be bought on [Tindie](https://www.tindie.com/products/GiovanniCas/cc2530-cc2592-zigbee-dongle/)
+- How to flash: see flashing section of [How to create a CC2530 router](../how_tos/how_to_create_a_cc2530_router.md) or [alternative flashing methods](./alternative_flashing_methods.md)
+- [Connecting the CC2530](./connecting_cc2530.md)
+
+### Texas Instruments CC2531
+![CC2531](../images/cc2531.jpg)
+
+- USB connected Zigbee adapter with PCB antenna.
+- Cheap but not very powerful (+- $5), may not be powerfull enough for larger networks (20+ devices).
+- Limited range, ~30m line of sight
+- Requires additional hardware to be flashed (CC debugger and downloader cable)
+- Coordinator firmware: [Zigbee 1.2 (recommended)](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_Home_1.2/bin) and [Zigbee 3.0](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.0.x/bin)
+- Router firmware: [Zigbee 1.2](https://github.com/Koenkk/Z-Stack-firmware/tree/master/router/CC2531/bin), can be re-paired pressing the S2 button for 5 seconds.
+- Can be bought on [AliExpress](https://www.aliexpress.com/wholesale?catId=0&initiative_id=SB_20191108075039&SearchText=cc2531)
+- [How to flash with CC debugger](../information/flashing_the_cc2531.md) or [alternative flashing methods](./alternative_flashing_methods.md)
+
+> **Watch out!** There are plenty of CC2531 fakes sold on Aliexpress and similar platforms! They are **far away** from original T.I. quality!
+
+## DYI platforms
+
+### Electrolama zig-a-zig-ah! (zzh!)
+![zzh](../images/zzh.jpg)
+
+- USB connnected Zigbee adapter
+- **Very powerful**, will easily handle networks of 100+ devices.
+- Very good range (due to external antenna)
+- Can be bought on [Tindie](https://www.tindie.com/products/electrolama/zzh-cc2652r-multiprotocol-rf-stick/#product-reviews)
+- Coordinator firmware: [Zigbee 3.0](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.x.0/bin) (use **CC26X2R1_*.zip**)
+- [Flashing guide](https://electrolama.com/projects/zig-a-zig-ah/#flash-firmware) (requires no additional hardware to flash)
+- When migrating from another dongle (e.g. CC2531), make sure to modify your `pan_id` in your [configuration](configuration.md), otherwise Zigbee2MQTT won't start.
+
+### slaesh's CC2652RB stick
+![slaesh's CC2652RB stick](../images/slaeshs_cc2652rb_stick.jpg)
+
+- USB connnected Zigbee adapter
+- **Very powerful**, will easily handle networks of 100+ devices.
+- Very good range (due to external antenna, SMA female connector)
+- Can be bought on [Tindie](https://www.tindie.com/products/slaesh/cc2652-zigbee-coordinator-or-openthread-router/#product-reviews)
+- Coordinator firmware: [Zigbee 3.0](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.x.0/bin) (use **CC2652RB_*.zip**)
+- [Flashing guide](https://slae.sh/projects/cc2652/#flashing) (requires no additional hardware to flash)
+- When migrating from another dongle (e.g. CC2531), make sure to modify your `pan_id` in your [configuration](configuration.md), otherwise Zigbee2MQTT won't start.
+
+## Other supported adapters
 
 ### ConBee II
 ![Conbee II](../images/conbee.jpg)


### PR DESCRIPTION
Update supported_devices to highlight least-headache-generating devices on top. Previous order was favoring CC2531 which is extremely fakeable on Aliexpress and in most cases is good just for playground – not for production use.

This is extreme problem in tons of community forums. People are asking "Conbee II or CC2531" like the second is a keyword for Zigbee2MQTT. I guess, in the end, it makes a lot of headache and lots of people lost their trust to Z2M.