### PR TITLE
Explanation what reportable_change means

### DIFF
--- a/docs/information/mqtt_topics_and_message_structure.md
+++ b/docs/information/mqtt_topics_and_message_structure.md
@@ -327,6 +327,7 @@ To disable reporting set the `maximum_report_interval` to `65535`.
 Notes:
 - Not all devices support the Zigbee configure reporting command (e.g. Xiaomi WSDCGQ11LM temperature/humidity sensors don't support it)
 - If configure reporting fails for a battery powered device make sure to wake it up right before sending the command.
+- The `reportable_change` value depends on the unit of the attribute, e.g. for temperature 100 means in general 1°C of change.
 
 
 ### Group


### PR DESCRIPTION
Hi,

i had to lookup a bit the code of the zigbee-herdsman-converters in order to ensure that 100 in the reportable_change for a reporting configuration stands for 1°C. The Configure Reporting Command in the ZigBee Cluster Library is also not noting what reportable_change really means. From the frontend you don't know that the device is sending in temperature*100°C steps formatted as integer, hence it would be nice to note somewhere that the reportable_change is the device's reported raw value. I am not sure if my explanation is good enough but maybe it can help one or the other.