### PR TITLE
Update ZB003-X.md

### DIFF
--- a/docs/devices/ZB003-X.md
+++ b/docs/devices/ZB003-X.md
@@ -24,6 +24,9 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Notes
+Device accepting setting change only when powered via USB cable. 
+Battery powered device just ignore any changes like Reporting_time, Temperature_calibration, Pir_enable, etc.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/ZB003-X.md
+++ b/docs/devices/ZB003-X.md
@@ -25,9 +25,9 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
 ## Notes
-Device accepting setting change only when powered via USB cable. 
-Battery powered device just ignore any changes like Reporting_time, Temperature_calibration, Pir_enable, etc.
 
+### Setting device options
+Setting options (e.g. `illuminance_calibration`) is only possible when the device is powered via an USB cable.
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
Device accepting setting change only when powered via USB cable. 
Battery powered device just ignore any changes like Reporting_time, Temperature_calibration, Pir_enable, etc.