### PR TITLE
Add EGLO lamp to 33957.md

### DIFF
--- a/docs/devices/33957.md
+++ b/docs/devices/33957.md
@@ -23,7 +23,16 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+The following devices are supported under the same name:
 
+|     |     |
+|-----|-----|
+| Model | 12239  |
+| Vendor  | EGLO  |
+| Description | LED light with color temperature |
+| Exposes | light (state, brightness), effect, linkquality |
+| Picture | [EGLO 12239](https://www.eglo.com/at/leuchtmittel-12239.html) |
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
Update to include the EGLO ledfilamentlamp Zigbee G95 E27 6W as an additional product supported with the same hardware name. Note: I tried to add the picture as per the instructions on https://www.zigbee2mqtt.io/advanced/support-new-devices/01_support_new_devices.html#_3-adding-converter-s-for-your-device, but the target site (https://www.zigbee2mqtt.io/public/images/devices/) throws me an Error 404. For now, I linked the manufacturer's website (that contains a picture).

Entry in the database.db:
````
{"id":4,"type":"Router","ieeeAddr":"0xa4c138b83d0d95fb","nwkAddr":56107,"manufId":4417,"manufName":"AwoX","powerSource":"Mains (single phase)","modelId":"TLSR82xx","epList":[1,3],"endpoints":{"1":{"profId":260,"epId":1,"devId":268,"inClusterList":[0,3,4,5,6,8,768,4096,64599],"outClusterList":[6],"clusters":{"genBasic":{"attributes":{"modelId":"TLSR82xx","manufacturerName":"AwoX","powerSource":1,"zclVersion":3,"appVersion":0,"stackVersion":2,"hwVersion":0,"swBuildId":"0122052017"}},"lightingColorCtrl":{"attributes":{"colorCapabilities":16,"colorTempPhysicalMin":250,"colorTempPhysicalMax":454}}},"binds":[],"configuredReportings":[],"meta":{}},"3":{"profId":4751,"epId":3,"devId":268,"inClusterList":[65360,65361],"outClusterList":[65360,65361],"clusters":{},"binds":[],"configuredReportings":[],"meta":{}}},"appVersion":0,"stackVersion":2,"hwVersion":0,"swBuildId":"0122052017","zclVersion":3,"interviewCompleted":true,"meta":{"configured":88764544},"lastSeen":1651857441884,"defaultSendRequestWhen":"immediate"}
````