### PR TITLE
Update supported_adapters.md with ConBee firmware links

### DIFF
--- a/docs/information/supported_adapters.md
+++ b/docs/information/supported_adapters.md
@@ -113,6 +113,8 @@ Zigbee2MQTT officially supports the following adapters:
 
 - USB connnected Zigbee adapter
 - **Very powerful**, will easily handle networks of 100+ devices.
+- Coordinator firmware: Recommend upgrading to latest [deCONZ Zigbee Home Automation 1.2 coordinator firmware](https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Update-deCONZ-manually).
+  - Note! There is [no deCONZ Zigbee 3.0 coordinator firmware for ConBee or RaspBee as of yet](https://github.com/dresden-elektronik/deconz-rest-plugin/issues/2057).
 - Support is still **experimental**. ([discussion](https://github.com/Koenkk/zigbee-herdsman/issues/72))
 - In case you are getting the following error: `Error: Failed to connect to the adapter (Error: SRSP - SYS - ping after 6000ms)` set the following in your `configuration.yaml`.
 


### PR DESCRIPTION
Update supported_adapters.md with ConBee firmware links. Note that current recommendation from dresden elektronik is to upgrade deCONZ firmware (Zigbee stack application firmware) for ConBee and RaspBee as per https://github.com/dresden-elektronik/deconz-rest-plugin/releases ("This firmware update is also recommended for ZHA, zigbee2mqtt and WebThings users. In this release it needs to be installed manually as described in the [Wik](https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Update-deCONZ-manually)i").