### PR TITLE
Added CC2652R, CC2652RB and CC2530 + CC2591 cases

### DIFF
--- a/docs/information/3d_cases.md
+++ b/docs/information/3d_cases.md
@@ -2,30 +2,36 @@
 ---
 # 3D cases
 
-## Raspberry Pi Zero
- - Blog post about a [round case for the Raspberry Pi Zero by Jens Willmer][jwillmer-blog-post]. The files can also be found on [Thingiverse][thingiverse-jwillmer-design].
- - [Minimal Pi Zero Case by Jens Willmer][thingiverse-jwillmer-design2]
-
-## Raspberry Pi
- - Case design for a [Raspberry Pi with hard drive and optional USB stick by Kelvin Shirley on Thingiverse][thingiverse-rpi-owncloud-design].
-
-## CC2531 Zigbee dongle
- - Case design for a [CC2531 Zigbee dongle][thingiverse-rpi-cc2531-dongle]
+## CC1352P1, CC1352P-2 and CC2652R LaunchXL
+- Case designs for [TI LaunchXL boards for CC1352P1, CC1352P-2 and CC2652R][thingiverse-c1352p1-cc1352p-2-cc2652r-launchxl]
 
 ## CC2530 Zigbee dongle
  - Case design for a [CC2530 Zigbee minimal case][thingiverse-cc2530-case]
 
-## CC2530 + CC2591 Combination
-- Case design for a [minimal case compatible with the CC2530 + CC2591 combination][thingiverse-cc2530-cc2591-case]
+## CC2531 Zigbee dongle
+ - Case design for a [CC2531 Zigbee dongle][thingiverse-rpi-cc2531-dongle]
 
 ## CC2531 Zigbee dongle with external antenna
- - Case design for a [CC2531 Zigbee dongle with external antenna](https://www.thingiverse.com/thing:3731958)
+ - Case design for a [CC2531 Zigbee dongle with external antenna][thingiverse-rpi-cc2531-dongle-external-antenna]
+ - Case design with buttons for a [CC2531 Zigbee dongle with external antenna][thingiverse-rpi-cc2531-dongle-with-buttons]
 
-## CC1352P1, CC1352P-2 and CC2652R LaunchXL
-- Case designs for [TI LaunchXL boards for CC1352P1, CC1352P-2 and CC2652R](https://www.thingiverse.com/thing:3928171)
+## CC2652R Zigbee dongle from electrolama aka zzh!
+ - Case design with button for a [CC2652R Zigbee dongle from electrolama aka zzh!][thingiverse-CC2652R-zzh-case]
 
-## CC2530 + CC2591 with PSU and C7 socket
-- Case design for a [CC2530 + CC2591 Enclosure](https://www.thingiverse.com/thing:4590891) which has room for an AC to DC 3.3v PSU and a C7 socket
+## CC2652RB Zigbee dongle from slaehs
+ - Case design for a [CC2652R Zigbee dongle from slaehs][thingiverse-CC2652RB-slaesh-case]
+
+## CC2530 + CC2591 Combination
+- Case design for a [minimal case compatible with the CC2530 + CC2591 combination][thingiverse-cc2530-cc2591-case]
+- Case design with PSU and C7 socket for a [CC2530 + CC2591 + PSU + C7 socket][thingiverse-cc2530-cc2591-case-psu-c7]
+- Case design with PSU HLK-PM03 for a [CC2530 + CC2591 + HLK-PM03][thingiverse-cc2530-cc2591-case-hlk-pm03]
+
+## Raspberry Pi
+ - Case design for a [Raspberry Pi with hard drive and optional USB stick by Kelvin Shirley on Thingiverse][thingiverse-rpi-owncloud-design].
+
+## Raspberry Pi Zero
+ - Blog post about a [round case for the Raspberry Pi Zero by Jens Willmer][jwillmer-blog-post]. The files can also be found on [Thingiverse][thingiverse-jwillmer-design].
+ - [Minimal Pi Zero Case by Jens Willmer][thingiverse-jwillmer-design2]
 
 ## Alternatives
 A lot of different case designs can be found via the [Thingiverse search][thingiverse-search-rpi]
@@ -36,5 +42,12 @@ A lot of different case designs can be found via the [Thingiverse search][thingi
 [thingiverse-search-rpi]: https://www.thingiverse.com/search?q=raspberry+pi+case
 [thingiverse-rpi-owncloud-design]: https://www.thingiverse.com/thing:1357022
 [thingiverse-rpi-cc2531-dongle]: https://www.thingiverse.com/thing:2803664
+[thingiverse-rpi-cc2531-dongle-external-antenna]: https://www.thingiverse.com/thing:3731958
+[thingiverse-rpi-cc2531-dongle-with-buttons]: https://www.thingiverse.com/thing:4544187
+[thingiverse-CC2652R-zzh-case]: https://www.thingiverse.com/thing:4642451
+[thingiverse-CC2652RB-slaesh-case]: https://www.thingiverse.com/thing:4618490
 [thingiverse-cc2530-case]: https://www.thingiverse.com/thing:3257462
 [thingiverse-cc2530-cc2591-case]: https://www.thingiverse.com/thing:3416548
+[thingiverse-cc2530-cc2591-case-psu-c7]: https://www.thingiverse.com/thing:4590891
+[thingiverse-cc2530-cc2591-case-hlk-pm03]: https://www.thingiverse.com/thing:4561570
+[thingiverse-c1352p1-cc1352p-2-cc2652r-launchxl]: https://www.thingiverse.com/thing:3928171


### PR DESCRIPTION
Link types have been normalized and everything has been sorted alphabetically