### PR TITLE
Update AC26940_AC31266.md

### DIFF
--- a/docs/devices/AC26940_AC31266.md
+++ b/docs/devices/AC26940_AC31266.md
@@ -17,7 +17,7 @@ pageClass: device-page
 |-----|-----|
 | Model | AC26940/AC31266  |
 | Vendor  | LEDVANCE  |
-| Description | Smart Zigbee outdoor plug |
+| Description | Smart Zigbee outdoor plug/Smart+ Nightlight plug |
 | Exposes | switch (state), linkquality |
 | Picture | ![LEDVANCE AC26940/AC31266](https://www.zigbee2mqtt.io/images/devices/AC26940-AC31266.jpg) |
 


### PR DESCRIPTION
It seems that Ledvance uses the same identifier for multiple devices. I've got an Ledvance Smart+ Nightlight Plug which identifies as LEDVANCE AC26940/AC31266. I've updated the device file (not sure if that's the correct way though, due to the warning that this page was auto-generated (but I can't find the source)).

The referenced image should maybe also be changed.

Here's the link: https://lb.ledvance.de/consumer/produkte/smart-home/smart-home-produkte-mit-zigbee-technologie/smart-home-komponenten/smart-nightlight-plug/index.jsp