### PR TITLE
Fixed a Typo in docs ("tripple" to "triple")

### DIFF
--- a/docs/devices/WXKG01LM.md
+++ b/docs/devices/WXKG01LM.md
@@ -78,7 +78,7 @@ The unit of this value is `%`.
 Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
-The possible values are: `single`, `double`, `tripple`, `quadruple`, `hold`, `release`.
+The possible values are: `single`, `double`, `triple`, `quadruple`, `hold`, `release`.
 
 ### Linkquality (numeric)
 Link quality (signal strength).


### PR DESCRIPTION
confirmed that the output is indeed "triple" with my local instance Screenshot is of node red, reading it from home assistant through mosquitto mqtt, so it's not direct "proof" but like.. this is obviously a typo
![image](https://user-images.githubusercontent.com/1852285/104827699-a8489100-582e-11eb-80bb-8dcc115a60f9.png)
