### PR TITLE
Update TS0601_air_quality_sensor.md

### DIFF
--- a/docs/devices/TS0601_air_quality_sensor.md
+++ b/docs/devices/TS0601_air_quality_sensor.md
@@ -49,7 +49,7 @@ It's not possible to read (`/get`) or write (`/set`) this value.
 The unit of this value is `%`.
 
 ### Co2 (numeric)
-The measured CO2 (carbon monoxide) value.
+The measured CO2 (carbon dioxide) value.
 Value can be found in the published state on the `co2` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The unit of this value is `ppm`.


### PR DESCRIPTION
CO2 is carbon dioxide, not carbon monoxide.