### PR TITLE
Update PTM_216Z.md

### DIFF
--- a/docs/devices/PTM_216Z.md
+++ b/docs/devices/PTM_216Z.md
@@ -33,6 +33,9 @@ Not all Zigbee devices can do this translation, currently the only devices known
 
 Green Power devices don't support binding and are not included in network scans.
 
+Binding may work between this module and the actuator, depending if the actuator supports the Zigbee Green Power standard & if the actuators user interface supports "Finding & binding" or "EZ-mode". For more information, contact the supplier of the actuator.
+
+
 ### Pairing
 This device has 4 buttons:
 


### PR DESCRIPTION
I received confirmation from Ubisys that their
D1
S2
C4
... modules support direct binding from PTM216Z modules (wire- & batteryless switch) to their modules.
I plan on testing it myself.

So far, I had to use an external tool like NodeRed to make these batteryless switches do stuff. (which works great!)
But for many applications, a direct link would not need that extra service running & could be preferable reliability-wise.