### PR TITLE
Add Note for Hue reset w/dimmer switch

### DIFF
--- a/docgen/device_page_notes.js
+++ b/docgen/device_page_notes.js
@@ -1642,7 +1642,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it is possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/046677476816.md
+++ b/docs/devices/046677476816.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/046677551780.md
+++ b/docs/devices/046677551780.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1741530P7.md
+++ b/docs/devices/1741530P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1741830P7.md
+++ b/docs/devices/1741830P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1742930P7.md
+++ b/docs/devices/1742930P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1743030P7.md
+++ b/docs/devices/1743030P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1743130P7.md
+++ b/docs/devices/1743130P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1743230P7.md
+++ b/docs/devices/1743230P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/17435_30_P7.md
+++ b/docs/devices/17435_30_P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/17436_30_P7.md
+++ b/docs/devices/17436_30_P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1743830P7.md
+++ b/docs/devices/1743830P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1743930P7.md
+++ b/docs/devices/1743930P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1744130P7.md
+++ b/docs/devices/1744130P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1745630P7.md
+++ b/docs/devices/1745630P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1745730V7.md
+++ b/docs/devices/1745730V7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1745930P7.md
+++ b/docs/devices/1745930P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1746130P7.md
+++ b/docs/devices/1746130P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1746230V7.md
+++ b/docs/devices/1746230V7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1746330P7.md
+++ b/docs/devices/1746330P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/1746430P7.md
+++ b/docs/devices/1746430P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3115331PH.md
+++ b/docs/devices/3115331PH.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3216131P5.md
+++ b/docs/devices/3216131P5.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3216131P6.md
+++ b/docs/devices/3216131P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3216231P5.md
+++ b/docs/devices/3216231P5.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3216231P6.md
+++ b/docs/devices/3216231P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3216331P5.md
+++ b/docs/devices/3216331P5.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3216331P6.md
+++ b/docs/devices/3216331P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3216431P5.md
+++ b/docs/devices/3216431P5.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3216431P6.md
+++ b/docs/devices/3216431P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3261030P6.md
+++ b/docs/devices/3261030P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3261030P7.md
+++ b/docs/devices/3261030P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3261031P6.md
+++ b/docs/devices/3261031P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3261048P6.md
+++ b/docs/devices/3261048P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3261331P7.md
+++ b/docs/devices/3261331P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3306431P7.md
+++ b/docs/devices/3306431P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3402831P7.md
+++ b/docs/devices/3402831P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3417711P6.md
+++ b/docs/devices/3417711P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3417931P6.md
+++ b/docs/devices/3417931P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3418131P6.md
+++ b/docs/devices/3418131P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3418411P6.md
+++ b/docs/devices/3418411P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3418631P6.md
+++ b/docs/devices/3418631P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/3435011P7.md
+++ b/docs/devices/3435011P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4023330P7.md
+++ b/docs/devices/4023330P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4033930P6.md
+++ b/docs/devices/4033930P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4033930P7.md
+++ b/docs/devices/4033930P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4034030P6.md
+++ b/docs/devices/4034030P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4034031P6.md
+++ b/docs/devices/4034031P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4034031P7.md
+++ b/docs/devices/4034031P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4080148P9.md
+++ b/docs/devices/4080148P9.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4080248P9.md
+++ b/docs/devices/4080248P9.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4090130P7.md
+++ b/docs/devices/4090130P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4090230P9.md
+++ b/docs/devices/4090230P9.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4090331P9.md
+++ b/docs/devices/4090331P9.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4090531P7.md
+++ b/docs/devices/4090531P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4090531P9.md
+++ b/docs/devices/4090531P9.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4090631P7.md
+++ b/docs/devices/4090631P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4096730P6.md
+++ b/docs/devices/4096730P6.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4096730U7.md
+++ b/docs/devices/4096730U7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4098430P7.md
+++ b/docs/devices/4098430P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/433714.md
+++ b/docs/devices/433714.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4503848C5.md
+++ b/docs/devices/4503848C5.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4505748C5.md
+++ b/docs/devices/4505748C5.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/4507748C5.md
+++ b/docs/devices/4507748C5.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/464800.md
+++ b/docs/devices/464800.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5041131P9.md
+++ b/docs/devices/5041131P9.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5042131P9.md
+++ b/docs/devices/5042131P9.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5045131P7.md
+++ b/docs/devices/5045131P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5045148P7.md
+++ b/docs/devices/5045148P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5047131P9.md
+++ b/docs/devices/5047131P9.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5055131P7.md
+++ b/docs/devices/5055131P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5055148P7.md
+++ b/docs/devices/5055148P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5060730P7.md
+++ b/docs/devices/5060730P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5061031P7.md
+++ b/docs/devices/5061031P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5062131P7.md
+++ b/docs/devices/5062131P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5062148P7.md
+++ b/docs/devices/5062148P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5062231P7.md
+++ b/docs/devices/5062231P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5062248P7.md
+++ b/docs/devices/5062248P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5062331P7.md
+++ b/docs/devices/5062331P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5062348P7.md
+++ b/docs/devices/5062348P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5062431P7.md
+++ b/docs/devices/5062431P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5062448P7.md
+++ b/docs/devices/5062448P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5063231P7.md
+++ b/docs/devices/5063231P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5063331P7.md
+++ b/docs/devices/5063331P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5063431P7.md
+++ b/docs/devices/5063431P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5110131H5.md
+++ b/docs/devices/5110131H5.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/548727.md
+++ b/docs/devices/548727.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5900131C5.md
+++ b/docs/devices/5900131C5.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5995111U5.md
+++ b/docs/devices/5995111U5.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5996311U5.md
+++ b/docs/devices/5996311U5.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5996411U5.md
+++ b/docs/devices/5996411U5.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5996511U5.md
+++ b/docs/devices/5996511U5.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/5996611U5.md
+++ b/docs/devices/5996611U5.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/7099860PH.md
+++ b/docs/devices/7099860PH.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/7099930PH.md
+++ b/docs/devices/7099930PH.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/7121131PU.md
+++ b/docs/devices/7121131PU.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/7146060PH.md
+++ b/docs/devices/7146060PH.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/7199960PH.md
+++ b/docs/devices/7199960PH.md
@@ -51,7 +51,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/7299355PH.md
+++ b/docs/devices/7299355PH.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/7299760PH.md
+++ b/docs/devices/7299760PH.md
@@ -51,7 +51,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/7531609.md
+++ b/docs/devices/7531609.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/7602031P7.md
+++ b/docs/devices/7602031P7.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/8718696153055.md
+++ b/docs/devices/8718696153055.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/8718696153062.md
+++ b/docs/devices/8718696153062.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/8718696167991.md
+++ b/docs/devices/8718696167991.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/8718696170557.md
+++ b/docs/devices/8718696170557.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/8718696170625.md
+++ b/docs/devices/8718696170625.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/8718696449691.md
+++ b/docs/devices/8718696449691.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/8718696485880.md
+++ b/docs/devices/8718696485880.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/8718696548738.md
+++ b/docs/devices/8718696548738.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/8718696598283.md
+++ b/docs/devices/8718696598283.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/8718696695203.md
+++ b/docs/devices/8718696695203.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/8718699673147.md
+++ b/docs/devices/8718699673147.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/8718699688820.md
+++ b/docs/devices/8718699688820.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/8718699688882.md
+++ b/docs/devices/8718699688882.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/8718699703424.md
+++ b/docs/devices/8718699703424.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/8719514279131.md
+++ b/docs/devices/8719514279131.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/915005106701.md
+++ b/docs/devices/915005106701.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/915005587401.md
+++ b/docs/devices/915005587401.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/915005733701.md
+++ b/docs/devices/915005733701.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290002579A.md
+++ b/docs/devices/9290002579A.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290011370.md
+++ b/docs/devices/9290011370.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290011370B.md
+++ b/docs/devices/9290011370B.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290011998B.md
+++ b/docs/devices/9290011998B.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290012573A.md
+++ b/docs/devices/9290012573A.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290018187B.md
+++ b/docs/devices/9290018187B.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290018194.md
+++ b/docs/devices/9290018194.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290018195.md
+++ b/docs/devices/9290018195.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290018215.md
+++ b/docs/devices/9290018215.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290018216.md
+++ b/docs/devices/9290018216.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/929001821618.md
+++ b/docs/devices/929001821618.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/929001953101.md
+++ b/docs/devices/929001953101.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/929001953301.md
+++ b/docs/devices/929001953301.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290019534.md
+++ b/docs/devices/9290019534.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/929002039801.md
+++ b/docs/devices/929002039801.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290020399.md
+++ b/docs/devices/9290020399.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290022166.md
+++ b/docs/devices/9290022166.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290022167.md
+++ b/docs/devices/9290022167.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290022169.md
+++ b/docs/devices/9290022169.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290022267.md
+++ b/docs/devices/9290022267.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290022268.md
+++ b/docs/devices/9290022268.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290022411.md
+++ b/docs/devices/9290022411.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/929002241201.md
+++ b/docs/devices/929002241201.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/929002277501.md
+++ b/docs/devices/929002277501.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290022890.md
+++ b/docs/devices/9290022890.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290022891.md
+++ b/docs/devices/9290022891.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/929002294101.md
+++ b/docs/devices/929002294101.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/929002294203.md
+++ b/docs/devices/929002294203.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290022944.md
+++ b/docs/devices/9290022944.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290023349.md
+++ b/docs/devices/9290023349.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/929002335001.md
+++ b/docs/devices/929002335001.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290023351.md
+++ b/docs/devices/9290023351.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/929002375901.md
+++ b/docs/devices/929002375901.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/929002376001.md
+++ b/docs/devices/929002376001.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/929002376101.md
+++ b/docs/devices/929002376101.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/929002376201.md
+++ b/docs/devices/929002376201.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/929002376801.md
+++ b/docs/devices/929002376801.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/9290024406.md
+++ b/docs/devices/9290024406.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/929002459201.md
+++ b/docs/devices/929002459201.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)

--- a/docs/devices/LWG004.md
+++ b/docs/devices/LWG004.md
@@ -30,7 +30,15 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-[VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
+With [one](324131092621) of the [two](929002398602) Hue Dimmer switches it's possible to put the bulbs into a factory reset.
+
+1. Power-supply the bulb
+2. Bring the dimmer switch next to the bulb, as close as possible
+3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
+5. Switch the bulb off and on again: it can now be paired again.
+
+See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 
 #### Bluetooth (if supported by device)
 Install the Philips Hue Bluetooth app for [Android](https://play.google.com/store/apps/details?id=com.signify.hue.blue)


### PR DESCRIPTION
This adds a direction to the Notes section of every Philips device
on how to factory-reset the bulbs using the Dimmer Switch.
In a second commit it contains the rendering of this addition.