### PR TITLE
Avoid useless sudo commands in Linux installation

### DIFF
--- a/docs/guide/installation/01_linux.md
+++ b/docs/guide/installation/01_linux.md
@@ -29,7 +29,7 @@ lrwxrwxrwx. 1 root root 13 Oct 19 19:26 usb-Texas_Instruments_TI_CC2531_USB_CDC_
 ## Installing
 ```bash
 # Setup Node.js repository
-sudo curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 
 # NOTE 1: If you see the message below please follow: https://gist.github.com/Koenkk/11fe6d4845f5275a2a8791d04ea223cb.
 # ## You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later.
@@ -46,8 +46,8 @@ node --version  # Should output v10.X, v12.X, v14.X, v15.X or V16.X
 npm --version  # Should output 6.X or 7.X
 
 # Clone Zigbee2MQTT repository
-sudo git clone https://github.com/Koenkk/zigbee2mqtt.git /opt/zigbee2mqtt
-sudo chown -R pi:pi /opt/zigbee2mqtt
+git clone https://github.com/Koenkk/zigbee2mqtt.git
+sudo mv zigbee2mqtt /opt/zigbee2mqtt
 
 # Install dependencies (as user "pi")
 cd /opt/zigbee2mqtt

--- a/docs/guide/installation/01_linux.md
+++ b/docs/guide/installation/01_linux.md
@@ -28,17 +28,10 @@ lrwxrwxrwx. 1 root root 13 Oct 19 19:26 usb-Texas_Instruments_TI_CC2531_USB_CDC_
 
 ## Installing
 ```bash
-# Setup Node.js repository
-curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
-
-# NOTE 1: If you see the message below please follow: https://gist.github.com/Koenkk/11fe6d4845f5275a2a8791d04ea223cb.
-# ## You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later.
-# IMPORTANT: In this case instead of the apt-get install mentioned below; do: sudo apt-get install -y git make g++ gcc
-
-# NOTE 2: On x86, Node.js 10 may not work. It's recommended to install an unofficial Node.js 14 build which can be found here: https://unofficial-builds.nodejs.org/download/release/ (e.g. v14.16.0)
-
-# Install Node.js
-sudo apt-get install -y nodejs git make g++ gcc
+# Install Node.js and required dependencies
+# In Debian/Raspbian bullseye and up (11 and up), NodeJS v12.X is packaged, this is the safest method of installing NodeJS (from official repositories) for Zigbee2MQTT.
+# Check https://github.com/nodesource/distributions/blob/master/README.md if you want to install a specific version from NodeJS repositories instead.
+sudo apt-get install -y nodejs npm git make g++ gcc
 
 # Verify that the correct nodejs and npm (automatically installed with nodejs)
 # version has been installed


### PR DESCRIPTION
Hi,

It seems there are quite a few `sudo` commands which are useless in the Linux installation guide:

- [x] Calling `sudo curl` is not required, `curl` is enough. This is especially critical since `curl` is making an outgoing HTTP request and might be vulnerable (CVE, etc.), so you definitely do not want exposing `curl` with elevated privileges.
- [x] Same apply for `git`, you can simply call `git` with user `pi` and `mv` afterwards (this spares as well the `chown` command, since `pi` is the right owner in the end).
- [x] In Raspbian 11 (bullseye), the Node version from the repos is `v12.22.5`, which seems to be fine for running Zigbee2MQTT. Using the official version would spare a risky `curl | sudo bash` and rely on the security of Debian repos.

If last point sounds fine for you, we could further replace

```bash
curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
# NOTE 1: If you see the message below please follow: https://gist.github.com/Koenkk/11fe6d4845f5275a2a8791d04ea223cb.
# ## You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later.
# IMPORTANT: In this case instead of the apt-get install mentioned below; do: sudo apt-get install -y git make g++ gcc
# NOTE 2: On x86, Node.js 10 may not work. It's recommended to install an unofficial Node.js 14 build which can be found here: https://unofficial-builds.nodejs.org/download/release/ (e.g. v14.16.0)
# Install Node.js
sudo apt-get install -y nodejs git make g++ gcc
```

by the single line

```bash
sudo apt-get install -y nodejs npm git make g++ gcc
```


Best