### PR TITLE
Remove mention of relay from SNZB-03 documentation

### DIFF
--- a/docgen/device_page_notes.js
+++ b/docgen/device_page_notes.js
@@ -1420,7 +1420,7 @@ Turn the bulb on and off consecutively 6 times, then on again, at which point it
         model: ['SNZB-03'],
         note: `
 ### Pairing
-If brand new, when powered on it will attempt to pair to Zigbee2MQTT automatically. If not (or if has been paired before and needs to be re-paired) - press and hold the reset button through the small hole at the top for about 5 seconds until the light flashes several times. The device will then go into pairing mode. It should then be connected to Zigbee2MQTT. Pressing the button should activate the relay on/off as normal, and the red LED will be on/off.
+If brand new, when powered on it will attempt to pair to Zigbee2MQTT automatically. If not (or if has been paired before and needs to be re-paired) - press and hold the reset button through the small hole at the top for about 5 seconds until the light flashes several times. The device will then go into pairing mode. It should then be connected to Zigbee2MQTT.
 `,
     },
     {

--- a/docs/devices/SNZB-03.md
+++ b/docs/devices/SNZB-03.md
@@ -20,7 +20,7 @@ description: "Integrate your SONOFF SNZB-03 via Zigbee2MQTT with whatever smart 
 
 
 ### Pairing
-If brand new, when powered on it will attempt to pair to Zigbee2MQTT automatically. If not (or if has been paired before and needs to be re-paired) - press and hold the reset button through the small hole at the top for about 5 seconds until the light flashes several times. The device will then go into pairing mode. It should then be connected to Zigbee2MQTT. Pressing the button should activate the relay on/off as normal, and the red LED will be on/off.
+If brand new, when powered on it will attempt to pair to Zigbee2MQTT automatically. If not (or if has been paired before and needs to be re-paired) - press and hold the reset button through the small hole at the top for about 5 seconds until the light flashes several times. The device will then go into pairing mode. It should then be connected to Zigbee2MQTT.
 
 
 


### PR DESCRIPTION
The SNZB-03 is a PIR - it looks like this part of the documentation was copied from the BASICZBR3.