### PR TITLE
Fix incorrect markdown in Niko Switch pages

### DIFF
--- a/docs/devices/552-721X1.md
+++ b/docs/devices/552-721X1.md
@@ -35,6 +35,8 @@ This device does not support binding to groups or devices.
 This device does support decoupling from the build in relay, when the device is decoupled it will emit a 'single', 'hold', and 'release' action.
 
 ### LED
+| LED | Description |
+|-----|-----|
 | off | normal operation, the load is off |
 | white continues | normal operation, the load is on |
 | red flashing | connection to the zigbee network lost |

--- a/docs/devices/552-721X2.md
+++ b/docs/devices/552-721X2.md
@@ -35,6 +35,8 @@ This device does not support binding to groups or devices.
 This device does support decoupling from the build in relay, when the device is decoupled it will emit a 'single', 'hold', and 'release' action.
 
 ### LED
+| LED | Description |
+|-----|-----|
 | off | normal operation, the load is off |
 | white continues | normal operation, the load is on |
 | red flashing | connection to the zigbee network lost |


### PR DESCRIPTION
Looks like without the header the table does not render correctly.