### PR TITLE
Add a note about pressing a button on the remote prior to binding

### DIFF
--- a/docs/devices/E1524_E1810.md
+++ b/docs/devices/E1524_E1810.md
@@ -41,6 +41,8 @@ The [binding](../guide/usage/binding.md) functionallity of this remote varies pe
 - 2.3.014 - 2.3.74: suppports binding to groups only. It can only be bound to 1 group at a time. By default this remote is bound to the default bind group which you first have to unbind it from. This can be done by sending to `zigbee2mqtt/bridge/request/device/unbind` payload `{"from": "DEVICE_FRIENDLY_NAME", "to": "default_bind_group"}`. Wake up the device right before sending the commands by pressing a button on it.
 - 2.3.75 and greater : supports binding to devices only
 
+**Note:** Prior to sending a 'bind' command using an MQTT message directly or through the frontend, push a button on the remote to wake it up. Otherwise, the remote will not be in a receiving state and the bind will fail with a general 'error'.
+
 Once bound to a group/bulb you will notice that the toggle and brightness buttons will work, but scenes/color temperature most likely won't work. This appears to be a missing piece of functionality ([discussion](https://github.com/Koenkk/zigbee2mqtt/issues/1232)), but via a workaround this can be managed;
 1. Create a group with ID **65289** (name it ie. Trafri_scenes) and add the device(s) you control with the remote.
 2. Add/store [scenes](../guide/usage/scenes.md) for the created group


### PR DESCRIPTION
For IKEA Tradfri E1810 remote.