### PR TITLE
Update LED1623G12.md

### DIFF
--- a/docs/devices/LED1623G12.md
+++ b/docs/devices/LED1623G12.md
@@ -24,8 +24,8 @@ After resetting the bulb will automatically connect.
 
 While pairing, keep the bulb close to the CC2531 USB sniffer.
 
-What works is to use (very) short “on’s” and a little bit longer “off’s”.
-Start with bulb on, then off, and then 6 “on’s”, where you kill the light as soon as the bulb shows signs of turning on.
+What works is to use (very) short “on’s” and a little bit longer “off’s”, where you kill the light as soon as the bulb shows signs of turning on.
+Start with bulb on, then off, and then 6 “on’s”, wait in the 6th ON state. (If you try play safe and go for 7 "on's" the reset sometimes fails.)
 
 ### Device type specific configuration
 *[How to use device type specific configuration](../information/configuration.md)*


### PR DESCRIPTION
Having trouble pairing a new bulb, I've updated the reset proces just a little. It seems that on new bulbs the reset sequence must be exactly 6 "on's". That is what caused me a lot of time to figure out as many people suggest to 'play safe' and use more than 6 "on's" in which case the bulb (maybe limited to newer bulbs) will start glowing, but does not reset!