### PR TITLE
Fix CC-Debugger pins image error

### DIFF
--- a/docs/advanced/zigbee/05_create_a_cc2530_router.md
+++ b/docs/advanced/zigbee/05_create_a_cc2530_router.md
@@ -24,9 +24,7 @@ The CC2530 has to be flashed with a router firmware which has to be done with a 
 
 ### CC debugger pin layout
 
-<div style="float: right;">
-  ![CC-Debugger Pins](../../images/ccdebugger_pins.png)
-</div>
+![CC-Debugger Pins](../../images/ccdebugger_pins.png)
 
 | CC debugger | CC2530 |
 | ----------- | ------ |


### PR DESCRIPTION
The CC-Debugger pins image was not displayed due to a faulty div alignment. The alignment therefore was removed.