### PR TITLE
Update 01_linux.md for i386 hardware

### DIFF
--- a/docs/guide/installation/01_linux.md
+++ b/docs/guide/installation/01_linux.md
@@ -29,7 +29,7 @@ lrwxrwxrwx. 1 root root 13 Oct 19 19:26 usb-Texas_Instruments_TI_CC2531_USB_CDC_
 ## Installing
 ```bash
 # Install Node.js and required dependencies
-# In Debian/Raspbian bullseye and up (11 and up), NodeJS v12.X is packaged, this is the safest method of installing NodeJS (from official repositories) for Zigbee2MQTT.
+# In Debian/Raspbian bullseye and up (11 and up), NodeJS v12.X is packaged, this is the safest method of installing NodeJS (from official repositories) for Zigbee2MQTT. Older i386 hardware can work with [unofficial-builds.nodejs.org](https://unofficial-builds.nodejs.org/download/release/v12.16.3/ e.g. Version 12.16.3 should work.
 # Check https://github.com/nodesource/distributions/blob/master/README.md if you want to install a specific version from NodeJS repositories instead.
 sudo apt-get install -y nodejs npm git make g++ gcc
 


### PR DESCRIPTION
i386 hardware has no official node support anymore. But it's still working.