### PR TITLE
Update how_to_connect_to_a_remote_adapter.md

### DIFF
--- a/docs/how_tos/how_to_connect_to_a_remote_adapter.md
+++ b/docs/how_tos/how_to_connect_to_a_remote_adapter.md
@@ -3,7 +3,9 @@ This how-to explains how to run Zigbee2MQTT with an adapter on a remote location
 We will use ser2net for this which allows to connect to a serial port over TCP.
 In this way you can e.g. setup a Raspberry Pi Zero with the adapter connected while running Zigbee2MQTT on a different system. The instructions below have to be executed on the system where the adapter is connected to.
 
-DeCONZ Conbee II is not supported over tcp connections using this or any other configuration at this time. 
+DeCONZ Conbee II is not supported over TCO connections using this or any other configuration at this time. 
+
+WiFi-based Serial-to-IP bridges are not recommended for Silicon Labs EZSP adapters as the serial protocol does not have enough fault-tolerance to handle packet loss or latency delays that can normally occur over WiFi connections.
 
 ## 1. Install ser2net
 ```bash


### PR DESCRIPTION
Update how_to_connect_to_a_remote_adapter.md with a recommendation not to use WiFi-based Serial-to-IP bridges (serial proxy servers) with Silicon Labs EZSP adapters.

https://github.com/zigpy/bellows#warning-about-zigbee-to-wifi-bridges