### PR TITLE
Invalid json in example message

### DIFF
--- a/docs/devices/HG06467.md
+++ b/docs/devices/HG06467.md
@@ -72,7 +72,7 @@ Controls the 16 build-in effects of the LED string. An effect expects 3 paramete
                 "r": 0,
                 "g": 0,
                 "b": 255
-            },
+            }
         ]
     }
 }


### PR DESCRIPTION
The example message for effects contains an extra comma at the end of the list of colors. Took me an embarrassing amount of time to figure out why it wasn't working.