### PR TITLE
Update E1524_E1810.md

### DIFF
--- a/docs/devices/E1524_E1810.md
+++ b/docs/devices/E1524_E1810.md
@@ -81,8 +81,8 @@ The unit of this value is `%`.
 ### Action (enum)
 Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.
-It's not possible to read (`/get`) or write (`/set`) this value.
-The possible values are: `brightness_down_release`, `toggle_hold`, `toggle`, `arrow_left_click`, `arrow_right_click`, `arrow_left_hold`, `arrow_right_hold`, `arrow_left_release`, `arrow_right_release`, `brightness_up_click`, `brightness_down_click`, `brightness_up_hold`, `brightness_up_release`.
+It's not possible to read (`/get`) or write (`/set`) this value. 
+The possible values are: `arrow_left_click`, `arrow_left_hold`, `arrow_left_release`, `arrow_right_click`, `arrow_right_hold`, `arrow_right_release`, `brightness_down_click`, `brightness_down_hold`, `brightness_down_release`, `brightness_up_click`, `brightness_up_hold`, `brightness_up_release`.
 
 ### Linkquality (numeric)
 Link quality (signal strength).


### PR DESCRIPTION
added brightness_down_hold to the enum of actions, and sorted the enum a bit more logically.