### PR TITLE
Remove float support from AC03647 docs

### DIFF
--- a/docs/devices/AC03647.md
+++ b/docs/devices/AC03647.md
@@ -27,7 +27,7 @@ Various Osram/Sylvania LED support setting a default transition when turning a l
     "set_transition": 0.1
 }
 ```
-**INFO**: Value is time in seconds (integer or float)
+**INFO**: Value is time in seconds (integer, float values are not supported)
 
 ### Remember current light state
 Various Osram/Sylvania LED support remembering their current state in case of power loss, or if a light

--- a/docs/devices/AC03647.md
+++ b/docs/devices/AC03647.md
@@ -24,7 +24,7 @@ Various Osram/Sylvania LED support setting a default transition when turning a l
 **TOPIC**: `zigbee2mqtt/FRIENDLY_NAME/set`
 ```js
 {
-    "set_transition": 0.1
+    "set_transition": 1
 }
 ```
 **INFO**: Value is time in seconds (integer, float values are not supported)
@@ -94,7 +94,7 @@ This light supports the following features: `state`, `brightness`, `color_temp`,
 
 #### Transition
 For all of the above mentioned features it is possible to do a transition of the value over time. To do this add an additional property `transition` to the payload which is the transition time in seconds.
-Examples: `{"brightness":156,"transition":3}`, `{"color_temp":241,"transition":0.5}`.
+Examples: `{"brightness":156,"transition":3}`, `{"color_temp":241,"transition":2}`.
 
 #### Moving/stepping
 Instead of setting a value (e.g. brightness) directly it is also possible to:


### PR DESCRIPTION
This commit removes the non-existing float support from the AC03647 according to [#6574](https://github.com/Koenkk/zigbee2mqtt/issues/6574)