### PR TITLE
Changed CO2 to CO for Carbon Monoxide sensors

### DIFF
--- a/docs/devices/CR701-YZ.md
+++ b/docs/devices/CR701-YZ.md
@@ -28,7 +28,7 @@ It's not possible to read (`/get`) or write (`/set`) this value.
 If value equals `true` gas is ON, if `false` OFF.
 
 ### Carbon_monoxide (binary)
-Indicates if CO2 (carbon monoxide) is detected.
+Indicates if CO (carbon monoxide) is detected.
 Value can be found in the published state on the `carbon_monoxide` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 If value equals `true` carbon_monoxide is ON, if `false` OFF.

--- a/docs/devices/DIYRuZ_AirSense.md
+++ b/docs/devices/DIYRuZ_AirSense.md
@@ -42,8 +42,8 @@ e.g. `1` would add 1 to the pressure reported by the device; default `0`.
 
 
 ## Exposes
-### Co2 (numeric)
-The measured CO2 (carbon monoxide) value.
+### CO (numeric)
+The measured CO (carbon monoxide) value.
 Value can be found in the published state on the `co2` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The unit of this value is `ppm`.
@@ -81,14 +81,14 @@ To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/
 If value equals `ON` enable_abc is ON, if `OFF` OFF.
 
 ### Threshold1 (numeric)
-Warning (LED2) CO2 level.
+Warning (LED2) CO level.
 Value can be found in the published state on the `threshold1` property.
 To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"threshold1": ""}`.
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"threshold1": NEW_VALUE}`.
 The unit of this value is `ppm`.
 
 ### Threshold2 (numeric)
-Critical (LED3) CO2 level.
+Critical (LED3) CO level.
 Value can be found in the published state on the `threshold2` property.
 To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"threshold2": ""}`.
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"threshold2": NEW_VALUE}`.

--- a/docs/devices/HS1CA-E.md
+++ b/docs/devices/HS1CA-E.md
@@ -22,7 +22,7 @@ None
 
 ## Exposes
 ### Carbon_monoxide (binary)
-Indicates if CO2 (carbon monoxide) is detected.
+Indicates if CO (carbon monoxide) is detected.
 Value can be found in the published state on the `carbon_monoxide` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 If value equals `true` carbon_monoxide is ON, if `false` OFF.

--- a/docs/devices/HS1CA-M.md
+++ b/docs/devices/HS1CA-M.md
@@ -22,7 +22,7 @@ None
 
 ## Exposes
 ### Carbon_monoxide (binary)
-Indicates if CO2 (carbon monoxide) is detected.
+Indicates if CO (carbon monoxide) is detected.
 Value can be found in the published state on the `carbon_monoxide` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 If value equals `true` carbon_monoxide is ON, if `false` OFF.

--- a/docs/devices/SCA01ZB.md
+++ b/docs/devices/SCA01ZB.md
@@ -22,7 +22,7 @@ None
 
 ## Exposes
 ### Carbon_monoxide (binary)
-Indicates if CO2 (carbon monoxide) is detected.
+Indicates if CO (carbon monoxide) is detected.
 Value can be found in the published state on the `carbon_monoxide` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 If value equals `true` carbon_monoxide is ON, if `false` OFF.

--- a/docs/devices/W2-Module.md
+++ b/docs/devices/W2-Module.md
@@ -22,7 +22,7 @@ None
 
 ## Exposes
 ### Carbon_monoxide (binary)
-Indicates if CO2 (carbon monoxide) is detected.
+Indicates if CO (carbon monoxide) is detected.
 Value can be found in the published state on the `carbon_monoxide` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 If value equals `true` carbon_monoxide is ON, if `false` OFF.


### PR DESCRIPTION
In the docs I see for carbon monoxide something in the text docs like:
"Indicates if CO2 (carbon monoxide) is detected."
This should be CO (monoxide) compared do CO2 DIoxide

Grepped for 'CO2'  in all files.

For 2 sensors:
MCLH-08.md
TPZRCO2HT-Z3.md
I think these are actually CO2 sensors... but not 100% sure.