### PR TITLE
Fix getting started typo from .yml to .yaml

### DIFF
--- a/docs/guide/getting-started/README.md
+++ b/docs/guide/getting-started/README.md
@@ -86,7 +86,7 @@ services:
       - /dev/ttyUSB0:/dev/ttyUSB0
 ```
 
-In the next step we'll create a simple [Zigbee2MQTT config file](../configuration/) in `zigbee2mqtt-data/configuration.yml`.
+In the next step we'll create a simple [Zigbee2MQTT config file](../configuration/) in `zigbee2mqtt-data/configuration.yaml`.
 
 ```yaml
 # Let new devices join our zigbee network


### PR DESCRIPTION
The getting started guide uses the following path for the config:

> zigbee2mqtt-data/configuration.yml

On `docker-compose up -d`, a different file, with the path: `zigbee2mqtt-data/configuration.yaml` is created. 

This PR corrects the typo from `.yml` to `.yaml` to prevent users from experiencing setup issues with their config.