### PR TITLE
Remove unsupported action

### DIFF
--- a/docs/devices/WXKG03LM.md
+++ b/docs/devices/WXKG03LM.md
@@ -56,7 +56,7 @@ The unit of this value is `%`.
 Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
-The possible values are: `single`, `double`, `hold`, `release`.
+The possible values are: `single`, `double`, `hold`.
 
 ### Linkquality (numeric)
 Link quality (signal strength).


### PR DESCRIPTION
This device doesn't send a "release" action that I could detect.