### PR TITLE
Add adapter type to documentation

### DIFF
--- a/docs/guide/adapters/flashing/connecting_cc2530.md
+++ b/docs/guide/adapters/flashing/connecting_cc2530.md
@@ -160,6 +160,7 @@ Now add the following to the Zigbee2MQTT `configuration.yaml`:
 ```yaml
 serial:
     port: 'tcp://192.168.2.13:20108'
+    adapter: zstack
 ```
 
 Note to change the IP address and port.


### PR DESCRIPTION
Add adapter type to the sample code to be Zstack.
(I kept switching from a ezsp and a zstack router for testing and without the adapter being set to zstack it would default to the last value)