### PR TITLE
Add note about frontend and WebKit bug

### DIFF
--- a/docs/information/frontend.md
+++ b/docs/information/frontend.md
@@ -21,7 +21,9 @@ To specify the `auth_token` in a different file set e.g. `auth_token: '!secret a
 ![Frontend](../images/frontend.png)
 
 ## Nginx proxy configuration
-In case you want to run the frontend behind a proxy you can use the following config as an example:
+In case you want to run the frontend behind a proxy you can use the following config as an example.
+
+Due to [WebKit Bug 80362](https://bugs.webkit.org/show_bug.cgi?id=80362), which prevents basic authentication from being used with WebSockets, the frontend will not work in WebKit-based browsers when this type of authentication is configured. This includes desktop Safari on Mac and _all_ browsers and web views on iOS. To work around the issue, configure the frontend's `auth_token` to configure application-level auth and remove `auth_basic` from the web server config. 
 
 ```
 server {


### PR DESCRIPTION
Due to this long-standing  WebKit bug, the frontend can’t be used when basic auth is configured. Swapping to token based auth is a workaround, explained in this PR. 