### PR TITLE
 Add documentation for Home Assistant legacy entity attributes configuration

### DIFF
--- a/docs/information/configuration.md
+++ b/docs/information/configuration.md
@@ -141,6 +141,12 @@ advanced:
   homeassistant_discovery_topic: 'homeassistant'
   # Optional: Home Assistant status topic (default: shown below)
   homeassistant_status_topic: 'homeassistant/status'
+  # Optional: Home Assistant legacy entity attributes (default: show below), when enabled:
+  # Zigbee2MQTT will send additional states as attributes with each entity. For example,
+  # A temperature & humidity sensor will have 2 entities for the temperature and
+  # humidity, with this setting enabled both entities will also have
+  # an temperature and humidity attribute.
+  homeassistant_legacy_entity_attributes: false
   # Optional: Home Assistant legacy triggers (default: shown below), when enabled:
   # - Zigbee2mqt will send an empty 'action' or 'click' after one has been send
   # - A 'sensor_action' and 'sensor_click' will be discoverd


### PR DESCRIPTION
This PR add documentation for the `homeassistant_legacy_entity_attributes` configuration option, introduced in https://github.com/Koenkk/zigbee2mqtt/pull/7683