### PR TITLE
a couple updates to all sinopé docs

### DIFF
--- a/docs/devices/TH1123ZB.md
+++ b/docs/devices/TH1123ZB.md
@@ -1,25 +1,26 @@
 ---
-title: "Sinope TH1123ZB control via MQTT"
-description: "Integrate your Sinope TH1123ZB via Zigbee2MQTT with whatever smart home
+title: "Sinopé TH1123ZB control via MQTT"
+description: "Integrate your Sinopé TH1123ZB via Zigbee2MQTT with whatever smart home
  infrastructure you are using without the vendors bridge or gateway."
 ---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docs/devices/TH1123ZB.md)*
 
-# Sinope TH1123ZB
+# Sinopé TH1123ZB
 
 | Model | TH1123ZB  |
-| Vendor  | Sinope  |
+| Vendor  | Sinopé  |
 | Description | Zigbee line volt thermostat |
 | Exposes | local_temperature, keypad_lockout, power, current, voltage, energy, climate (occupied_heating_setpoint, local_temperature, system_mode, running_state), backlight_auto_dim, linkquality |
-| Picture | ![Sinope TH1123ZB](../images/devices/TH1123ZB.jpg) |
+| Picture | ![Sinopé TH1123ZB](../images/devices/TH1123ZB.jpg) |
 
 ## Notes
 
 
 ### Setting outdoor temperature
 To set _outdoor temperature_, you need to send the value to the following MQTT topic:
+
 ```
 zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_outdoor_temperature
 ```
@@ -28,25 +29,38 @@ If you want to automate the publishing of the outdoor temperature using Home Ass
 
 ``` yaml
 - id: 'Auto_Publish_Outdoor_Temprature'
-  alias: Auto_Publish_Outdoor_Temprature
-  description: Automatically Publish the outdoor temperature to thermostats
+  alias: 'Publish outside temperature'
+  description: 'Automatically Publish the outdoor temperature to thermostats'
+  mode: single
   trigger:
-  - entity_id: sensor.outdoor_temprature_sensor
-    platform: state
+  - platform: state
+    entity_id: sensor.<OUTDOOR_TEMPERATURE_SENSOR_NAME>
   condition: []
   action:
-  - data:
-      payload_template: '{{ states(''sensor.outdoor_temprature_sensor'') | string }}'
+  - service: mqtt.publish
+    data:
       topic: zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_outdoor_temperature
-    service: mqtt.publish
+      payload_template: "{{ states('sensor.<OUTDOOR_TEMPERATURE_SENSOR_NAME>') }}"
 ```
 
 ### Enabling time
 To enable _time_ you need to send a _blank_ message to the following MQTT topic:
+
 ```
 zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_time
 ```
-Every time the above message is sent, Zigbee2MQTT will calculate the current time and send it to the thermostat.
+
+*Every time the above message is sent, Zigbee2MQTT will calculate the current time and send it to the thermostat.*
+
+If the thermostat loses power, you need to do this again. For Home Assistant users: if you want to avoid remembering to do this, you can
+add the following `action` to your `Auto_Publish_Outdoor_Temperature` automation (noted above).
+
+``` yaml
+  - service: mqtt.publish
+    data:
+      topic: zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_time
+      payload: ''
+```
 
 ### Device type specific configuration
 *[How to use device type specific configuration](../information/configuration.md)*

--- a/docs/devices/TH1124ZB.md
+++ b/docs/devices/TH1124ZB.md
@@ -1,19 +1,19 @@
 ---
-title: "Sinope TH1124ZB control via MQTT"
-description: "Integrate your Sinope TH1124ZB via Zigbee2MQTT with whatever smart home
+title: "Sinopé TH1124ZB control via MQTT"
+description: "Integrate your Sinopé TH1124ZB via Zigbee2MQTT with whatever smart home
  infrastructure you are using without the vendors bridge or gateway."
 ---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docs/devices/TH1124ZB.md)*
 
-# Sinope TH1124ZB
+# Sinopé TH1124ZB
 
 | Model | TH1124ZB  |
-| Vendor  | Sinope  |
+| Vendor  | Sinopé  |
 | Description | Zigbee line volt thermostat |
 | Exposes | local_temperature, keypad_lockout, power, current, voltage, energy, climate (occupied_heating_setpoint, local_temperature, system_mode, running_state, pi_heating_demand), backlight_auto_dim, linkquality |
-| Picture | ![Sinope TH1124ZB](../images/devices/TH1124ZB.jpg) |
+| Picture | ![Sinopé TH1124ZB](../images/devices/TH1124ZB.jpg) |
 
 ## Notes
 

--- a/docs/devices/TH1300ZB.md
+++ b/docs/devices/TH1300ZB.md
@@ -1,19 +1,19 @@
 ---
-title: "Sinope TH1300ZB control via MQTT"
-description: "Integrate your Sinope TH1300ZB via Zigbee2MQTT with whatever smart home
+title: "Sinopé TH1300ZB control via MQTT"
+description: "Integrate your Sinopé TH1300ZB via Zigbee2MQTT with whatever smart home
  infrastructure you are using without the vendors bridge or gateway."
 ---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docs/devices/TH1300ZB.md)*
 
-# Sinope TH1300ZB
+# Sinopé TH1300ZB
 
 | Model | TH1300ZB  |
-| Vendor  | Sinope  |
+| Vendor  | Sinopé  |
 | Description | Zigbee smart floor heating thermostat |
 | Exposes | local_temperature, keypad_lockout, climate (occupied_heating_setpoint, local_temperature, system_mode, running_state, pi_heating_demand), backlight_auto_dim, linkquality |
-| Picture | ![Sinope TH1300ZB](../images/devices/TH1300ZB.jpg) |
+| Picture | ![Sinopé TH1300ZB](../images/devices/TH1300ZB.jpg) |
 
 ## Notes
 

--- a/docs/devices/TH1400ZB.md
+++ b/docs/devices/TH1400ZB.md
@@ -1,21 +1,66 @@
 ---
-title: "Sinope TH1400ZB control via MQTT"
-description: "Integrate your Sinope TH1400ZB via Zigbee2MQTT with whatever smart home
+title: "Sinopé TH1400ZB control via MQTT"
+description: "Integrate your Sinopé TH1400ZB via Zigbee2MQTT with whatever smart home
  infrastructure you are using without the vendors bridge or gateway."
 ---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docs/devices/TH1400ZB.md)*
 
-# Sinope TH1400ZB
+# Sinopé TH1400ZB
 
 | Model | TH1400ZB  |
-| Vendor  | Sinope  |
+| Vendor  | Sinopé  |
 | Description | Zigbee low volt thermostat |
 | Exposes | climate (occupied_heating_setpoint, local_temperature, system_mode, running_state), backlight_auto_dim, linkquality |
-| Picture | ![Sinope TH1400ZB](../images/devices/TH1400ZB.jpg) |
+| Picture | ![Sinopé TH1400ZB](../images/devices/TH1400ZB.jpg) |
 
 ## Notes
+
+### Setting outdoor temperature
+To set the *outdoor temperature* (value below the Out label on the thermostat display), you need to send the value to the following MQTT
+topic:
+
+```
+zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_outdoor_temperature
+```
+
+If you want to automate the publishing of the outdoor temperature using Home Assistant, you may create an automation like this:
+
+``` yaml
+- id: 'Auto_Publish_Outdoor_Temprature'
+  alias: 'Publish outside temperature'
+  description: 'Automatically Publish the outdoor temperature to thermostats'
+  mode: single
+  trigger:
+  - platform: state
+    entity_id: sensor.<OUTDOOR_TEMPERATURE_SENSOR_NAME>
+  condition: []
+  action:
+  - service: mqtt.publish
+    data:
+      topic: zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_outdoor_temperature
+      payload_template: "{{ states('sensor.<OUTDOOR_TEMPERATURE_SENSOR_NAME>') }}"
+```
+
+### Setting outdoor temperature
+To enable time you need to send a blank message to the following MQTT topic:
+
+```
+zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_time
+```
+
+*Every time the above message is sent, Zigbee2MQTT will calculate the current time and send it to the thermostat.*
+
+If the thermostat loses power, you need to do this again. For Home Assistant users: if you want to avoid remembering to do this, you can
+add the following `action` to your `Auto_Publish_Outdoor_Temperature` automation (noted above).
+
+``` yaml
+  - service: mqtt.publish
+    data:
+      topic: zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_time
+      payload: ''
+```
 
 ### Device type specific configuration
 *[How to use device type specific configuration](../information/configuration.md)*

--- a/docs/devices/TH1500ZB.md
+++ b/docs/devices/TH1500ZB.md
@@ -1,19 +1,19 @@
 ---
-title: "Sinope TH1500ZB control via MQTT"
-description: "Integrate your Sinope TH1500ZB via Zigbee2MQTT with whatever smart home
+title: "Sinopé TH1500ZB control via MQTT"
+description: "Integrate your Sinopé TH1500ZB via Zigbee2MQTT with whatever smart home
  infrastructure you are using without the vendors bridge or gateway."
 ---
 
 *To contribute to this page, edit the following
 [file](https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docs/devices/TH1500ZB.md)*
 
-# Sinope TH1500ZB
+# Sinopé TH1500ZB
 
 | Model | TH1500ZB  |
-| Vendor  | Sinope  |
+| Vendor  | Sinopé  |
 | Description | Zigbee dual pole line volt thermostat |
 | Exposes | climate (occupied_heating_setpoint, local_temperature, system_mode, running_state, pi_heating_demand), backlight_auto_dim, linkquality |
-| Picture | ![Sinope TH1500ZB](../images/devices/TH1500ZB.jpg) |
+| Picture | ![Sinopé TH1500ZB](../images/devices/TH1500ZB.jpg) |
 
 ## Notes
 


### PR DESCRIPTION
minor documentation changes based on my recent testing and device setup. they include:

 * TH1400ZB: tested instruction on setting OUT temp and TIME
 * TH1123ZB: tweaks to existing OUT and TIME instructions
 * ALL: corrected name to include é (e-acute) in Sinopé