### PR TITLE
Missing quotation marks from example payloads and responses

### DIFF
--- a/docs/information/touchlink.md
+++ b/docs/information/touchlink.md
@@ -21,4 +21,4 @@ Zigbee2MQTT will now start scanning, this can take up to 1 minute and during thi
 
 Now that your device has been factory reset, it will automatically join Zigbee2MQTT (make sure that joining is enabled through `permit_join: true`). If it doesn't, try powering the bulb off and on 1 time.
 
-In case you want to factory reset a specific device (which can be found through a scan, see above) request the factory reset with the following payload: `{ieee_address: '0x12345678', channel: 12}`.
+In case you want to factory reset a specific device (which can be found through a scan, see above) request the factory reset with the following payload: `{"ieee_address": "0x12345678", "channel": 12}`.

--- a/docs/information/touchlink.md
+++ b/docs/information/touchlink.md
@@ -7,10 +7,10 @@ Note that not all Zigbee devices support Touchlink, but most bulbs of common bra
 
 ## Scan
 This allows to scan for Touchlink enabled devices. The outcome of this scan can be used later to determine what device to factory reset. To scan send a MQTT message to `zigbee2mqtt/bridge/request/touchlink/scan` with an empty payload.
-The response will be send to `zigbee2mqtt/bridge/response/touchlink/scan`, example payload: `{"data":{"found":[{ieee_address: '0x12345678', channel: 12}, {ieee_address: '0x12654321', channel: 24}]},"status":"ok"}`.
+The response will be send to `zigbee2mqtt/bridge/response/touchlink/scan`, example payload: `{"data":{"found":[{"ieee_address": '0x12345678', "channel": 12}, {"ieee_address": '0x12654321', "channel": 24}]},"status":"ok"}`.
 
 ## Identify
-This allows to identify (e.g. bulb blinking) a device via Touchlink. To identify send a MQTT message to `zigbee2mqtt/bridge/request/touchlink/identify` with payload e.g. `{ieee_address: '0x12345678', channel: 12}` (use scan from above to determine `ieee_address` and `channel`).
+This allows to identify (e.g. bulb blinking) a device via Touchlink. To identify send a MQTT message to `zigbee2mqtt/bridge/request/touchlink/identify` with payload e.g. `{"ieee_address": '0x12345678', "channel": 12}` (use scan from above to determine `ieee_address` and `channel`).
 
 ## Factory reset device
 Zigbee2MQTT allows to factory reset devices through Touchlink. This is especially handy for e.g. Philips Hue bulbs as they cannot be factory resetted by turning them on/off 5 times. Demo: [video](https://www.youtube.com/watch?v=kcRj77YGyKk)


### PR DESCRIPTION
The example responses from Scan and the example payload from Identify are missing quotation marks