### PR TITLE
Update README.md with link to llama-bsl

### DIFF
--- a/docs/guide/adapters/README.md
+++ b/docs/guide/adapters/README.md
@@ -398,6 +398,7 @@ Before buying an adapter, please read the notes below!
 Adapters based on CC1352 or CC2652 chips can be flashed by putting them in the bootloader. See your adapter manual on how to do this. After you have done this one of the following tools can be used to flash it.
 - [ZigStar GW Multi tool](https://github.com/xyzroe/ZigStarGW-MT) (multi platform GUI tool)
 - [CC2538-BSL](https://github.com/JelmerT/cc2538-bsl) (multi platform Python based command line tool)
+- [llama-bsl](https://github.com/electrolama/llama-bsl) (multi platform Python based command line tool, a fork of cc2538-bsl with added features)
 - Texas Instrumens [FLASH PROGRAMMER 2](https://www.ti.com/tool/FLASH-PROGRAMMER) (Windows only)
 
 Migrating from a different adapter? Make sure to [copy the ieee address](../faq/README.md#how-do-i-migrate-from-a-cc2530-cc2531-to-a-more-powerful-coordinator-e-g-zzh).


### PR DESCRIPTION
Update README.md with link to [llama-bsl](https://github.com/electrolama/llama-bsl) (developed by omerk of Electrorama ZZH fame) which is fork of cc2538-bsl script but with added features to make it more user-friendly to new users, such as board type detection + automation download of coordinator and router firmware (features that only make sense in a limited context, therefore unlikely to be ever merged into the upstream cc2538-bsl script).