### PR TITLE
Add action-concurrency

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,5 +1,9 @@
 name: Build ⚙ and Deploy 🚀
+
 on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.ref }}
 
 jobs:
   build_and_deploy:

--- a/.github/workflows/update-algolia-index.yml
+++ b/.github/workflows/update-algolia-index.yml
@@ -7,6 +7,10 @@ on:
     branches: [ master ]
     types: [ completed ]
 
+concurrency:
+  group: algolia-update
+  cancel-in-progress: true
+
 jobs:
   update-algolia-index:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ensures that only the latest commit gets published.