### PR TITLE
Make user extension example actually work

### DIFF
--- a/docs/information/user_extensions.md
+++ b/docs/information/user_extensions.md
@@ -4,17 +4,26 @@ User extensions is a way to extend Zigbee2MQTT behaviour, user extensions works 
 
 To get familiar with  extensions framework please read [source code of internal extensions](https://github.com/Koenkk/zigbee2mqtt/tree/master/lib/extension).
 
-User extensions are stored in `data/extensions` folder and have to export a JavaScript Class or Function.
+User extensions are stored in `data/extension` folder and have to export a JavaScript Class or Function.
 
 Example:
 
-File: `data/extensions/my-first-extension.js`
+File: `data/extension/my-first-extension.js`
 
 ```js
-class MyExampleExtension {
+const Extension = require('../../lib/extension/extension');
+
+class MyExampleExtension extends Extension {
     constructor(zigbee, mqtt, state, publishEntityState, eventBus, settings, logger) {
+        super(zigbee, mqtt, state, publishEntityState, eventBus);
         logger.info('Loaded  MyExampleExtension');
-        mqtt.publish('example/extension', 'hello from MyExampleExtension')
+    }
+    
+    /**
+     * This method is called by the controller once connected to the MQTT server.
+     */
+    onMQTTConnected() {
+        this.mqtt.publish('example/extension', 'hello from MyExampleExtension');
     }
 }
 

--- a/docs/information/user_extensions.md
+++ b/docs/information/user_extensions.md
@@ -11,23 +11,58 @@ Example:
 File: `data/extension/my-first-extension.js`
 
 ```js
-const Extension = require('../../lib/extension/extension');
-
-class MyExampleExtension extends Extension {
+class MyExampleExtension {
     constructor(zigbee, mqtt, state, publishEntityState, eventBus, settings, logger) {
-        super(zigbee, mqtt, state, publishEntityState, eventBus);
+        this.zigbee = zigbee;
+        this.mqtt = mqtt;
+        this.state = state;
+        this.publishEntityState = publishEntityState;
+        this.eventBus = eventBus;
+        this.settings = settings;
+        this.logger = logger;
+
         logger.info('Loaded  MyExampleExtension');
     }
-    
+
+    /**
+     * This method is called by the controller once Zigbee has been started.
+     */
+    // onZigbeeStarted() {}
+
     /**
      * This method is called by the controller once connected to the MQTT server.
      */
     onMQTTConnected() {
         this.mqtt.publish('example/extension', 'hello from MyExampleExtension');
     }
+
+    /**
+     * Is called when a Zigbee message from a device is received.
+     * @param {string} type Type of the message
+     * @param {Object} data Data of the message
+     * @param {Object?} resolvedEntity Resolved entity returned from this.zigbee.resolveEntity()
+     * @param {Object?} settingsDevice Device settings
+     */
+    // onZigbeeEvent(type, data, resolvedEntity) {}
+
+    /**
+     * Is called when a MQTT message is received
+     * @param {string} topic Topic on which the message was received
+     * @param {Object} message The received message
+     * @return {boolean} if the message was handled
+     */
+    // onMQTTMessage(topic, message) {}
+
+    /**
+     * Is called once the extension has to stop
+     */
+    stop() {
+        this.eventBus.removeListenersExtension(this.constructor.name);
+    }
 }
 
 module.exports = MyExampleExtension;
+
 ```
 
 ## User extensions list


### PR DESCRIPTION
Currently, the example extension in the docs does not work because:

1. Extensions are actually loaded from `data/extension` directory (https://github.com/Koenkk/zigbee2mqtt/blob/master/lib/extension/externalExtension.js#L17:L17)
2. MQTT connection is not available in constructor