### PR TITLE
Update KMPCIL_RES005.md

### DIFF
--- a/docs/devices/KMPCIL_RES005.md
+++ b/docs/devices/KMPCIL_RES005.md
@@ -98,7 +98,7 @@ If value equals `true` occupancy is ON, if `false` OFF.
 
 ### Switch 
 The current state of this switch is in the published state under the `state` property (value is `ON` or `OFF`).
-To control this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"state": "ON"}`, `{"state": "OFF"}` or `{"state": "TOGGLE"}`.
+To control this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"state": "on"}`, `{"state": "off"}` or `{"state": "toggle"}`.
 To read the current state of this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"state": ""}`.
 
 ### Linkquality (numeric)


### PR DESCRIPTION
Through experimentation I found that the state commands must be lowercase to be effective.

The device's Exposes page has the state switch commands in uppercase and fails because of it. That needs to be changed too.