### PR TITLE
Update QBKG23LM.md

### DIFF
--- a/docs/devices/QBKG23LM.md
+++ b/docs/devices/QBKG23LM.md
@@ -110,7 +110,7 @@ The unit of this value is `V`.
 Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
-The possible values are: `hold`, `single`, `double`, `triple`, `release`.
+The possible values are: `single` and `release`.
 
 ### Linkquality (numeric)
 Link quality (signal strength).


### PR DESCRIPTION
Unlike the 2 gang variety, the Aqara D1 1 gang with neutral, unfortunately does not publish 'double' and 'triple' actions. Amended to reflect.