### PR TITLE
[TASK] Update Flashing link for zzh!

### DIFF
--- a/docs/information/supported_adapters.md
+++ b/docs/information/supported_adapters.md
@@ -18,7 +18,7 @@ Zigbee2MQTT officially supports the following adapters:
     <td>Electrolama zig-a-zig-ah! (zzh!) <b>(recommended)</b></td>
     <td>USB connected adapter with external antenna</td>
     <td><a href="https://github.com/Koenkk/Z-Stack-firmware/raw/master/coordinator/Z-Stack_3.x.0/bin/CC2652R_coordinator_20210120.zip">Coordinator</a><br/> <a href="https://github.com/Koenkk/Z-Stack-firmware/raw/master/router/Z-Stack_3.x.0/bin/CC2652R_router_20210128.zip">Router</a></td>
-    <td><a href="https://electrolama.com/projects/zig-a-zig-ah/#flash-firmware">Flashing</a></td>
+    <td><a href="https://electrolama.com/radio-docs/#step-3-flash-the-firmware-on-your-stick">Flashing</a></td>
     <td><a href="https://www.tindie.com/products/electrolama/zzh-cc2652r-multiprotocol-rf-stick/#product-reviews">Tindie</a></td>
   </tr>
   <tr>


### PR DESCRIPTION
With the reorg on Electrolama's docs
done with https://github.com/electrolama/docs/commit/10d74d23
the location for how to flash the device
has changed. This updates the URL
accordingly.