### PR TITLE
Adapters config notes

### DIFF
--- a/docs/guide/getting-started/README.md
+++ b/docs/guide/getting-started/README.md
@@ -11,7 +11,7 @@ In order to use Zigbee2MQTT we need the following hardware:
 
 1. <img src="../../images/zzh.jpg" title="ZZH" class="float-left" /> **A Zigbee Adapter** which is the interface between the Computer (or Server) where you run Zigbee2MQTT and the Zigbee radio
 communication. Zigbee2MQTT supports a variety of adapters with different kind of connections like USB, GPIO or remote via WIFI or Ethernet.
-  Recommended adapters have a chip starting with CC2652 or CC1352. See [supported Adapters](../adapters/README.md). <br class="clear" />
+  Recommended adapters have a chip starting with CC2652 or CC1352. See [supported Adapters](../adapters/README.md). It's recommended to check out your adapter's recommendation details before the installation process, to find out whether it needs any additional configuration parameters. <br class="clear" />
 
 2. <img src="../../images/pi.jpg" title="Raspberry Pi" class="float-left" /> **A Server** where you would run Zigbee2MQTT. Most Raspberry-Pi models are known to work but you can run it on many computers and platforms including Linux, Windows an MacOS. It should have an MQTT broker installed. [Mosquitto](https://www.mosquitto.org/download/) ([Tutorial for Raspberry-Pi](https://randomnerdtutorials.com/how-to-install-mosquitto-broker-on-raspberry-pi/)) is the recommended MQTT broker but [others](https://mqtt.org/software/) should also work fine. <br class="clear" />
 

--- a/docs/guide/installation/01_linux.md
+++ b/docs/guide/installation/01_linux.md
@@ -63,7 +63,7 @@ Open the configuration file:
 nano /opt/zigbee2mqtt/data/configuration.yaml
 ```
 
-For a basic configuration, the default settings are probably good. The only thing we need to change is the MQTT server url/authentication and the serial port. This can be done by changing the section below in your `configuration.yaml`.
+For a basic configuration, the default settings are probably good. The only thing we need to change is the MQTT server url/authentication and the serial port (in some cases, your adapter might need additional configuration parameters, see [supported Adapters](../adapters/README.md)). This can be done by changing the section below in your `configuration.yaml`.
 
 ```yaml
 # MQTT settings

--- a/docs/guide/installation/01_linux.md
+++ b/docs/guide/installation/01_linux.md
@@ -19,7 +19,7 @@ pi@raspberry:~ $ ls -l /dev/ttyACM0
 crw-rw---- 1 root dialout 166, 0 May 16 19:15 /dev/ttyACM0  # <-- adapter (CC2531 in this case) on /dev/ttyACM0
 ```
 
-As an alternative, the device can also be mapped by an ID. This can be handy if you have multiple serial devices connected to your Raspberry Pi. In the example below the device location is: `/dev/serial/by-id/usb-Texas_Instruments_TI_CC2531_USB_CDC___0X00124B0018ED3DDF-if00`
+However, it is **recommended** to use "by ID" mapping of the device (see [Adapter settings](../configuration/adapter-settings.md)). This kind of device path mapping is more stable, but can also be handy if you have multiple serial devices connected to your Raspberry Pi. In the example below the device location is: `/dev/serial/by-id/usb-Texas_Instruments_TI_CC2531_USB_CDC___0X00124B0018ED3DDF-if00`
 ```bash
 pi@raspberry:/ $ ls -l /dev/serial/by-id
 total 0

--- a/docs/guide/installation/20_zigbee2mqtt-fails-to-start.md
+++ b/docs/guide/installation/20_zigbee2mqtt-fails-to-start.md
@@ -10,7 +10,7 @@ Most of the time this is caused by Zigbee2MQTT not being able to communicate wit
 
 ## Error: `SRSP - SYS - ping after 6000ms`
 
-2 common reasons of this error:
+3 common reasons of this error:
 
 1. The port of your serial adapter changed.
    Check [this](../installation/01_linux.md#1-determine-location-of-the-adapter-and-checking-user-permissions) to find
@@ -18,6 +18,7 @@ Most of the time this is caused by Zigbee2MQTT not being able to communicate wit
 2. If you are using a CC2530 or CC2531; it is a common issue for this adapter to crash (due to its outdated hardware).
    Reflashing the firmware should fix the problem. If it happens often consider flashing the [source routing firmware](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_Home_1.2/bin/source_routing) or upgrade to
    a [more powerful adapter](../adapters/README.md).
+3. Your adapter requires additional configuration parameters. Check [supported Adapters](../adapters/README.md) section to find out if your adapter requires extra parameters (eg. ConBee II / RaspBee II).
 
 ## Verify that you put the correct port in configuration.yaml
 


### PR DESCRIPTION
During my latest migration to Z2M I've struggled a bit with the initial configuration of the bridge, which later on turned out to be a simple missing param for my ConBee II adapter. However, it was easier to find a solution for this by going through various HA-specific problem threads on their forum, rather to find that being mentioned in this documentation.

I think it wouldn't hurt to mention it a bit more prominently in the "Getting started" and "Installation" sections, to let users know that besides the usual config, there might be this or that parameter required for their specific adapter. Therefore, let's recommend that they should venture to the `Supported Hardware > Adapters` section to find that out before they run into any troubles (or at least provide a quick guidance if they already did). I've also added a mention about adapter's specific config in "Zigbee2MQTT fails to start" section.

In addition to that, I took the liberty of mentioning the recommended way of configuring adapter's device path using the "by ID" mapping. The recommendation was already there, in the "Configuration > Adapter settings" section, but I think it would be better to mention it right away during the installation process, to promote the best practice right from the start, rather than an afterthought.