### PR TITLE
Lidl Silvercrest Device HG06338 - Avoid sending JSON as payload 

### DIFF
--- a/docs/devices/HG06338.md
+++ b/docs/devices/HG06338.md
@@ -34,18 +34,18 @@ How to use the connector strip with Node-Red: Use the "command node" of the node
 
 ### Switch (l1 endpoint)
 The current state of this switch is in the published state under the `state_l1` property (value is `ON` or `OFF`).
-To control this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"state_l1": "ON"}`, `{"state_l1": "OFF"}` or `{"state_l1": "TOGGLE"}`.
-To read the current state of this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"state_l1": ""}`.
+To control this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/l1/set` with payload `{"ON"}`, `{"OFF"}` or `{"TOGGLE"}`.
+To read the current state of this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/l1/state` with payload `{""}`.
 
 ### Switch (l2 endpoint)
 The current state of this switch is in the published state under the `state_l2` property (value is `ON` or `OFF`).
-To control this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"state_l2": "ON"}`, `{"state_l2": "OFF"}` or `{"state_l2": "TOGGLE"}`.
-To read the current state of this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"state_l2": ""}`.
+To control this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/l2/set` with payload `{"ON"}`, `{"OFF"}` or `{"TOGGLE"}`.
+To read the current state of this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/l2/state` with payload `{""}`.
 
 ### Switch (l3 endpoint)
 The current state of this switch is in the published state under the `state_l3` property (value is `ON` or `OFF`).
-To control this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"state_l3": "ON"}`, `{"state_l3": "OFF"}` or `{"state_l3": "TOGGLE"}`.
-To read the current state of this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"state_l3": ""}`.
+To control this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/l3/set` with payload `{"ON"}`, `{"OFF"}` or `{"TOGGLE"}`.
+To read the current state of this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/l2/state` with payload `{""}`.
 
 ### Linkquality (numeric)
 Link quality (signal strength).


### PR DESCRIPTION
The Device accepts a regular mqtt message structure. It's not needed to send a JSON file as payload.