### PR TITLE
Recommend using docker to run npm ci

### DIFF
--- a/docs/how_tos/how_to_support_new_devices.md
+++ b/docs/how_tos/how_to_support_new_devices.md
@@ -114,7 +114,7 @@ To setup a local copy of zigbee-herdsman-converters so that you can modify e.g. 
 cd /opt
 git clone https://github.com/Koenkk/zigbee-herdsman-converters.git
 cd zigbee-herdsman-converters
-npm ci
+docker run -v "$PWD":/app -w /app --rm node:12 npm ci
 ```
 
 Now add the volumes to the Docker container by adding the following to your `docker run` command.:


### PR DESCRIPTION
Just noticed while creating the debug log for https://github.com/Koenkk/zigbee-herdsman-converters/issues/1985#issuecomment-751697805 that running npm ci on debian/linux isn't that straight forward. Installing NPM via apt results in a incompatible npm version with the installed node version. I could install it directly without the package manager but I don't really want npm on my server in the first place.

Since this part of the documentation is already only for docker users it makes sense to use a docker command here to run npm ci as well.

The upside is that we can make sure that the user has a up2date npm and node version.