### PR TITLE
Add note about restarting HA when disabling legacy entity attributes

### DIFF
--- a/docs/information/configuration.md
+++ b/docs/information/configuration.md
@@ -146,6 +146,7 @@ advanced:
   # A temperature & humidity sensor will have 2 entities for the temperature and
   # humidity, with this setting enabled both entities will also have
   # an temperature and humidity attribute.
+  # Note: Disabling this option, requires a Home Assistant restart
   homeassistant_legacy_entity_attributes: true
   # Optional: Home Assistant legacy triggers (default: shown below), when enabled:
   # - Zigbee2mqt will send an empty 'action' or 'click' after one has been send


### PR DESCRIPTION
Added a small note for when someone disables `homeassistant_legacy_entity_attributes`, it requires a Home Assistant restart.

See: Koenkk/zigbee2mqtt#7802