### PR TITLE
Correct two tiny typos

### DIFF
--- a/docs/devices/WV704R0A0902.md
+++ b/docs/devices/WV704R0A0902.md
@@ -43,11 +43,11 @@ After installing the TRV twist the cap in the **-** direction and hold for
 2 seconds until the blue LED lights up.
 
 ### Device hard reset
-If the device fails to pair/join the network (`red:yellow:blue` on paring mode) or you changed the network id/channel, connect to another network, bought the TRV second hand, you can perform a factory reset to start fresh.
+If the device fails to pair/join the network (`red:yellow:blue` on pairing mode) or you changed the network id/channel, connect to another network, bought the TRV second hand, you can perform a factory reset to start fresh.
 
 1. Make sure that the TRV is NOT in pairing mode.
 2. Twist the cap in the **-** direction and hold till blue light turns off and then center light blinks red (about 15 seconds).
-3. Release the button, you should see a `red:gree:blue` short flash; the valve will go into installation mode.
+3. Release the button, you should see a `red:green:blue` short flash; the valve will go into installation mode.
 
 ### Controlling
 


### PR DESCRIPTION
Spotted a couple of small typos while using the documentation. 
