### PR TITLE
Update calibration instructions for Tuya TS130F

### DIFF
--- a/docs/devices/TS130F.md
+++ b/docs/devices/TS130F.md
@@ -31,10 +31,12 @@ Press on stop button for 10 seconds to enter pairing mode
 
 ### Calibration
 
-* Open curtains completely
-* Send calibration command to the switch: mosquitto_pub -d -m 'on' -t 'zigbee2mqtt/Living_Room_Sunblind_Switch/set/calibration'
-* Press on close button on the switch, wait until curtains are fully closed
-* Send calibration command to the switch: mosquitto_pub -d -m 'off' -t 'zigbee2mqtt/Living_Room_Sunblind_Switch/set/calibration'
+* Press the open button on the switch, wait until the curtains are completely open.
+* Press the pause button on the switch.
+* Put the device into calibration mode, see [below](https://www.zigbee2mqtt.io/devices/TS130F.html#calibration-binary).
+* Press the close button on the switch, wait until curtains are fully closed.
+* Press the pause button on the switch.
+* Disable the calibration mode, see [below](https://www.zigbee2mqtt.io/devices/TS130F.html#calibration-binary).
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/TS130F.md
+++ b/docs/devices/TS130F.md
@@ -33,10 +33,10 @@ Press on stop button for 10 seconds to enter pairing mode
 
 * Press the open button on the switch, wait until the curtains are completely open.
 * Press the pause button on the switch.
-* Put the device into calibration mode, see [below](https://www.zigbee2mqtt.io/devices/TS130F.html#calibration-binary).
+* Put the device into calibration mode, see [below](#calibration-binary).
 * Press the close button on the switch, wait until curtains are fully closed.
 * Press the pause button on the switch.
-* Disable the calibration mode, see [below](https://www.zigbee2mqtt.io/devices/TS130F.html#calibration-binary).
+* Disable the calibration mode, see [below](#calibration-binary).
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
According to the instructions of the product, you need to press the "pause" button after fully closed. I tried without it and it did not work, with it all worked perfectly.

I've removed too the mosquitto command to put it into calibration mode, I think it can produce confusion to people. There are easier ways to enable/disable de calibration mode, like using the z2m UI or HA UI.

The LoraTap white-label image of the product is quite different from the Tuya one. Is there a way to add different images for the same product here? Can I simply add another Picture to the table?