### PR TITLE
Remove extraneous comma in JSON payload example

### DIFF
--- a/docs/devices/8718699703424.md
+++ b/docs/devices/8718699703424.md
@@ -61,8 +61,7 @@ Send a MQTT command to [`zigbee2mqtt/FRIENDLY_NAME/set`](https://www.zigbee2mqtt
     "hue_power_on_behavior": "on",          // default, on, off, recover
     "hue_power_on_brightness": 125,         // same values as brightness
     "hue_power_on_color_temperature": 280,  // same values as color_temp
-    "hue_power_on_color": "#0000FF",        // color in hex notation, e.g. #0000FF = blue
-
+    "hue_power_on_color": "#0000FF"         // color in hex notation, e.g. #0000FF = blue
 }
 ```
 


### PR DESCRIPTION
The example JSON payload given in the section _power-on behaviour_ contains an extraneous comma that z2m won't accept:

```
[debug] Received MQTT message on 'zigbee2mqtt/FRIENDLY_NAME/set' with data '{ "hue_power_on_behavior": "on", "hue_power_on_brightness": 8, "hue_power_on_color_temperature": 500, }'
[error] Invalid JSON '{ "hue_power_on_behavior": "on", "hue_power_on_brightness": 8, "hue_power_on_color_temperature": 500, }', skipping...
```

Removing the comma, the payload gets accepted without issues.

```
[debug] Received MQTT message on 'zigbee2mqtt/uf_mb_bed_headboard/set' with data '{ "hue_power_on_behavior": "on", "hue_power_on_brightness": 8, "hue_power_on_color_temperature": 500 }'
[debug] Publishing 'set' 'hue_power_on_behavior' to 'FRIENDLY_NAME'
[debug] Received Zigbee message from 'FRIENDLY_NAME', type 'readResponse', cluster 'lightingColorCtrl', data '{"colorCapabilities":31}' from endpoint 11 with groupID 0
[debug] Publishing 'set' 'hue_power_on_brightness' to 'FRIENDLY_NAME'
```