### PR TITLE
Filled in missing climate topics in SPZB0001.md

### DIFF
--- a/docs/devices/SPZB0001.md
+++ b/docs/devices/SPZB0001.md
@@ -182,20 +182,20 @@ climate:
     temp_step: 0.5
     min_temp: "5"
     max_temp: "30"
-    current_temperature_topic: true
+    current_temperature_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     current_temperature_template: "{{ value_json.local_temperature }}"
-    mode_state_topic: true
+    mode_state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     mode_state_template: "{{ value_json.system_mode }}"
     modes: 
       - "off"
       - "auto"
       - "heat"
-    mode_command_topic: true
-    action_topic: true
+    mode_command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set/system_mode"
+    action_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
     action_template: "{% set values = {'idle':'off','heat':'heating','cool':'cooling','fan only':'fan'} %}{{ values[value_json.running_state] }}"
-    temperature_command_topic: "occupied_heating_setpoint"
+    temperature_command_topic: "zigbee2mqtt/<FRIENDLY_NAME>/set/occupied_heating_setpoint"
     temperature_state_template: "{{ value_json.occupied_heating_setpoint }}"
-    temperature_state_topic: true
+    temperature_state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
 
 sensor:
   - platform: "mqtt"


### PR DESCRIPTION
I noticed the topics are missing from the manual home-assistant climate config.
I tested this with my `SPZB0001` (new firmware) which doesn't work with the home-assistant default MQTT discovery.