### PR TITLE
Add pairing docs for Hive Thermostat and Controller

### DIFF
--- a/docs/devices/SLR1.md
+++ b/docs/devices/SLR1.md
@@ -17,6 +17,16 @@ description: "Integrate your Hive SLR1 via Zigbee2MQTT with whatever smart home
 
 ## Notes
 
+### Pairing
+
+To pair the thermostat with Zigbee2Mqtt, follow these steps:
+
+1. Temporarily disconnect any thermostat controllers connected to the thermostat by remove a battery from them. 
+2. Turn the thermostat and boiler off, then on again to ensure it is not trying to connect to any thermostat controllers.
+3. Once the thermostat and boiler are on, hold down the Central heating button on the device until the Central heating'light turns white/ pink, then release the button. This will enable stand-alone mode on the thermostat.
+4. Hold down the central heating button again until the Central heating light begins to flash amber. The device is now in pairing mode and should be found by Zigbee2MQTT.
+5. You can now re-insert the battery back into any thermostat controllers disconnected in step 1 and pair them to the boiler (and optionally Zigbee2MQTT). For information on pairing the thermostat controllers see the pairing instructions for the [Hive SLT3B](./SLT3.md). Note that the thermostat's Central heating light will remain amber until a controller is paired with the thermostat, however the thermostat will still function correctly.
+
 
 ### How to start/edit native boost
 The receiver has support for native Boost, which will allow to display the remaining time on a compatible remote.

--- a/docs/devices/SLR1b.md
+++ b/docs/devices/SLR1b.md
@@ -17,6 +17,15 @@ description: "Integrate your Hive SLR1b via Zigbee2MQTT with whatever smart home
 
 ## Notes
 
+### Pairing
+
+To pair the thermostat with Zigbee2Mqtt, follow these steps:
+
+1. Temporarily disconnect any thermostat controllers connected to the thermostat by remove a battery from them. 
+2. Turn the thermostat and boiler off, then on again to ensure it is not trying to connect to any thermostat controllers.
+3. Once the thermostat and boiler are on, hold down the Central heating button on the device until the Central heating'light turns white/ pink, then release the button. This will enable stand-alone mode on the thermostat.
+4. Hold down the central heating button again until the Central heating light begins to flash amber. The device is now in pairing mode and should be found by Zigbee2MQTT.
+5. You can now re-insert the battery back into any thermostat controllers disconnected in step 1 and pair them to the boiler (and optionally Zigbee2MQTT). For information on pairing the thermostat controllers see the pairing instructions for the [Hive SLT3B](./SLT3.md). Note that the thermostat's Central heating light will remain amber until a controller is paired with the thermostat, however the thermostat will still function correctly.
 
 ### How to start/edit native boost
 The receiver has support for native Boost, which will allow to display the remaining time on a compatible remote.

--- a/docs/devices/SLR2.md
+++ b/docs/devices/SLR2.md
@@ -17,6 +17,17 @@ description: "Integrate your Hive SLR2 via Zigbee2MQTT with whatever smart home
 
 ## Notes
 
+### Pairing
+
+* The following steps have not been tested with the
+
+To pair the thermostat with Zigbee2Mqtt, follow these steps:
+
+1. Temporarily disconnect any thermostat controllers connected to the thermostat by remove a battery from them. 
+2. Turn the thermostat and boiler off, then on again to ensure it is not trying to connect to any thermostat controllers.
+3. Once the thermostat and boiler are on, hold down the Central heating button on the device until the Central heating'light turns white/ pink, then release the button. This will enable stand-alone mode on the thermostat.
+4. Hold down the central heating button again until the Central heating light begins to flash amber. The device is now in pairing mode and should be found by Zigbee2MQTT.
+5. You can now re-insert the battery back into any thermostat controllers disconnected in step 1 and pair them to the boiler (and optionally Zigbee2MQTT). For information on pairing the thermostat controllers see the pairing instructions for the [Hive SLT3B](./SLT3.md). Note that the thermostat's Central heating light will remain amber until a controller is paired with the thermostat, however the thermostat will still function correctly.
 
 ### Sending payloads on dual channel receivers
 As the receiver makes use of two endpoints, `water` and `heat` there are two methods of sending payloads, both equally valid. For example, the `heat` endpoint:

--- a/docs/devices/SLR2b.md
+++ b/docs/devices/SLR2b.md
@@ -17,6 +17,15 @@ description: "Integrate your Hive SLR2b via Zigbee2MQTT with whatever smart home
 
 ## Notes
 
+### Pairing
+
+To pair the thermostat with Zigbee2Mqtt, follow these steps:
+
+1. Temporarily disconnect any thermostat controllers connected to the thermostat by remove a battery from them. 
+2. Turn the thermostat and boiler off, then on again to ensure it is not trying to connect to any thermostat controllers.
+3. Once the thermostat and boiler are on, hold down the Central heating button on the device until the Central heating'light turns white/ pink, then release the button. This will enable stand-alone mode on the thermostat.
+4. Hold down the central heating button again until the Central heating light begins to flash amber. The device is now in pairing mode and should be found by Zigbee2MQTT.
+5. You can now re-insert the battery back into any thermostat controllers disconnected in step 1 and pair them to the boiler (and optionally Zigbee2MQTT). For information on pairing the thermostat controllers see the pairing instructions for the [Hive SLT3B](./SLT3.md). Note that the thermostat's Central heating light will remain amber until a controller is paired with the thermostat, however the thermostat will still function correctly.
 
 ### Sending payloads on dual channel receivers
 As the receiver makes use of two endpoints, `water` and `heat` there are two methods of sending payloads, both equally valid. For example, the `heat` endpoint:

--- a/docs/devices/SLT3.md
+++ b/docs/devices/SLT3.md
@@ -17,8 +17,9 @@ description: "Integrate your Hive SLT3 via Zigbee2MQTT with whatever smart home
 
 ## Notes
 
-None
+### Pairing
 
+To pair the thermostat controller to both Zigbee2MQTT and the thermostat, a factory reset will need to be performed. To begin a factory reset, press and hold both the menu and back buttons together. Allow the countdown to finish before releasing to factory reset the device. After the device has reset and a language has been selected, Zigbee2MQTT should find the device. The device should be able to control the boiler whilst still reporting to Zigbee2MQTT.
 
 ## Exposes
 

--- a/docs/devices/SLT3B.md
+++ b/docs/devices/SLT3B.md
@@ -17,8 +17,9 @@ description: "Integrate your Hive SLT3B via Zigbee2MQTT with whatever smart home
 
 ## Notes
 
-None
+### Pairing
 
+To pair the thermostat controller to both Zigbee2MQTT and the thermostat, a factory reset will need to be performed. To begin a factory reset, press and hold both the menu and back buttons together. Allow the countdown to finish before releasing to factory reset the device. After the device has reset and a language has been selected, Zigbee2MQTT should find the device. The device should be able to control the boiler whilst still reporting to Zigbee2MQTT.
 
 ## Exposes
 


### PR DESCRIPTION
This PR adds notes about pairing for the SLR1, SLR1b, SLR2, SLR2b, SLT3 and SLT3b.

There also exists the SLT2 and WPT1 thermostat controllers, however I don't have these devices nor have found any information on their pairing modes to submit pairing docs for them.