### PR TITLE
Update ubisys J1 docs to reflect HA's changes to *_template MQTT configuration attributes

### DIFF
--- a/docs/devices/J1.md
+++ b/docs/devices/J1.md
@@ -94,17 +94,21 @@ functionality this can be passed along to Home Assistant by disabling some of th
 for example:
 ```yaml
 '0x001fee0000001234':
-    friendly_name: cover_not_supporting_tilt'
+    friendly_name: cover_not_supporting_tilt
     homeassistant:
       tilt_command_topic: null
       tilt_status_topic: null
+      tilt_status_template: null
 '0x001fee0000001234':
-    friendly_name: cover_supporting_neither_lift_nor_tilt'
+    friendly_name: cover_supporting_neither_lift_nor_tilt
     homeassistant:
-    set_position_topic: null
-    position_topic: null
+      set_position_topic: null
+      set_position_template: null
+      position_topic: null
+      position_template: null
       tilt_command_topic: null
       tilt_status_topic: null
+      tilt_status_template: null
 ```
 
 


### PR DESCRIPTION
Since a few Home Assistant versions ago one must also remove `tilt_status_template` for covers without tilt and `set_position_template`, `position_template` and `tilt_status_template` for covers with neither lift nor tilt from HAs MQTT auto discovery message for the covers to still be discovered