### PR TITLE
Update supported_adapters.md

### DIFF
--- a/docs/information/supported_adapters.md
+++ b/docs/information/supported_adapters.md
@@ -180,7 +180,7 @@ Zigbee2MQTT officially supports the following adapters:
   <tr>
     <td><img src="../images/Silicon_Labs_Gecko_EFR32_SoCs.webp"></td>
     <td>Silicon Labs EZSP v8 <b>(experimental)</b></td>
-    <td>Initial development started on experimental (pre-alpha stage) support for various adapters based on Silicon Labs EFR32 SoC families with EmberZNet NCP 6.7.8 firmware or later via EZSP version 8 (EmberZNet Serial Protocol) interface. This include all hardware based on SoCs/Modules from Silabs EFR32MG21/MGM210 and EFR32MG12/MGM12 series.</td>
+    <td>Initial development started on experimental (pre-alpha stage) support for various adapters based on Silicon Labs EM35X and EFR32MG SoC families with EmberZNet NCP 6.7.8 firmware or later via EZSP version 8 (EmberZNet Serial Protocol) interface. This include all hardware based on SoCs/Modules from Silabs EFR32MG21/MGM210 and EFR32MG12/MGM12 series.</td>
     <td><a href="https://github.com/Koenkk/zigbee-herdsman/issues/319">Coordinator</a><br/></td>
     <td></td>
     <td></td>


### PR DESCRIPTION
EFR32 is not only Zigbee radios so shall being written EFR32MG that is the Zigbee family of the EFR32.
EM35X is also supported then its have enough hardware and we have ported EZSP 6.7.8.0 to it and its working OK.
From the host system its transparent wot radio hardware its running only the version of the firmware that is making it  compatible or not.
List of radios with verified working firmware https://github.com/zigpy/zigpy/wiki/Coordinator-Firmware-Updates