### PR TITLE
Update HG06335.md

### DIFF
--- a/docs/devices/HG06335.md
+++ b/docs/devices/HG06335.md
@@ -34,7 +34,7 @@ While pairing, keep the motion detector close to the adapter.
 Press the tamper button a few times while pairing to keep the sensor a wake.
 
 ### Tamper
-If the button on the back is pressed (i.e. the device is on the mounting plate), the value of `tamper` equals `true` otherwise it is `false`.
+If the button on the back is pressed (i.e. the device is on the mounting plate), the value of `tamper` equals `false` otherwise it is `true`.
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
Will be added as "Modell HG06335/HG07310". Because of that the sensor has no picture and the model hyperlink goes to https://www.zigbee2mqtt.io/devices/HG06335_HG07310.html#lidl-hg06335%252Fhg07310 instead of https://www.zigbee2mqtt.io/devices/HG06335.html.
Fixed tamper description. False = button pressed = no tamper.