### PR TITLE
Update README.md

### DIFF
--- a/docs/guide/adapters/README.md
+++ b/docs/guide/adapters/README.md
@@ -397,7 +397,7 @@ Before buying an adapter, please read the notes below!
 ### Flashing CC1352/CC2652/CC2538 based adapters
 Adapters based on CC1352 or CC2652 chips can be flashed by putting them in the bootloader. See your adapter manual on how to do this. After you have done this one of the following tools can be used to flash it.
 - [ZigStar GW Multi tool](https://github.com/xyzroe/ZigStarGW-MT) (multi platform GUI tool)
-- [CC2538-BSL](https://www.ti.com/tool/FLASH-PROGRAMMER) (multi platform Python based command line tool)
+- [CC2538-BSL](https://github.com/JelmerT/cc2538-bsl) (multi platform Python based command line tool)
 - Texas Instrumens [FLASH PROGRAMMER 2](https://www.ti.com/tool/FLASH-PROGRAMMER) (Windows only)
 
 ### Router


### PR DESCRIPTION
The link for the CC2538-BSL tool for flashing the CC1352/CC2652/CC2538 adapters was pointing to the Texas Instruments FLASH PROGRAMMER 2 as well.
I changed that link to now point to https://github.com/JelmerT/cc2538-bsl