### PR TITLE
Update deconz adapter information

### DIFF
--- a/docs/guide/adapters/README.md
+++ b/docs/guide/adapters/README.md
@@ -280,7 +280,7 @@ _(in order of first appearance)_
   * <details>
     <summary>ConBee / ConBee II / RaspBee / RaspBee II</summary>
   
-    USB connected (ConBee and ConBee II) and Raspberry Pi GPIO module (RaspBee and RaspBee II) adapters.
+    USB connected adapters (ConBee and ConBee II) and Raspberry Pi GPIO modules (RaspBee and RaspBee II).
     If Zigbee2MQTT fails to start, try adding the following to your `configuration.yaml`
     ```yaml
     serial:

--- a/docs/guide/adapters/README.md
+++ b/docs/guide/adapters/README.md
@@ -278,18 +278,19 @@ _(in order of first appearance)_
 
 ### Other
   * <details>
-    <summary>ConBee II / RaspBee II</summary>
+    <summary>ConBee / ConBee II / RaspBee / RaspBee II</summary>
   
-    USB connected adapter    
+    USB connected (ConBee and ConBee II) and Raspberry Pi GPIO module (RaspBee and RaspBee II) adapters.
     If Zigbee2MQTT fails to start, try adding the following to your `configuration.yaml`
     ```yaml
     serial:
       adapter: deconz
     ```
   
-    * [Coordinator firmware](https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Update-deCONZ-manually)  
-    * [Flashing](https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Update-deCONZ-manually)  
-    * [Buy](https://phoscon.de/en/conbee2?buy=1#buy)
+    * [Coordinator firmware](https://deconz.dresden-elektronik.de/deconz-firmware/)
+    * [Flashing](https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Update-deCONZ-manually)
+    * [Buy](https://phoscon.de/en/conbee2?#buy) (ConBee II)
+    * [Buy](https://phoscon.de/en/raspbee2#buy) (RaspBee II)
   
     ![](../../images/conbee.jpg)
     </details>


### PR DESCRIPTION
* Mention ConBee and RaspBee as they are also supported.
  * Source: I own a RaspBee and works perfectly with Zigbee2MQTT.
* Update firmware link, buying links and general wording.

Note: While I don't own a ConBee, it uses the same chipset as the RaspBee and therefore it _should_ also be compatible.