### PR TITLE
Removing unsupported action

### DIFF
--- a/docs/devices/WXKG06LM.md
+++ b/docs/devices/WXKG06LM.md
@@ -56,7 +56,7 @@ The unit of this value is `%`.
 Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
-The possible values are: `single`, `double`, `hold`, `release`.
+The possible values are: `single`, `double`, `hold`.
 
 ### Linkquality (numeric)
 Link quality (signal strength).


### PR DESCRIPTION
Sorry @Koenkk  I think this may be the same. I don't have one to test, but given all the other battery powered Xiaomi devices don't have a "release" action, I would presume this one doesn't either.