### PR TITLE
Update how_to_connect_to_a_remote_adapter.md

### DIFF
--- a/docs/how_tos/how_to_connect_to_a_remote_adapter.md
+++ b/docs/how_tos/how_to_connect_to_a_remote_adapter.md
@@ -3,12 +3,14 @@ This how-to explains how to run Zigbee2MQTT with an adapter on a remote location
 We will use ser2net for this which allows to connect to a serial port over TCP.
 In this way you can e.g. setup a Raspberry Pi Zero with the adapter connected while running Zigbee2MQTT on a different system. The instructions below have to be executed on the system where the adapter is connected to.
 
+DeCONZ Conbee II is not supported over tcp connections using this or any other configuration at this time. 
+
 ## 1. Install ser2net
 ```bash
 sudo apt-get install ser2net
 ```
 
-## 2. Configure ser2net
+## 2(a). Configure ser2net (<4.0)
 ```bash
 sudo nano /etc/ser2net.conf
 ```
@@ -24,8 +26,29 @@ After this reboot the system.
 reboot
 ```
 
+## 2(b). Configure ser2net (>=4.0)
+```bash
+sudo nano /etc/ser2net.yaml
+```
+
+Add the following entry, replace `/dev/ttyACM0` with the correct path to your adapter.
+
+```
+connection: &con01
+  accepter: tcp,20108
+  connector: serialdev,/dev/ttyACM0,115200n81,local
+  options:
+    kickolduser: true
+```
+
+After this reboot the system.
+```bash
+reboot
+```
+
+
 ## 3. Configure
-Now edit the Zigbee2MQTT `configuration.yaml` accordingly, replace `192.168.2.13` with the IP of your system where the adapter is connectd to.
+Now edit the Zigbee2MQTT `configuration.yaml` accordingly, replace `192.168.2.13` with the IP or hostname of your system where the adapter is connectd to.
 
 ```yaml
 serial:


### PR DESCRIPTION
Updated how_to_connect_to_a_remote_adapter with warning about how Conbee II is currently unsupported as a TCP device based on testing. 
https://github.com/cminyard/ser2net/issues/35
https://github.com/Koenkk/zigbee-herdsman/issues/72

Also updated configuration instructions for ser2net as new version has been rewritten and uses a different configuration file syntax.