### PR TITLE
[DOCS] Fix dashes that should be underscores in action

### DIFF
--- a/docs/devices/324131092621.md
+++ b/docs/devices/324131092621.md
@@ -88,7 +88,7 @@ The unit of this value is `%`.
 Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
-The possible values are: `on-press`, `on-hold`, `on-hold-release`, `up-press`, `up-hold`, `up-hold-release`, `down-press`, `down-hold`, `down-hold-release`, `off-press`, `off-hold`, `off-hold-release`.
+The possible values are: `on_press`, `on_hold`, `on_hold_release`, `up_press`, `up_hold`, `up_hold_release`, `down_press`, `down_hold`, `down_hold_release`, `off_press`, `off_hold`, `off_hold_release`.
 
 ### Action_duration (numeric)
 Value can be found in the published state on the `action_duration` property.


### PR DESCRIPTION
As we can see, the actual published values from the Philips 324131092621 remote use underscores:

<img width="567" alt="Screen Shot 2022-02-22 at 8 06 43 AM" src="https://user-images.githubusercontent.com/255023/155138356-2267067d-4bec-439f-a6dd-0d2766e5c722.png">
