### PR TITLE
Added pairing to Müller Licht 404002 control

### DIFF
--- a/docs/devices/404002.md
+++ b/docs/devices/404002.md
@@ -17,6 +17,12 @@ description: "Integrate your Müller Licht 404002 via Zigbee2MQTT with whatever 
 
 ## Notes
 
+### Pairing
+
+Press the small reset button (at backside of the remote at the lower part of the battery lid) e.g. with a pin for about 4 seconds. The device will reset and try to join a network. The LED is switched on during the pairing process. If pairing failes it might work after repeating this procedure and lowering the distance to your Zigbee adapter.
+
+Pairing directly to a nearby (distance ca. 5 cm) Müller Licht Tint bulb is possible by holding down the "power" and "dim down" buttons until the LED starts blinking.
+
 ### Device type specific configuration
 *[How to use device type specific configuration](../information/configuration.md)*
 
@@ -38,7 +44,7 @@ simulated_brightness:
 Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
-The possible values are: `on`, `off`, `brightness_step_up`, `brightness_step_down`, `brightness_move_up`, `brightness_move_down`, `brightness_stop`.
+The possible values are: `on`, `off`, `brightness_step_up`, `brightness_step_down`, `brightness_move_up`, `brightness_move_down`, `brightness_stop`, `recall_1`.
 
 ### Linkquality (numeric)
 Link quality (signal strength).


### PR DESCRIPTION
Hello,

I would like to propose following additions to the documentation of the "Müller Licht 404002 control". It should be noted that it is probably identical to "Airam AIRAM-CTR.U". I tested the process with multiple remotes. "recall_1" is sent as "action" if the lowermost button is pressed with this code addition: https://github.com/Koenkk/zigbee-herdsman-converters/pull/2048 .


Best regards,

Andreas