### PR TITLE
HG06668 is a door bell _button_, not a door bell

### DIFF
--- a/docs/devices/HG06668.md
+++ b/docs/devices/HG06668.md
@@ -11,7 +11,7 @@ description: "Integrate your Lidl HG06668 via Zigbee2MQTT with whatever smart ho
 
 | Model | HG06668  |
 | Vendor  | Lidl  |
-| Description | Silvercrest smart wireless door bell |
+| Description | Silvercrest smart wireless door bell button |
 | Exposes | battery, action, battery_low, tamper, linkquality |
 | Picture | ![Lidl HG06668](../images/devices/HG06668.jpg) |
 


### PR DESCRIPTION
This device is just a button (which is clear from the "exposes" section, and from descriptions found online).
But the name "wireless door bell" sounds like it were a device that can deliver a signal. [Wikipedia says:](https://en.wikipedia.org/wiki/Doorbell) "A doorbell is a signaling device..." (I nearly wrongly ordered one of these)