### PR TITLE
Ikea E1524 `action: toggle` was missing

### DIFF
--- a/docs/devices/E1524_E1810.md
+++ b/docs/devices/E1524_E1810.md
@@ -82,7 +82,7 @@ The unit of this value is `%`.
 Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
-The possible values are: `arrow_left_click`, `arrow_left_hold`, `arrow_left_release`, `arrow_right_click`, `arrow_right_hold`, `arrow_right_release`, `brightness_down_click`, `brightness_down_hold`, `brightness_down_release`, `brightness_up_click`, `brightness_up_hold`, `brightness_up_release`.
+The possible values are: `arrow_left_click`, `arrow_left_hold`, `arrow_left_release`, `arrow_right_click`, `arrow_right_hold`, `arrow_right_release`, `brightness_down_click`, `brightness_down_hold`, `brightness_down_release`, `brightness_up_click`, `brightness_up_hold`, `brightness_up_release`, `toggle`.
 
 ### Linkquality (numeric)
 Link quality (signal strength).


### PR DESCRIPTION
really small update here, just adding `action: toggle` to the document as it was missing. the toggle action is sent when the middle "power" button on the remote control is pressed.

