### PR TITLE
Update SJCGQ11LM.md

### DIFF
--- a/docs/devices/SJCGQ11LM.md
+++ b/docs/devices/SJCGQ11LM.md
@@ -18,7 +18,7 @@ pageClass: device-page
 | Model | SJCGQ11LM  |
 | Vendor  | Xiaomi  |
 | Description | Aqara water leak sensor |
-| Exposes | battery, water_leak, battery_low, voltage, temperature, linkquality |
+| Exposes | battery, water_leak, battery_low, voltage, tamper, linkquality |
 | Picture | ![Xiaomi SJCGQ11LM](https://www.zigbee2mqtt.io/images/devices/SJCGQ11LM.jpg) |
 
 
@@ -63,11 +63,11 @@ Value can be found in the published state on the `voltage` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The unit of this value is `mV`.
 
-### Temperature (numeric)
-Measured temperature value.
-Value can be found in the published state on the `temperature` property.
+### Tamper (binary)
+Indicates whether the device is tampered.
+Value can be found in the published state on the `tamper` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
-The unit of this value is `°C`.
+If value equals `true` tamper is ON, if `false` OFF.
 
 ### Linkquality (numeric)
 Link quality (signal strength).


### PR DESCRIPTION
In the current Version it is mentioned that this device is measuring the temperature. But it has, as the other xioami water leak device SJCGQ12LM an attribute tamper with a true false value. So I wanted to correct this in the document