### PR TITLE
update Enbrighten 43082 documentation

### DIFF
--- a/docs/devices/43082.md
+++ b/docs/devices/43082.md
@@ -23,8 +23,20 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
 
+### LED status indicator
+To change the LED status indicator press the top of rocker 3 times and then the bottom of the rocker 1 time. This will cycle between these modes:
+1. LED is ON when the load if OFF (Default)
+2. LED is ON when the load if ON
+3. LED is always OFF
+
+### Pairing
+Factory reset the dimmer by pressing the top of the rocker 10 times quickly.
+
+### Binding
+This device does not support [binding](../guide/usage/binding.md) to groups. It does support binding to devices.
 <!-- Notes END: Do not edit below this line -->
 
 
@@ -68,4 +80,3 @@ Value can be found in the published state on the `linkquality` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `255`.
 The unit of this value is `lqi`.
-


### PR DESCRIPTION
Update the documentation for Enbrighten 43082, partially as a result of https://github.com/Koenkk/zigbee2mqtt/issues/11527. 

LED status indicator and pairing sections copied from Enbrighten 43080, verified with the user manual that came with my switches.