### PR TITLE
Update 4058075208421.md .Correction of name. Name is NOT "tunable" but "dimmable"  (if model is OKE??!!)

### DIFF
--- a/docs/devices/4058075208421.md
+++ b/docs/devices/4058075208421.md
@@ -17,7 +17,7 @@ pageClass: device-page
 |-----|-----|
 | Model | 4058075208421  |
 | Vendor  | LEDVANCE  |
-| Description | SMART+ candle E14 tunable white |
+| Description | SMART+ candle E14 dimmable white |
 | Exposes | light (state, brightness), effect, linkquality |
 | Picture | ![LEDVANCE 4058075208421](https://www.zigbee2mqtt.io/images/devices/4058075208421.jpg) |
 


### PR DESCRIPTION
Correction of name of LEDVANCE model 4058075208421  The name is NOT "tunable" but " dimmable"  (if model is OKE??!!)

According to de Ledvance site the name of model 4058075208421 is differently. It IS NOT the "tunable" model 4058075208414 but the "dimmable" model 4058075208421. See:
https://shop.ledvance.com/en/products/ledvance-smart-led-zigbee-lampe-mit-e14-sockel-warmweiss-dimmbar-direkt-kompatibel-mit-echo-plus-und-echo-show-2-gen-kompatibel-mit-philips-hue-bridge

I paired under HA/CC2531/zigbee2MQTT the LEDVANCE "SMART+ bulb E27 dimmable white" which is NOT supported according to the zigbe2mqtt site. 
It first gave a message "unsupported" and then paired successfully as model: 4058075208421. The bulb works OKE, but I assume it is a paired to the wrong model "SMART+ candle E14 dimmable white"  4058075208421.
I can provide more info if needed. 
See:  https://shop.ledvance.com/en/products/ledvance-smart-led-zigbee-lampe-mit-e27-sockel-warmweiss-dimmbar-direkt-kompatibel-mit-echo-plus-und-echo-show-2-gen-kompatibel-mit-philips-hue-bridge?variant=41260721537205

With the pair of LEDVANCE "SMART+ bulb E27 dimmable white" I get: friendly_name":"0xf0d1b800001b7090"
Do not know why it is "not friendly":  Due to the pair to another model or it is not "set" OKE?   

Can provide more info if you want to add the "SMART+ bulb E27 dimmable white" as a "correct" supported model.