### PR TITLE
Added Pairing details for this device

### DIFF
--- a/docs/devices/4000116784070.md
+++ b/docs/devices/4000116784070.md
@@ -19,6 +19,9 @@ description: "Integrate your Lonsonho 4000116784070 via Zigbee2MQTT with whateve
 
 None
 
+### Pairing
+Press and hold the power button on the device for +- 5 seconds (until a blue light starts blinking).
+After this the device will automatically join.
 
 ## Exposes
 


### PR DESCRIPTION
Bought a couple of these and noticed pairing details were missing on device page, Box also didn't have a manual. Relatively easy to figure out but thought it'd be useful to add the details.