### PR TITLE
Added missing details about exposed properties

### DIFF
--- a/docs/devices/4000116784070.md
+++ b/docs/devices/4000116784070.md
@@ -19,6 +19,9 @@ description: "Integrate your Lonsonho 4000116784070 via Zigbee2MQTT with whateve
 
 None
 
+### Pairing
+Press and hold the power button on the device for +- 5 seconds (until a blue light starts blinking).
+After this the device will automatically join.
 
 ## Exposes
 

--- a/docs/devices/4000116784070.md
+++ b/docs/devices/4000116784070.md
@@ -12,7 +12,7 @@ description: "Integrate your Lonsonho 4000116784070 via Zigbee2MQTT with whateve
 | Model | 4000116784070  |
 | Vendor  | Lonsonho  |
 | Description | Smart plug EU |
-| Exposes | switch (state), linkquality |
+| Exposes | switch (state), linkquality, voltage, power, energy, current |
 | Picture | ![Lonsonho 4000116784070](../images/devices/4000116784070.jpg) |
 
 ## Notes
@@ -37,6 +37,35 @@ It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `255`.
 The unit of this value is `lqi`.
 
+### Power (numeric)
+Instantaneous measured power.
+Value can be found in the published state on the `power` property.
+To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"power": ""}`.
+It's not possible to write (`/set`) this value.
+The unit of this value is `W`.
+
+### Energy (numeric)
+Sum of consumed energy.
+Value can be found in the published state on the `energy` property.
+To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"energy": ""}`.
+It's not possible to write (`/set`) this value.
+The unit of this value is `kWh`.
+
+### Voltage (numeric)
+Measured electrical potential value.
+Value can be found in the published state on the `voltage` property.
+To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"voltage": ""}`.
+It's not possible to write (`/set`) this value.
+The unit of this value is `V`.
+
+### Current (numeric)
+Instantaneous measured electrical current.
+Value can be found in the published state on the `current` property.
+To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"current": ""}`.
+It's not possible to write (`/set`) this value.
+The unit of this value is `A`.
+
+
 ## Manual Home Assistant configuration
 Although Home Assistant integration through [MQTT discovery](../integration/home_assistant) is preferred,
 manual integration is possible with the following configuration:
@@ -60,6 +89,39 @@ sensor:
     unit_of_measurement: "lqi"
     value_template: "{{ value_json.linkquality }}"
     icon: "mdi:signal"
+    
+sensor:
+  - platform: "mqtt"
+    state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
+    availability_topic: "zigbee2mqtt/bridge/state"
+    unit_of_measurement: "W"
+    value_template: "{{ value_json.power }}"
+    icon: "mdi:flash"
+
+sensor:
+  - platform: "mqtt"
+    state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
+    availability_topic: "zigbee2mqtt/bridge/state"
+    unit_of_measurement: "kWh"
+    value_template: "{{ value_json.energy }}"
+    icon: "mdi:power-plug"
+
+sensor:
+  - platform: "mqtt"
+    state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
+    availability_topic: "zigbee2mqtt/bridge/state"
+    unit_of_measurement: "V"
+    value_template: "{{ value_json.voltage }}"
+    icon: "mdi:alpha-v"
+
+sensor:
+  - platform: "mqtt"
+    state_topic: "zigbee2mqtt/<FRIENDLY_NAME>"
+    availability_topic: "zigbee2mqtt/bridge/state"
+    unit_of_measurement: "A"
+    value_template: "{{ value_json.current }}"
+    icon: "mdi:current-ac"
+
 ```
 {% endraw %}
 


### PR DESCRIPTION
After updating my zigbee2mqtt bridge from 1.13.0 to 1.17.0 I noticed that this plug is now exposing 4 new details that are not referenced in the documentation.
New properties are Voltage, Energy, Power and Current.
Added to both the "Exposes" section and also to the "Manual Configuration". Copied a lot of the text from a similar Xiaomi plug as it's exactly the same properties and types.
As a note, and this is probably a comment for the herdsman project, the HA integration is automatically creating a power_outage_memory sensor that the plug doesn't seem to support.
(copied from commit)