### PR TITLE
Correct indentation for external_converters

### DIFF
--- a/docs/advanced/support-new-devices/01_support_new_devices.md
+++ b/docs/advanced/support-new-devices/01_support_new_devices.md
@@ -51,8 +51,8 @@ Now set the Zigbee2MQTT `log_level` to `debug` and enable the external converter
 ```yaml
 advanced:
   log_level: debug
-external_converters:
-  - WSDCGQ01LM.js
+  external_converters:
+    - WSDCGQ01LM.js
 ```
 
 Once finished, restart Zigbee2MQTT and trigger some actions on the device. You will see messages like:


### PR DESCRIPTION
Z2M wouldn't start without 'external_converters' being indented