### PR TITLE
OSRAM is now LEDVANCE

### DIFF
--- a/docs/devices/AC10691.md
+++ b/docs/devices/AC10691.md
@@ -14,7 +14,7 @@ description: "Integrate your OSRAM AC10691 via Zigbee2MQTT with whatever smart h
 | Description | Smart+ plug |
 | Exposes | switch (state), linkquality |
 | Picture | ![OSRAM AC10691](../images/devices/AC10691.jpg) |
-
+| White-label | LEDVANCE Smart+ Plug |
 ## Notes
 
 None


### PR DESCRIPTION
OSRAM is now LEDVANCE https://en.wikipedia.org/wiki/LEDVANCE