### PR TITLE
Update Supported Adapters documentation page

### DIFF
--- a/docs/guide/adapters/README.md
+++ b/docs/guide/adapters/README.md
@@ -21,7 +21,7 @@ _(in order of first appearance)_
     * [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/master/coordinator/Z-Stack_3.x.0/bin/CC2652R_coordinator_20210708.zip)  
     * [Router firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/master/router/Z-Stack_3.x.0/bin/CC2652R_router_20210128.zip)  
     * [Flashing instructions](https://electrolama.com/radio-docs/#step-3-flash-the-firmware-on-your-stick)  
-    * [Buy](https://www.tindie.com/products/electrolama/zzh-cc2652r-multiprotocol-rf-stick/#product-reviews)
+    * [Buy](https://shop.electrolama.com/collections/usb-rf-sticks/products/zzh-multiprotocol-rf-stick)
   
     ![](../../images/zzh.jpg)
     </details>  


### PR DESCRIPTION
Purchasing link for zzh now points to the Electrolama Shop.