### PR TITLE
Conbee II also works with Green Power devices

### DIFF
--- a/docs/devices/PTM_215Z.md
+++ b/docs/devices/PTM_215Z.md
@@ -30,7 +30,7 @@ pageClass: device-page
 ### Green Power
 This is a Zigbee Green Power device which allows it to be very energy efficient.
 Messages from Green Power devices cannot be "understood" by normal Zigbee devices, therefore they need to be "translated" first.
-Not all Zigbee devices can do this translation, currently the only devices known to do this are Philips Hue devices. This means that the Green Power device has to be in range of a Philips Hue device in order to use it.
+Not all Zigbee devices can do this translation, currently the only devices known to do this are Philips Hue devices and the Conbee II stick. This means that the Green Power device has to be in range of a Philips Hue device or the Conbee II stick in order to use it.
 
 Green Power devices don't support binding and are not included in network scans.
 
@@ -64,6 +64,7 @@ Alternatively, you should be able to reset the switch with the following pattern
 2. Press and hold top right (B0) for about 10 seconds 
 3. press top right (B0) and bottom left (A1) at the same time 
 4. press top left (A0)
+
 Note: Please make sure the module is positioned the right way up.
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
I wanted to know if the Conbee II stick could also handle Green Power devices. So this is what I did:

I unscrew all Hue bulbs in my house, also unscrew any other lights (ikea) that I could easily reach. Then turned off the mains power to every room that had smart devices in it (built-in smart dimmers, smart plugs) which also shut down my Hue Bridge.
By now, my server (with HA and Zigbee2MQTT and Conbee II stick) and network equipment (switch, router, modem) were running on the UPS.
I then got into HA on my tablet and went to Node Red and switched to the tab where I could see the messages from the debug nodes, so I could see the clicks on the Senic switch come in.
And clicking it worked! So I can hereby confirm that the Conbee II stick also handles green power devices.

(Also added a newline more to the end)