### PR TITLE
Add documentation for local OTA firmware files

### DIFF
--- a/docs/guide/usage/ota_updates.md
+++ b/docs/guide/usage/ota_updates.md
@@ -63,7 +63,7 @@ advanced:
   ikea_ota_use_test_url: true
 ```
 
-## Overriding OTA index files
+## Local OTA index and firmware files
 
 OTA Index file is a list of firmware images available on a particular server. When checking if an update is available, Zigbee2MQTT determines current hardware and firmware version for a particular device, and then searches for a suitable upgrade image in the index file. Some vendors (such as IKEA Tradfri, Ledvance, Salus, Ubisys) use their proprietary index files, but the most of the devices use [Zigbee-OTA](https://github.com/Koenkk/zigbee-OTA) firmware repository with a [main index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index.json).
 
@@ -74,11 +74,22 @@ ota:
     zigbee_ota_override_index_location: my_index.json
 ```
 
-Local index file is searched in the configuration directory (next to `configuration.yaml`).The file name could be also a full path to the file, taking into account that host file system may not be available when running Zigbee2MQTT inside a docker container. Alternatively, Zigbee2MQTT supports index files located on a remote HTTP(s) server. In this case `zigbee_ota_override_index_location` key should be an URL of the index file.
+Local index file is searched in the configuration directory (next to `configuration.yaml`). The file name could be also a full path to the file, taking into account that host file system may not be available when running Zigbee2MQTT inside a docker container. Alternatively, Zigbee2MQTT supports index files located on a remote HTTP(s) server. In this case `zigbee_ota_override_index_location` key should be an URL of the index file.
 
 The override OTA index file shall have the same structure as the [main index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index.json). To create the index file it is possible to use add.js script (follow instructions [here](https://github.com/Koenkk/zigbee-OTA)). Correct image location and image URL as necessary.
 
-Note: Firmware images must be located on a web server. You can use a simple Python http server for this. Support of local firmware image files is not yet implemented.
+Firmware files can be located either on a web server, or on the local file system. In this case `url` field in the index file entry shall be either a full path to the image file, or relative to the Zigbee2MQTT configuration directory. In case of local image file, index entry can be simplified and look like this
+
+```json
+[
+    {
+        "fileVersion": 2,
+        "manufacturerCode": 4151,
+        "imageType": 1,
+        "url": "HelloZigbee.ota"
+    }
+]
+```
 
 ## Troubleshooting
 - `Device didn't respond to OTA request` or `Update failed with reason: 'aborted by device'`: try restarting the device by disconnecting the power/battery for a few seconds and try again.


### PR DESCRIPTION
This is supporting documentation for [this](https://github.com/Koenkk/zigbee2mqtt/pull/10676) and [this](https://github.com/Koenkk/zigbee-herdsman-converters/pull/3652) - a support for local OTA firmware files.