### PR TITLE
Fix yaml syntax

### DIFF
--- a/docgen/device_page_notes.js
+++ b/docgen/device_page_notes.js
@@ -2734,13 +2734,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     \`\`\`yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     \`\`\`
 `,
     },

--- a/docs/devices/07004D_07005L.md
+++ b/docs/devices/07004D_07005L.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/07008L.md
+++ b/docs/devices/07008L.md
@@ -43,13 +43,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/07115L.md
+++ b/docs/devices/07115L.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/100.001.96.md
+++ b/docs/devices/100.001.96.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/100.075.74.md
+++ b/docs/devices/100.075.74.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/100.491.61.md
+++ b/docs/devices/100.491.61.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/10011725.md
+++ b/docs/devices/10011725.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/10297666.md
+++ b/docs/devices/10297666.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/10297667.md
+++ b/docs/devices/10297667.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/14148906L.md
+++ b/docs/devices/14148906L.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/14149505L_14149506L.md
+++ b/docs/devices/14149505L_14149506L.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1741530P7.md
+++ b/docs/devices/1741530P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1741830P7.md
+++ b/docs/devices/1741830P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1742930P7.md
+++ b/docs/devices/1742930P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1743030P7.md
+++ b/docs/devices/1743030P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1743130P7.md
+++ b/docs/devices/1743130P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1743230P7.md
+++ b/docs/devices/1743230P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/17435_30_P7.md
+++ b/docs/devices/17435_30_P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1743830P7.md
+++ b/docs/devices/1743830P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1743930P7.md
+++ b/docs/devices/1743930P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1744130P7.md
+++ b/docs/devices/1744130P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1745630P7.md
+++ b/docs/devices/1745630P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1745730V7.md
+++ b/docs/devices/1745730V7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1745930P7.md
+++ b/docs/devices/1745930P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1746130P7.md
+++ b/docs/devices/1746130P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1746230V7.md
+++ b/docs/devices/1746230V7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1746330P7.md
+++ b/docs/devices/1746330P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/1746430P7.md
+++ b/docs/devices/1746430P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/3115331PH.md
+++ b/docs/devices/3115331PH.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/33943.md
+++ b/docs/devices/33943.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/33944.md
+++ b/docs/devices/33944.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/371000002.md
+++ b/docs/devices/371000002.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/3802962.md
+++ b/docs/devices/3802962.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/3A12S-15.md
+++ b/docs/devices/3A12S-15.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/404000_404005_404012.md
+++ b/docs/devices/404000_404005_404012.md
@@ -44,13 +44,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/404028.md
+++ b/docs/devices/404028.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/404036.md
+++ b/docs/devices/404036.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4052899926110.md
+++ b/docs/devices/4052899926110.md
@@ -75,13 +75,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4058075036147.md
+++ b/docs/devices/4058075036147.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4058075036185.md
+++ b/docs/devices/4058075036185.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4058075047853.md
+++ b/docs/devices/4058075047853.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4058075208339.md
+++ b/docs/devices/4058075208339.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4058075208353.md
+++ b/docs/devices/4058075208353.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4058075816718.md
+++ b/docs/devices/4058075816718.md
@@ -70,13 +70,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4058075816732.md
+++ b/docs/devices/4058075816732.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4080148P9.md
+++ b/docs/devices/4080148P9.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4080248P9.md
+++ b/docs/devices/4080248P9.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4090130P7.md
+++ b/docs/devices/4090130P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4090230P9.md
+++ b/docs/devices/4090230P9.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4090331P9.md
+++ b/docs/devices/4090331P9.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4090531P7.md
+++ b/docs/devices/4090531P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4090531P9.md
+++ b/docs/devices/4090531P9.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/4090631P7.md
+++ b/docs/devices/4090631P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/421792.md
+++ b/docs/devices/421792.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/44435.md
+++ b/docs/devices/44435.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/500.47.md
+++ b/docs/devices/500.47.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/50049_500.63.md
+++ b/docs/devices/50049_500.63.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5045131P7.md
+++ b/docs/devices/5045131P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5045148P7.md
+++ b/docs/devices/5045148P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5055131P7.md
+++ b/docs/devices/5055131P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5055148P7.md
+++ b/docs/devices/5055148P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5060730P7.md
+++ b/docs/devices/5060730P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5061031P7.md
+++ b/docs/devices/5061031P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5062131P7.md
+++ b/docs/devices/5062131P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5062148P7.md
+++ b/docs/devices/5062148P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5062231P7.md
+++ b/docs/devices/5062231P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5062248P7.md
+++ b/docs/devices/5062248P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5062331P7.md
+++ b/docs/devices/5062331P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5062348P7.md
+++ b/docs/devices/5062348P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5062431P7.md
+++ b/docs/devices/5062431P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5062448P7.md
+++ b/docs/devices/5062448P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5063231P7.md
+++ b/docs/devices/5063231P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5063331P7.md
+++ b/docs/devices/5063331P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5063431P7.md
+++ b/docs/devices/5063431P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/511.000.md
+++ b/docs/devices/511.000.md
@@ -40,13 +40,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/511.040.md
+++ b/docs/devices/511.040.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5412748727388.md
+++ b/docs/devices/5412748727388.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/548727.md
+++ b/docs/devices/548727.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5996511U5.md
+++ b/docs/devices/5996511U5.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/5996611U5.md
+++ b/docs/devices/5996611U5.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/7099860PH.md
+++ b/docs/devices/7099860PH.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/7099930PH.md
+++ b/docs/devices/7099930PH.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/7121131PU.md
+++ b/docs/devices/7121131PU.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/7146060PH.md
+++ b/docs/devices/7146060PH.md
@@ -101,13 +101,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/7199960PH.md
+++ b/docs/devices/7199960PH.md
@@ -116,13 +116,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/7299355PH.md
+++ b/docs/devices/7299355PH.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/7299760PH.md
+++ b/docs/devices/7299760PH.md
@@ -116,13 +116,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/73693.md
+++ b/docs/devices/73693.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/73699.md
+++ b/docs/devices/73699.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/73739.md
+++ b/docs/devices/73739.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/73741.md
+++ b/docs/devices/73741.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/73773.md
+++ b/docs/devices/73773.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/75541.md
+++ b/docs/devices/75541.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/7602031P7.md
+++ b/docs/devices/7602031P7.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/81809_81813.md
+++ b/docs/devices/81809_81813.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/8718696167991.md
+++ b/docs/devices/8718696167991.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/8718696170557.md
+++ b/docs/devices/8718696170557.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/8718696485880.md
+++ b/docs/devices/8718696485880.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/8718699703424.md
+++ b/docs/devices/8718699703424.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/89665.md
+++ b/docs/devices/89665.md
@@ -51,13 +51,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/915005106701.md
+++ b/docs/devices/915005106701.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/915005733701.md
+++ b/docs/devices/915005733701.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/929.66.md
+++ b/docs/devices/929.66.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/9290002579A.md
+++ b/docs/devices/9290002579A.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/9290012573A.md
+++ b/docs/devices/9290012573A.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/9290018187B.md
+++ b/docs/devices/9290018187B.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/929001953101.md
+++ b/docs/devices/929001953101.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/9290022166.md
+++ b/docs/devices/9290022166.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/9290022890.md
+++ b/docs/devices/9290022890.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/9290022891.md
+++ b/docs/devices/9290022891.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/929002294101.md
+++ b/docs/devices/929002294101.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/929002294203.md
+++ b/docs/devices/929002294203.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/929002375901.md
+++ b/docs/devices/929002375901.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/929002376001.md
+++ b/docs/devices/929002376001.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/929002376101.md
+++ b/docs/devices/929002376101.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/929002376201.md
+++ b/docs/devices/929002376201.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/929002376801.md
+++ b/docs/devices/929002376801.md
@@ -95,13 +95,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/9CZA-A806ST-Q1A.md
+++ b/docs/devices/9CZA-A806ST-Q1A.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/9CZA-G1521-Q1A.md
+++ b/docs/devices/9CZA-G1521-Q1A.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/9CZA-M350ST-Q1A.md
+++ b/docs/devices/9CZA-M350ST-Q1A.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/A806S-Q1G.md
+++ b/docs/devices/A806S-Q1G.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/AA69697.md
+++ b/docs/devices/AA69697.md
@@ -70,13 +70,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/AB35996.md
+++ b/docs/devices/AB35996.md
@@ -70,13 +70,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/AC0363900NJ.md
+++ b/docs/devices/AC0363900NJ.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/AC03645.md
+++ b/docs/devices/AC03645.md
@@ -70,13 +70,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/AC03647.md
+++ b/docs/devices/AC03647.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/AC08559.md
+++ b/docs/devices/AC08559.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/AC08560.md
+++ b/docs/devices/AC08560.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/AC16381.md
+++ b/docs/devices/AC16381.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/AC25697.md
+++ b/docs/devices/AC25697.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/AE_280_C.md
+++ b/docs/devices/AE_280_C.md
@@ -43,13 +43,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/AJ_ZB_GU10.md
+++ b/docs/devices/AJ_ZB_GU10.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/AU-A1GSZ9RGBW_HV-GSCXZB269K.md
+++ b/docs/devices/AU-A1GSZ9RGBW_HV-GSCXZB269K.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/AU-A1GUZBRGBW.md
+++ b/docs/devices/AU-A1GUZBRGBW.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/Aj_Zigbee_Led_Strip.md
+++ b/docs/devices/Aj_Zigbee_Led_Strip.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/BRHM8E27W70-I1.md
+++ b/docs/devices/BRHM8E27W70-I1.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/BY_185_C.md
+++ b/docs/devices/BY_185_C.md
@@ -43,13 +43,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/BY_285_C.md
+++ b/docs/devices/BY_285_C.md
@@ -43,13 +43,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/C422AC11D41H140.0W.md
+++ b/docs/devices/C422AC11D41H140.0W.md
@@ -47,13 +47,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/C422AC14D41H140.0W.md
+++ b/docs/devices/C422AC14D41H140.0W.md
@@ -47,13 +47,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/D1821.md
+++ b/docs/devices/D1821.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/E11-N1EA.md
+++ b/docs/devices/E11-N1EA.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/E11-U2E.md
+++ b/docs/devices/E11-U2E.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/E11-U3E.md
+++ b/docs/devices/E11-U3E.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/E12-N1E.md
+++ b/docs/devices/E12-N1E.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/E1F-N5E.md
+++ b/docs/devices/E1F-N5E.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/E1G-G8E.md
+++ b/docs/devices/E1G-G8E.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/FL_120_C.md
+++ b/docs/devices/FL_120_C.md
@@ -43,13 +43,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/FL_130_C.md
+++ b/docs/devices/FL_130_C.md
@@ -43,13 +43,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/FL_140_C.md
+++ b/docs/devices/FL_140_C.md
@@ -43,13 +43,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-B-001P.md
+++ b/docs/devices/GL-B-001P.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-B-001Z.md
+++ b/docs/devices/GL-B-001Z.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-B-001ZS.md
+++ b/docs/devices/GL-B-001ZS.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-B-007P.md
+++ b/docs/devices/GL-B-007P.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-B-007Z.md
+++ b/docs/devices/GL-B-007Z.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-B-007ZS.md
+++ b/docs/devices/GL-B-007ZS.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-B-008P.md
+++ b/docs/devices/GL-B-008P.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-B-008Z.md
+++ b/docs/devices/GL-B-008Z.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-B-008ZS.md
+++ b/docs/devices/GL-B-008ZS.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-C-007-1ID.md
+++ b/docs/devices/GL-C-007-1ID.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-C-007-2ID.md
+++ b/docs/devices/GL-C-007-2ID.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-C-007P.md
+++ b/docs/devices/GL-C-007P.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-C-007S.md
+++ b/docs/devices/GL-C-007S.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-C-008-1ID.md
+++ b/docs/devices/GL-C-008-1ID.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-C-008-2ID.md
+++ b/docs/devices/GL-C-008-2ID.md
@@ -50,13 +50,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-C-008P.md
+++ b/docs/devices/GL-C-008P.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-C-008S.md
+++ b/docs/devices/GL-C-008S.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-D-003P.md
+++ b/docs/devices/GL-D-003P.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-D-003Z.md
+++ b/docs/devices/GL-D-003Z.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-D-003ZS.md
+++ b/docs/devices/GL-D-003ZS.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-D-004P.md
+++ b/docs/devices/GL-D-004P.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-D-004Z.md
+++ b/docs/devices/GL-D-004Z.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-D-004ZS.md
+++ b/docs/devices/GL-D-004ZS.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-D-005P.md
+++ b/docs/devices/GL-D-005P.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-D-005Z.md
+++ b/docs/devices/GL-D-005Z.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-D-005ZS.md
+++ b/docs/devices/GL-D-005ZS.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-FL-004P.md
+++ b/docs/devices/GL-FL-004P.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-FL-004TZ.md
+++ b/docs/devices/GL-FL-004TZ.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-FL-004TZS.md
+++ b/docs/devices/GL-FL-004TZS.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-FL-005P.md
+++ b/docs/devices/GL-FL-005P.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-FL-005TZ.md
+++ b/docs/devices/GL-FL-005TZ.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-FL-005TZS.md
+++ b/docs/devices/GL-FL-005TZS.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-FL-006P.md
+++ b/docs/devices/GL-FL-006P.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-FL-006TZ.md
+++ b/docs/devices/GL-FL-006TZ.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-FL-006TZS.md
+++ b/docs/devices/GL-FL-006TZS.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-G-001P.md
+++ b/docs/devices/GL-G-001P.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-G-001Z.md
+++ b/docs/devices/GL-G-001Z.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-G-001ZS.md
+++ b/docs/devices/GL-G-001ZS.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-G-007Z.md
+++ b/docs/devices/GL-G-007Z.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-H-001.md
+++ b/docs/devices/GL-H-001.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-MC-001.md
+++ b/docs/devices/GL-MC-001.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-MC-001P.md
+++ b/docs/devices/GL-MC-001P.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-S-003Z.md
+++ b/docs/devices/GL-S-003Z.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-S-004P.md
+++ b/docs/devices/GL-S-004P.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-S-004Z.md
+++ b/docs/devices/GL-S-004Z.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-S-004ZS.md
+++ b/docs/devices/GL-S-004ZS.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-S-005Z.md
+++ b/docs/devices/GL-S-005Z.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-S-007P.md
+++ b/docs/devices/GL-S-007P.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-S-007Z.md
+++ b/docs/devices/GL-S-007Z.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-S-007ZS.md
+++ b/docs/devices/GL-S-007ZS.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GL-S-008Z.md
+++ b/docs/devices/GL-S-008Z.md
@@ -46,13 +46,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/GPDRPLOP401100CE.md
+++ b/docs/devices/GPDRPLOP401100CE.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/HAL300.md
+++ b/docs/devices/HAL300.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/HG06104A.md
+++ b/docs/devices/HG06104A.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/HG06106A.md
+++ b/docs/devices/HG06106A.md
@@ -47,13 +47,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/HG06106B.md
+++ b/docs/devices/HG06106B.md
@@ -47,13 +47,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/HG06106C.md
+++ b/docs/devices/HG06106C.md
@@ -47,13 +47,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/HG06467.md
+++ b/docs/devices/HG06467.md
@@ -100,13 +100,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/HGZB-06A.md
+++ b/docs/devices/HGZB-06A.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/HGZB-07A.md
+++ b/docs/devices/HGZB-07A.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/HGZB-DLC4-N12B.md
+++ b/docs/devices/HGZB-DLC4-N12B.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/HGZB-DLC4-N15B.md
+++ b/docs/devices/HGZB-DLC4-N15B.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/K2RGBW01.md
+++ b/docs/devices/K2RGBW01.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/L122AA63H11A6.5W.md
+++ b/docs/devices/L122AA63H11A6.5W.md
@@ -47,13 +47,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/L122CB63H11A9.0W.md
+++ b/docs/devices/L122CB63H11A9.0W.md
@@ -47,13 +47,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/L122FF63H11A5.0W.md
+++ b/docs/devices/L122FF63H11A5.0W.md
@@ -47,13 +47,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/LED1624G9.md
+++ b/docs/devices/LED1624G9.md
@@ -53,13 +53,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/LED1923R5.md
+++ b/docs/devices/LED1923R5.md
@@ -49,13 +49,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/LED1924G9.md
+++ b/docs/devices/LED1924G9.md
@@ -49,13 +49,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/LTFY004.md
+++ b/docs/devices/LTFY004.md
@@ -65,13 +65,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/LXZB-12A.md
+++ b/docs/devices/LXZB-12A.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/MCLH-02.md
+++ b/docs/devices/MCLH-02.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/MS-SP-LE27WRGB.md
+++ b/docs/devices/MS-SP-LE27WRGB.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/Mega23M12.md
+++ b/docs/devices/Mega23M12.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/NLG-RGB-TW_light.md
+++ b/docs/devices/NLG-RGB-TW_light.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/NLG-RGBW_light.md
+++ b/docs/devices/NLG-RGBW_light.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/OFL_120_C.md
+++ b/docs/devices/OFL_120_C.md
@@ -43,13 +43,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/OFL_140_C.md
+++ b/docs/devices/OFL_140_C.md
@@ -43,13 +43,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/OSL_130_C.md
+++ b/docs/devices/OSL_130_C.md
@@ -43,13 +43,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/RB_185_C.md
+++ b/docs/devices/RB_185_C.md
@@ -43,13 +43,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/RB_250_C.md
+++ b/docs/devices/RB_250_C.md
@@ -43,13 +43,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/RB_285_C.md
+++ b/docs/devices/RB_285_C.md
@@ -43,13 +43,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/RL804CZB.md
+++ b/docs/devices/RL804CZB.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/RS_230_C.md
+++ b/docs/devices/RS_230_C.md
@@ -43,13 +43,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/TS0503A.md
+++ b/docs/devices/TS0503A.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/TS0503B.md
+++ b/docs/devices/TS0503B.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/TS0504A.md
+++ b/docs/devices/TS0504A.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/TS0504B.md
+++ b/docs/devices/TS0504B.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/TS0505A.md
+++ b/docs/devices/TS0505A.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/TS0505A_led.md
+++ b/docs/devices/TS0505A_led.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/TS0505B.md
+++ b/docs/devices/TS0505B.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/TYZS1L.md
+++ b/docs/devices/TYZS1L.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/XY12S-15.md
+++ b/docs/devices/XY12S-15.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/YSR-MINI-01_rgbcct.md
+++ b/docs/devices/YSR-MINI-01_rgbcct.md
@@ -44,13 +44,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/YSR-MINI-01_wwcw.md
+++ b/docs/devices/YSR-MINI-01_wwcw.md
@@ -44,13 +44,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/ZB-RGBCW.md
+++ b/docs/devices/ZB-RGBCW.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/ZNTGMK11LM.md
+++ b/docs/devices/ZNTGMK11LM.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 

--- a/docs/devices/rgbw2.zbee27.md
+++ b/docs/devices/rgbw2.zbee27.md
@@ -39,13 +39,13 @@ rendition to other lights. Provide a minimum of 2 data sets in the correction ma
     ```yaml
     hue_correction:
         - in: 28
-            out: 45
+          out: 45
         - in: 89
-            out: 109
+          out: 109
         - in: 184
-            out: 203
+          out: 203
         - in: 334
-            out: 318
+          out: 318
     ```
 
 


### PR DESCRIPTION
There was an indentation problem in `hue_correction` example.