### PR TITLE
Remove icon property

### DIFF
--- a/docs/integration/home_assistant.md
+++ b/docs/integration/home_assistant.md
@@ -162,7 +162,6 @@ devices:
         object_id: light
       light:
         name: my_switch
-        icon: mdi:desk-lamp
       # OR if your devices has multiple endpoints (e.g. left/right)
       switch_left:
         type: light


### PR DESCRIPTION
Looks like in current ha version, devices.X.homeassistant.light.icon throws a 'unknown property' error when ha reads the entity config from mqtt.