### PR TITLE
Add JavaScript heap out of memory to common start failures

### DIFF
--- a/docs/guide/installation/20_zigbee2mqtt-fails-to-start.md
+++ b/docs/guide/installation/20_zigbee2mqtt-fails-to-start.md
@@ -122,6 +122,18 @@ In case you see message like below when running `dmesg -w` you are using a bad p
 
 When you have a SSD connected to the Pi, try connecting the adapter via a powered USB hub.
 
+## Error: JavaScript heap out of memory
+On memory constrained deviced it might be necessary to run 
+```bash
+export NODE_OPTIONS=--max_old_space_size=256
+```
+before executing `npm start`.
+
+It can also be run in one line like this
+```bash
+NODE_OPTIONS=--max_old_space_size=256 npm start
+```
+
 ## Make sure the extension cable works
 
 A bad extension cable can lead to connection issues between the system and the adapter. Symptoms of this are

--- a/docs/guide/installation/20_zigbee2mqtt-fails-to-start.md
+++ b/docs/guide/installation/20_zigbee2mqtt-fails-to-start.md
@@ -123,7 +123,7 @@ In case you see message like below when running `dmesg -w` you are using a bad p
 When you have a SSD connected to the Pi, try connecting the adapter via a powered USB hub.
 
 ## Error: JavaScript heap out of memory
-On memory constrained deviced it might be necessary to run 
+On memory constrained devices it might be necessary to run 
 ```bash
 export NODE_OPTIONS=--max_old_space_size=256
 ```


### PR DESCRIPTION
I'm a bit conflicted if this is common/important enough to be listed here. You be the judge.