### PR TITLE
Update supported_adapters.md with ZiGate firmware link

### DIFF
--- a/docs/information/supported_adapters.md
+++ b/docs/information/supported_adapters.md
@@ -128,6 +128,7 @@ serial:
 
 - USB connnected Zigbee adapter
 - Hardware based on NXP JN516x ( JN5168 / JN5169 ) chip with open source [ZiGate firmware](https://github.com/fairecasoimeme/ZiGate) from @fairecasoimeme
+- Coordinator firmware: Recommend upgrading to [ZiGate firmware version 3.1d or later](https://zigate.fr/tag/firmware/).
 - Support is still **experimental**. ([discussion](https://github.com/Koenkk/zigbee-herdsman/issues/242))
 - In case you are getting the following error: `Error: Failed to connect to the adapter (Error: SRSP - SYS - ping after 6000ms)` set the following in your `configuration.yaml`.
 


### PR DESCRIPTION
Update supported_adapters.md with ZiGate firmware link and recommend using firmware version 3.1d or later as it contains an important memory-leak bug-fix.