### PR TITLE
updating the actions for hue dimmer

### DIFF
--- a/docs/devices/324131092621.md
+++ b/docs/devices/324131092621.md
@@ -78,7 +78,7 @@ The unit of this value is `%`.
 Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
-The possible values are: `on-press`, `on-hold`, `on-release`, `up-press`, `up-hold`, `up-release`, `down-press`, `down-hold`, `down-release`, `off-press`, `off-hold`, `off-release`.
+The possible values are: `on-press`, `on-hold`, `on-hold-release`, `up-press`, `up-hold`, `up-hold-release`, `down-press`, `down-hold`, `down-hold-release`, `off-press`, `off-hold`, `off-hold-release`.
 
 ### Linkquality (numeric)
 Link quality (signal strength).


### PR DESCRIPTION
the release actions are called on-hold-release, for example, not on-release. updated all of them.