### PR TITLE
Add documentation for OTA index override functionality

### DIFF
--- a/docs/guide/configuration/ota-device-updates.md
+++ b/docs/guide/configuration/ota-device-updates.md
@@ -27,10 +27,10 @@ ota:
     zigbee_ota_override_index_location: my_index.json
 ```
 
-Value of this key is a file name in the configuration directory (next to configuration.yaml).
-The file name could be also a full path to the file, taking into account that host file system may not be available when running zigbee2mqtt inside a docker container.
+Value of this key is a file name in the configuration directory (next to `configuration.yaml`).
+The file name could be also a full path to the file, taking into account that host file system may not be available when running Zigbee2MQTT inside a docker container.
 
-Alternatively, zigbee2mqtt supports index files located on a remote HTTP(s) server. In this case `zigbee_ota_override_index_location` key should be an URL of the index file.
+Alternatively, Zigbee2MQTT supports index files located on a remote HTTP(s) server. In this case `zigbee_ota_override_index_location` key should be an URL of the index file.
 
-Please refer to [OTA firmware update usage guide](../usage/ota_updates.md) for more details how zigbee2mqtt fetches OTA images,
+Please refer to [OTA firmware update usage guide](../usage/ota_updates.md) for more details how Zigbee2MQTT fetches OTA images,
 how to add an image for a DIY device, or how to override official images with other ones.

--- a/docs/guide/configuration/ota-device-updates.md
+++ b/docs/guide/configuration/ota-device-updates.md
@@ -19,3 +19,18 @@ advanced:
   # Optional: use IKEA TRADFRI OTA test server, see OTA updates documentation (default: false)
   ikea_ota_use_test_url: false
 ```
+
+## OTA Index override file
+
+```yaml
+ota:
+    zigbee_ota_override_index_location: my_index.json
+```
+
+Value of this key is a file name in the configuration directory (next to configuration.yaml).
+The file name could be also a full path to the file, taking into account that host file system may not be available when running zigbee2mqtt inside a docker container.
+
+Alternatively, zigbee2mqtt supports index files located on a remote HTTP(s) server. In this case `zigbee_ota_override_index_location` key should be an URL of the index file.
+
+Please refer to [OTA firmware update usage guide](../usage/ota_updates.md) for more details how zigbee2mqtt fetches OTA images,
+how to add an image for a DIY device, or how to override official images with other ones.

--- a/docs/guide/usage/ota_updates.md
+++ b/docs/guide/usage/ota_updates.md
@@ -65,21 +65,20 @@ advanced:
 
 ## Overriding OTA index files
 
-OTA Index file is a list of firmware images available on a particular server. When checking if an update is available, zigbee2mqtt determines current hardware and firmware version for a particular device, and then searches for a suitable upgrade image in the index file. Some vendors (such as IKEA Tradfri, Ledvance, Salus, Ubisys) use their proprietary index files, but the most of the devices use [Zigbee-OTA](https://github.com/Koenkk/zigbee-OTA) firmware repository with a [main index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index.json).
+OTA Index file is a list of firmware images available on a particular server. When checking if an update is available, Zigbee2MQTT determines current hardware and firmware version for a particular device, and then searches for a suitable upgrade image in the index file. Some vendors (such as IKEA Tradfri, Ledvance, Salus, Ubisys) use their proprietary index files, but the most of the devices use [Zigbee-OTA](https://github.com/Koenkk/zigbee-OTA) firmware repository with a [main index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index.json).
 
-Sometimes it is necessary to add a firmware image that is not on the main index. This could be helpful when developing a DIY device, or install a test/alternate image for a mass-produced device. In this case user can supply zigbee2mqtt with an alternate index file, located locally or on a web server. This index file will point zigbee2mqtt to the firmware image files. Records in the override OTA index file will override corresponding records in the main index, so that it is possible to alter the image for a particular device type.
+Sometimes it is necessary to add a firmware image that is not on the main index. This could be helpful when developing a DIY device, or install a test/alternate image for a mass-produced device. In this case user can supply Zigbee2MQTT with an alternate index file, located locally or on a web server. This index file will point Zigbee2MQTT to the firmware image files. Records in the override OTA index file will override corresponding records in the main index, so that it is possible to alter the image for a particular device type.
 
 ```yaml
 ota:
     zigbee_ota_override_index_location: my_index.json
 ```
 
-Local index file is searched in the configuration directory (next to configuration.yaml).The file name could be also a full path to the file, taking into account that host file system may not be available when running zigbee2mqtt inside a docker container. Alternatively, zigbee2mqtt supports index files located on a remote HTTP(s) server. In this case `zigbee_ota_override_index_location` key should be an URL of the index file.
+Local index file is searched in the configuration directory (next to `configuration.yaml`).The file name could be also a full path to the file, taking into account that host file system may not be available when running Zigbee2MQTT inside a docker container. Alternatively, Zigbee2MQTT supports index files located on a remote HTTP(s) server. In this case `zigbee_ota_override_index_location` key should be an URL of the index file.
 
 The override OTA index file shall have the same structure as the [main index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index.json). To create the index file it is possible to use add.js script (follow instructions [here](https://github.com/Koenkk/zigbee-OTA)). Correct image location and image URL as necessary.
 
-Note: Firmware images must be located on a web server. You can use a simple python http server for this. Support of local firmware image files is not yet implemented.
-
+Note: Firmware images must be located on a web server. You can use a simple Python http server for this. Support of local firmware image files is not yet implemented.
 
 ## Troubleshooting
 - `Device didn't respond to OTA request` or `Update failed with reason: 'aborted by device'`: try restarting the device by disconnecting the power/battery for a few seconds and try again.

--- a/docs/guide/usage/ota_updates.md
+++ b/docs/guide/usage/ota_updates.md
@@ -63,6 +63,24 @@ advanced:
   ikea_ota_use_test_url: true
 ```
 
+## Overriding OTA index files
+
+OTA Index file is a list of firmware images available on a particular server. When checking if an update is available, zigbee2mqtt determines current hardware and firmware version for a particular device, and then searches for a suitable upgrade image in the index file. Some vendors (such as IKEA Tradfri, Ledvance, Salus, Ubisys) use their proprietary index files, but the most of the devices use [Zigbee-OTA](https://github.com/Koenkk/zigbee-OTA) firmware repository with a [main index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index.json).
+
+Sometimes it is necessary to add a firmware image that is not on the main index. This could be helpful when developing a DIY device, or install a test/alternate image for a mass-produced device. In this case user can supply zigbee2mqtt with an alternate index file, located locally or on a web server. This index file will point zigbee2mqtt to the firmware image files. Records in the override OTA index file will override corresponding records in the main index, so that it is possible to alter the image for a particular device type.
+
+```yaml
+ota:
+    zigbee_ota_override_index_location: my_index.json
+```
+
+Local index file is searched in the configuration directory (next to configuration.yaml).The file name could be also a full path to the file, taking into account that host file system may not be available when running zigbee2mqtt inside a docker container. Alternatively, zigbee2mqtt supports index files located on a remote HTTP(s) server. In this case `zigbee_ota_override_index_location` key should be an URL of the index file.
+
+The override OTA index file shall have the same structure as the [main index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index.json). To create the index file it is possible to use add.js script (follow instructions [here](https://github.com/Koenkk/zigbee-OTA)). Correct image location and image URL as necessary.
+
+Note: Firmware images must be located on a web server. You can use a simple python http server for this. Support of local firmware image files is not yet implemented.
+
+
 ## Troubleshooting
 - `Device didn't respond to OTA request` or `Update failed with reason: 'aborted by device'`: try restarting the device by disconnecting the power/battery for a few seconds and try again.
 - For battery powered devices make sure that the battery is 70%+ as OTA updating is very power consuming.


### PR DESCRIPTION
Supporting documentation for OTA image override functionality (see https://github.com/Koenkk/zigbee-herdsman-converters/pull/3495 and https://github.com/Koenkk/zigbee2mqtt/pull/10141)