### PR TITLE
Update running_zigbee2mqtt.md

### DIFF
--- a/docs/getting_started/running_zigbee2mqtt.md
+++ b/docs/getting_started/running_zigbee2mqtt.md
@@ -26,6 +26,8 @@ total 0
 lrwxrwxrwx. 1 root root 13 Oct 19 19:26 usb-Texas_Instruments_TI_CC2531_USB_CDC___0X00124B0018ED3DDF-if00 -> ../../ttyACM0
 ```
 
+**NOTE:** Docker mount command does not support certain symbols like colon (Example: `/dev/serial/by-id/usb-Silicon_Labs_http:__slae.sh_cc2652_-_slaesh_s_iot_stuff_XX:XX:XX:XX:XX:XX:XX:XX-if00-port0`). Error Message: `bad format for path`. You can create a persistant device name with udev or create a symbolic link.
+
 ## 2. Installing
 ```bash
 # Setup Node.js repository


### PR DESCRIPTION
Note added about Docker mount command does not support certain symbols like colon.