### PR TITLE
Add troubleshooting to Bitron AV2010/34

### DIFF
--- a/docs/devices/AV2010_34.md
+++ b/docs/devices/AV2010_34.md
@@ -17,7 +17,6 @@ description: "Integrate your Bitron AV2010/34 via Zigbee2MQTT with whatever smar
 
 ## Notes
 
-
 ### Deprecated click event
 By default this device exposes a deprecated `click` event. It's recommended to use the `action` event instead.
 
@@ -35,6 +34,13 @@ devices:
 
 * `legacy`: Set to `false` to disable the legacy integration (highly recommended!) (default: true)
 
+
+## Troubleshooting
+
+### Not receiving any actions
+
+In order to receive the `recall_*` action events, the device must be added to a group. There does not need to be any other members of the group.  
+To do this read the [groups documentation](/information/groups.html).
 
 
 ## Exposes


### PR DESCRIPTION
I spent quite a few hours trying to figure out why I wasnt receiving the actions data.
After a lot of googling and reading more into zigbee I discovered that the cause was the device not part of a group and so was not broadcasting the scene change.