### PR TITLE
Update possible action payload values for IKEA E1744

### DIFF
--- a/docs/devices/E1744.md
+++ b/docs/devices/E1744.md
@@ -91,7 +91,7 @@ The unit of this value is `%`.
 Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
-The possible values are: `rotate_left`, `rotate_right`, `rotate_stop`, `play_pause`, `skip_forward`, `skip_backward`.
+The possible values are: `rotate_left`, `rotate_right`, `rotate_stop`, `play_pause` (click), `skip_forward` (double click), `skip_backward` (triple click).
 
 ### Linkquality (numeric)
 Link quality (signal strength).

--- a/docs/devices/E1744.md
+++ b/docs/devices/E1744.md
@@ -91,7 +91,7 @@ The unit of this value is `%`.
 Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
-The possible values are: `brightness_move_up`, `brightness_move_down`, `brightness_stop`, `toggle`, `brightness_step_up`, `brightness_step_down`.
+The possible values are: `rotate_left`, `rotate_right`, `rotate_stop`, `play_pause`, `skip_forward`, `skip_backward`.
 
 ### Linkquality (numeric)
 Link quality (signal strength).


### PR DESCRIPTION
I have just set up a brand new SYMFONISK sound controller (E1744) and it sends action events with the payloads according to my edit.
Maybe an older version behaves differently, but I feel like this might be a copy/paste issue, as brightness* actions don't make a ton of sense with this sound controller.