### PR TITLE
SLZB-05 Zigbee LAN adapter

### DIFF
--- a/docs/guide/adapters/README.md
+++ b/docs/guide/adapters/README.md
@@ -179,7 +179,7 @@ _(in order of first appearance)_
   * <details>
     <summary>XGG 52PZ2MGateway</summary>
   
-    AAn open source Zstack3 gateway powered by ESP8266 and CC2652P modules. One costs less than 60 CNY in China.  
+    An open source Zstack3 gateway powered by ESP8266 and CC2652P modules. One costs less than 60 CNY in China.  
     * [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/master/coordinator/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_launchpad_coordinator_20210708.zip)  
     * [Router firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/master/router/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_launchpad_router_20210128.zip)  
     * [Description](https://z2m.wiki/)  

--- a/docs/guide/adapters/README.md
+++ b/docs/guide/adapters/README.md
@@ -188,9 +188,9 @@ _(in order of first appearance)_
     ![](../../images/CC2652P-Z2M.jpg)
     </details>
   * <details>
-    <summary>SMARTLIGHT ZigBee LAN CC2652P Adapter SLZB-05</summary>
+    <summary>SMARTLIGHT CC2652P ZigBee LAN Adapter SLZB-05</summary>
   
-    Pre-flashed ready-to-use plug&play Zigbee LAN CC2652P Adapter SMARTLIGHT SLZB-05, factory made, metal case, 6dB antenna, available external PoE additional solution, worldwide delivery, Zibee firmware can be updated via USB in 5 steps, customer support, fast order porcessing.  
+    Pre-flashed ready-to-use Zigbee LAN CC2652P Adapter, factory made, metal case, 6dB antenna, worldwide delivery, Zigbee firmware can be manually updated via USB in 5 easy steps, customer/tech support, fast order processing.  
     * [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/master/coordinator/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_other_coordinator_20210708.zip)  
     * [Router firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/master/router/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_other_router_20210708.zip)  
     * [Flashing instructions](https://smartlight.me/flashing_slzb-02)  
@@ -199,7 +199,6 @@ _(in order of first appearance)_
 
     ![](https://smartlight.me/ebay/images/slzb_05/smartlight-zigbee-lan-slzb-05.jpg)
     </details>
-
 
 * Raspberry Pi hat
   * <details>

--- a/docs/guide/adapters/README.md
+++ b/docs/guide/adapters/README.md
@@ -188,7 +188,7 @@ _(in order of first appearance)_
     ![](../../images/CC2652P-Z2M.jpg)
     </details>
   * <details>
-    <summary>SMARTLIGHT CC2652P ZigBee LAN Adapter SLZB-05</summary>
+    <summary>SMARTLIGHT ZigBee LAN Adapter CC2652P Model SLZB-05</summary>
   
     Pre-flashed ready-to-use Zigbee LAN CC2652P Adapter, factory made, metal case, 6dB antenna, worldwide delivery, Zigbee firmware can be manually updated via USB in 5 easy steps, customer/tech support, fast order processing.  
     * [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/master/coordinator/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_other_coordinator_20210708.zip)  

--- a/docs/guide/adapters/README.md
+++ b/docs/guide/adapters/README.md
@@ -89,7 +89,7 @@ _(in order of first appearance)_
     </details>
 
   * <details>
-    <summary>SMARTLIGHT CC2652P Zigbee USB dongle</summary>
+    <summary>SMARTLIGHT CC2652P Zigbee USB Adapter SLZB-02</summary>
   
     CC2652P factory-made Zigbee USB coordinator with external 6dB antenna and worldwide delivery  
     * [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/master/coordinator/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_other_coordinator_20210708.zip)  
@@ -187,6 +187,19 @@ _(in order of first appearance)_
   
     ![](../../images/CC2652P-Z2M.jpg)
     </details>
+  * <details>
+    <summary>SMARTLIGHT ZigBee LAN CC2652P Adapter SLZB-05</summary>
+  
+    Pre-flashed ready-to-use plug&play Zigbee LAN CC2652P Adapter SMARTLIGHT SLZB-05, factory made, metal case, 6dB antenna, available external PoE additional solution, worldwide delivery, Zibee firmware can be updated via USB in 5 steps, customer support, fast order porcessing.  
+    * [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/master/coordinator/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_other_coordinator_20210708.zip)  
+    * [Router firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/master/router/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_other_router_20210708.zip)  
+    * [Flashing instructions](https://smartlight.me/flashing_slzb-02)  
+    * [Description](https://smartlight.me/smart-home-devices/zigbee-devices/smlight-zigbee-lan-adapter-slzb-05en)  
+    * Buy: [eBay](https://www.ebay.com/itm/165178757770) [Official store](https://smartlight.me/smart-home-devices/zigbee-devices/smlight-zigbee-lan-adapter-slzb-05en) [Telegram](https://t.me/smartlightme)
+
+    ![](https://smartlight.me/ebay/images/slzb_05/smartlight-zigbee-lan-slzb-05.jpg)
+    </details>
+
 
 * Raspberry Pi hat
   * <details>

--- a/docs/guide/adapters/README.md
+++ b/docs/guide/adapters/README.md
@@ -188,7 +188,7 @@ _(in order of first appearance)_
     ![](../../images/CC2652P-Z2M.jpg)
     </details>
   * <details>
-    <summary>SMARTLIGHT ZigBee LAN Adapter CC2652P Model SLZB-05</summary>
+    <summary>SMARTLIGHT Zigbee LAN Adapter CC2652P Model SLZB-05</summary>
   
     Pre-flashed ready-to-use Zigbee LAN CC2652P Adapter, factory made, metal case, 6dB antenna, worldwide delivery, Zigbee firmware can be manually updated via USB in 5 easy steps, customer/tech support, fast order processing.  
     * [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/master/coordinator/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_other_coordinator_20210708.zip)  

--- a/docs/guide/adapters/README.md
+++ b/docs/guide/adapters/README.md
@@ -193,7 +193,6 @@ _(in order of first appearance)_
     Pre-flashed ready-to-use Zigbee LAN CC2652P Adapter, factory made, metal case, 6dB antenna, worldwide delivery, Zigbee firmware can be manually updated via USB in 5 easy steps, customer/tech support, fast order processing.  
     * [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/master/coordinator/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_other_coordinator_20210708.zip)  
     * [Router firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/master/router/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_other_router_20210708.zip)  
-    * [Flashing instructions](https://smartlight.me/flashing_slzb-02)  
     * [Description](https://smartlight.me/smart-home-devices/zigbee-devices/smlight-zigbee-lan-adapter-slzb-05en)  
     * Buy: [eBay](https://www.ebay.com/itm/165178757770) [Official store](https://smartlight.me/smart-home-devices/zigbee-devices/smlight-zigbee-lan-adapter-slzb-05en) [Telegram](https://t.me/smartlightme)
 


### PR DESCRIPTION
Added Smartlight's SLZB-05 Zigbee\LAN adapter to the list of supported adapters.