### PR TITLE
Include incomplete ZCL values for Alarm Keypads

### DIFF
--- a/docgen/device_page_notes.js
+++ b/docgen/device_page_notes.js
@@ -3490,7 +3490,7 @@ To set arming mode publish the following payload to \`zigbee2mqtt/FRIENDLY_NAME/
     }
 }
 \`\`\`
-Valid \`mode\` values are \`'disarm', 'arm_day_zones', 'arm_night_zones', 'arm_all_zones', 'exit_delay'\`
+Valid \`mode\` values as per ZCL specifications are \`disarm\`, \`arm_day_zones\`, \`arm_night_zones\`, \`arm_all_zones\`, \`exit_delay\`, \`entry_delay\`, \`not_ready\`, \`in_alarm\`, \`arming_stay\`, \`arming_night\`, \`arming_away\`.
 ### Arming/Disarming from the keypad
 When an attempt to set arm mode is done on the keypad, Zigbee2MQTT will publish the following payload to topic \`zigbee2mqtt/FRIENDLY_NAME\`:
 
@@ -3498,7 +3498,7 @@ When an attempt to set arm mode is done on the keypad, Zigbee2MQTT will publish 
 {
     "action": "arm_all_zones", // This is the example
     "action_code": "123", // The code being entered
-    "action_zone": 0, // The zone being (dis)armed (always 0)
+    "action_zone": 0, // The zone being armed (always 0)
     "action_transaction": 99 // The transaction number
 }
 \`\`\`
@@ -3533,7 +3533,7 @@ To set arming mode publish the following payload to \`zigbee2mqtt/FRIENDLY_NAME/
     }
 }
 \`\`\`
-Valid \`mode\` values are \`'disarm', 'arm_day_zones', 'arm_all_zones', 'exit_delay'\`
+Valid \`mode\` values as per ZCL specifications are \`disarm\`, \`arm_day_zones\`, \`arm_night_zones\`, \`arm_all_zones\`, \`exit_delay\`, \`entry_delay\`, \`not_ready\`, \`in_alarm\`, \`arming_stay\`, \`arming_night\`, \`arming_away\`.
 ### Arming/Disarming from the keypad
 When an attempt to set arm mode is done on the keypad, Zigbee2MQTT will publish the following payload to topic \`zigbee2mqtt/FRIENDLY_NAME\`:
 
@@ -3541,7 +3541,7 @@ When an attempt to set arm mode is done on the keypad, Zigbee2MQTT will publish 
 {
     "action": "arm_all_zones", // This is the example
     "action_code": "123", // The code being entered
-    "action_zone": 0, // The zone being (dis)armed (always 0)
+    "action_zone": 0, // The zone being armed (always 0)
     "action_transaction": 99 // The transaction number
 }
 \`\`\`

--- a/docs/devices/3400-D.md
+++ b/docs/devices/3400-D.md
@@ -38,7 +38,7 @@ To set arming mode publish the following payload to `zigbee2mqtt/FRIENDLY_NAME/s
     }
 }
 ```
-Valid `mode` values are `'disarm', 'arm_day_zones', 'arm_night_zones', 'arm_all_zones', 'exit_delay'`
+Valid `mode` values as per ZCL specifications are `disarm`, `arm_day_zones`, `arm_night_zones`, `arm_all_zones`, `exit_delay`, `entry_delay`, `not_ready`, `in_alarm`, `arming_stay`, `arming_night`, `arming_away`.
 ### Arming/Disarming from the keypad
 When an attempt to set arm mode is done on the keypad, Zigbee2MQTT will publish the following payload to topic `zigbee2mqtt/FRIENDLY_NAME`:
 
@@ -46,7 +46,7 @@ When an attempt to set arm mode is done on the keypad, Zigbee2MQTT will publish 
 {
     "action": "arm_all_zones", // This is the example
     "action_code": "123", // The code being entered
-    "action_zone": 0, // The zone being (dis)armed (always 0)
+    "action_zone": 0, // The zone being armed (always 0)
     "action_transaction": 99 // The transaction number
 }
 ```

--- a/docs/devices/KEYPAD001.md
+++ b/docs/devices/KEYPAD001.md
@@ -28,7 +28,7 @@ To set arming mode publish the following payload to `zigbee2mqtt/FRIENDLY_NAME/s
     }
 }
 ```
-Valid `mode` values are `'disarm', 'arm_day_zones', 'arm_all_zones', 'exit_delay'`
+Valid `mode` values as per ZCL specifications are `disarm`, `arm_day_zones`, `arm_night_zones`, `arm_all_zones`, `exit_delay`, `entry_delay`, `not_ready`, `in_alarm`, `arming_stay`, `arming_night`, `arming_away`.
 ### Arming/Disarming from the keypad
 When an attempt to set arm mode is done on the keypad, Zigbee2MQTT will publish the following payload to topic `zigbee2mqtt/FRIENDLY_NAME`:
 
@@ -36,7 +36,7 @@ When an attempt to set arm mode is done on the keypad, Zigbee2MQTT will publish 
 {
     "action": "arm_all_zones", // This is the example
     "action_code": "123", // The code being entered
-    "action_zone": 0, // The zone being (dis)armed (always 0)
+    "action_zone": 0, // The zone being armed (always 0)
     "action_transaction": 99 // The transaction number
 }
 ```

--- a/docs/devices/XHK1-TC.md
+++ b/docs/devices/XHK1-TC.md
@@ -38,7 +38,7 @@ To set arming mode publish the following payload to `zigbee2mqtt/FRIENDLY_NAME/s
     }
 }
 ```
-Valid `mode` values are `'disarm', 'arm_day_zones', 'arm_night_zones', 'arm_all_zones', 'exit_delay'`
+Valid `mode` values as per ZCL specifications are `disarm`, `arm_day_zones`, `arm_night_zones`, `arm_all_zones`, `exit_delay`, `entry_delay`, `not_ready`, `in_alarm`, `arming_stay`, `arming_night`, `arming_away`.
 ### Arming/Disarming from the keypad
 When an attempt to set arm mode is done on the keypad, Zigbee2MQTT will publish the following payload to topic `zigbee2mqtt/FRIENDLY_NAME`:
 
@@ -46,7 +46,7 @@ When an attempt to set arm mode is done on the keypad, Zigbee2MQTT will publish 
 {
     "action": "arm_all_zones", // This is the example
     "action_code": "123", // The code being entered
-    "action_zone": 0, // The zone being (dis)armed (always 0)
+    "action_zone": 0, // The zone being armed (always 0)
     "action_transaction": 99 // The transaction number
 }
 ```

--- a/docs/devices/XHK1-UE.md
+++ b/docs/devices/XHK1-UE.md
@@ -38,7 +38,7 @@ To set arming mode publish the following payload to `zigbee2mqtt/FRIENDLY_NAME/s
     }
 }
 ```
-Valid `mode` values are `'disarm', 'arm_day_zones', 'arm_night_zones', 'arm_all_zones', 'exit_delay'`
+Valid `mode` values as per ZCL specifications are `disarm`, `arm_day_zones`, `arm_night_zones`, `arm_all_zones`, `exit_delay`, `entry_delay`, `not_ready`, `in_alarm`, `arming_stay`, `arming_night`, `arming_away`.
 ### Arming/Disarming from the keypad
 When an attempt to set arm mode is done on the keypad, Zigbee2MQTT will publish the following payload to topic `zigbee2mqtt/FRIENDLY_NAME`:
 
@@ -46,7 +46,7 @@ When an attempt to set arm mode is done on the keypad, Zigbee2MQTT will publish 
 {
     "action": "arm_all_zones", // This is the example
     "action_code": "123", // The code being entered
-    "action_zone": 0, // The zone being (dis)armed (always 0)
+    "action_zone": 0, // The zone being armed (always 0)
     "action_transaction": 99 // The transaction number
 }
 ```


### PR DESCRIPTION
Hi @Koenkk 

As a results of the new issue https://github.com/Koenkk/zigbee2mqtt/issues/8630 I have reviewed the notes and realised I have not added all the valid ZCL values for `arm_mode`

I have now added them to the notes file but also the device.md so no need for a docgen, just a merge.

Apologies for giving you extra work.

PS: I will handle the above mentioned issue. It is just a case of users having to change their automation flows to use the standard logic, but all the functionality is available and correct.