### PR TITLE
Update ZL100050004 with correct product image

### DIFF
--- a/docs/devices/ZL100050004.md
+++ b/docs/devices/ZL100050004.md
@@ -19,7 +19,7 @@ pageClass: device-page
 | Vendor  | Linkind  |
 | Description | Zigbee LED 7.4W BR30 bulb E26, dimmable & tunable |
 | Exposes | light (state, brightness, color_temp, color_temp_startup), effect, linkquality |
-| Picture | ![Linkind ZL100050004](https://www.zigbee2mqtt.io/images/devices/ZL100050004.jpg) |
+| Picture | ![Linkind_ZL100050004](https://user-images.githubusercontent.com/23405764/153729256-d5e5a061-abe4-4e72-9343-610cb6938ece.jpg) |
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
@@ -82,4 +82,5 @@ Value can be found in the published state on the `linkquality` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `255`.
 The unit of this value is `lqi`.
+
 


### PR DESCRIPTION
The bulb type is BR30 and the bulb shown is an A-series type. Inline image added.