### PR TITLE
Add binding issue for Busch-Jae 6737

### DIFF
--- a/docs/devices/6735_6736_6737.md
+++ b/docs/devices/6735_6736_6737.md
@@ -28,6 +28,22 @@ description: "Integrate your Busch-Jaeger 6735/6736/6737 via Zigbee2MQTT with wh
 2. Press both buttons of the top row (or sole row for Model 6735) until the LEDs gleam permanently. They will blink alternately at first but keep the buttons pressed until really both lights are constantly illuminated. Then release the buttons. The LEDs should still glow.
 3. Now press both buttons again briefly. After about 1..2 seconds they will fade-glow; and your bridge should now instantly find it.
 
+### Known issues
+
+#### Bottom row of 4-gang device not bound
+
+It may occur that the bottom row of the 4-gang device 6737 does not work like the other ones, i.e. does not emit the actions (see related discussion [#7009](https://github.com/Koenkk/zigbee2mqtt/discussions/7009)). The reason is not fully understood yet, however it can be worked around by unbinding all four endpoints and re-binding them manually one after another:
+
+| Source EP   | Destination   | Destination EP   | Clusters                                              |
+|-------------|---------------|------------------|-------------------------------------------------------|
+| `10`        | `Coordinator` | `1`              | 6710&nbsp;U: `LevelCtrl`<br>6711&nbsp;U: `OnOff` [^1] |
+| `11`        | `Coordinator` | `1`              | `LevelCtrl`                                           |
+| `12`        | `Coordinator` | `1`              | `LevelCtrl`                                           |
+| `13`        | `Coordinator` | `1`              | `LevelCtrl`                                           |
+
+*[EP]: Endpoint
+[^1]: Depending on whether the control panel sits on a 6710&nbsp;U (power supply) or 6711&nbsp;U (relay), `OnOff` respectively `LevelCtrl` shall be used. 
+
 ### Action values
 This device send the following `action` values in its payload:
 


### PR DESCRIPTION
This adds an explanation and a reference
to the discussion about the binding issue
of the four-gang variant 6737's bottom row.

Preview of the rendering:
![image](https://user-images.githubusercontent.com/1125168/115953378-63965b00-a4eb-11eb-8be0-6072000fdada.png)

Footnote:
![image](https://user-images.githubusercontent.com/1125168/115953383-70b34a00-a4eb-11eb-8122-43ebb4e066b5.png)

Related: #7009