### PR TITLE
TS011F_plug_1 - update white label with BW-SHP15

### DIFF
--- a/docs/devices/TS011F_plug_1.md
+++ b/docs/devices/TS011F_plug_1.md
@@ -20,7 +20,7 @@ pageClass: device-page
 | Description | Smart plug (with power monitoring) |
 | Exposes | switch (state), power, current, voltage, energy, power_outage_memory, linkquality |
 | Picture | ![TuYa TS011F_plug_1](https://www.zigbee2mqtt.io/images/devices/TS011F_plug_1.jpg) |
-| White-label | LELLKI TS011F_plug, NEO NAS-WR01B |
+| White-label | LELLKI TS011F_plug, NEO NAS-WR01B, BlitzWolf BW-SHP15 |
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->


### PR DESCRIPTION
Checked and confirmed that BlitzWolf BW-SHP15 plug (discovered as TS011F_plug_1) works with all available options for this device.