### PR TITLE
Add warning in notes about Livolo device requiring channel 26

### DIFF
--- a/docs/devices/TI0001-cover.md
+++ b/docs/devices/TI0001-cover.md
@@ -25,6 +25,26 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
 
+### Important
+These devices can only be used on channel 26.
+These devices are locked to the manufacturer's network key (ext_pan_id).
+Your configuration file [data/configuration.yaml](../guide/configuration/) must contain the following:
+
+```yaml
+advanced:
+  ext_pan_id: [33,117,141,25,0,75,18,0]
+  channel: 26
+```
+
+Therefore these devices may not co-existence with other Zigbee devices.
+Maybe, you need to add a dedicated coordinator and create a new network for Livolo.
+If you decided to create a new network, you should specify another 'pan_id'.
+
+```yaml
+advanced:
+  pan_id: 6756
+```
+
 ### Pairing
 Press the buttons "down" and "settings" together for 3 seconds and it blinks red and blue in pairing mode.
 <!-- Notes END: Do not edit below this line -->


### PR DESCRIPTION
As with the Livolo TI0001 light switch, this device should include a warning in the notes that it requires the coordinator uses channel 26 and a specific PAN ID.