### PR TITLE
Update PTM_215Z.md

### DIFF
--- a/docs/devices/PTM_215Z.md
+++ b/docs/devices/PTM_215Z.md
@@ -58,8 +58,15 @@ To pair it, hold the corresponding button for that channel for 7 seconds or more
 Once the device is paired you need to confirm the channel. To do this press A1 and B0 together. Important: don't press any other buttons between this and the pairing.
 
 In case you want to pair it to a different channel you have to factory reset the device. This can be done by pressing all buttons (A0, A1, B0 and B1) simultaneously for at least 7 seconds.
-<!-- Notes END: Do not edit below this line -->
 
+Alternatively, you should be able to reset the switch with the following pattern:
+1. Press top left (A0)
+2. Press and hold top right (B0) for about 10 seconds 
+3. press top right (B0) and bottom left (A1) at the same time 
+4. press top left (A0)
+Note: Please make sure the module is positioned the right way up.
+
+<!-- Notes END: Do not edit below this line -->
 
 
 ## Exposes


### PR DESCRIPTION
Added an alternative way of resetting the switch, found here:
https://www.senic.com/pages/support-center
(under "I have problems with the FOH...")
thanks to this post (in Dutch) https://gathering.tweakers.net/forum/list_message/69560682#69560682

I needed to do this with my Senic Friends of Hue switches to get them to pair with Zigbee2MQTT (using a Conbee II)

BTW The Senic switches are not in the Z2M device list yet, and I have no idea how to add them, but they use the PTM215Z as well.
Furthermore, I think I read somewhere that the Conbee II also supports Green Power devices, which means you would not need a Hue light to get them to work, but have not been able to find this again, or to verify this. But maybe you already know ;-)