### PR TITLE
Pairing notes for Lonsonho ZB-RGBCW

### DIFF
--- a/docs/devices/ZB-RGBCW.md
+++ b/docs/devices/ZB-RGBCW.md
@@ -24,6 +24,13 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Notes
+
+### Pairing
+1. Switch on your device.
+2. Now switch off and back on within 2 seconds.
+3. Repeat off/on four more times.
+4. Reset is done when the device is switched on the fifth time and the light starts pulsing.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
Add pairing instructions for Lonsonho ZB-RGBCW. Instructions are from the included user manual and are made similar to existing instructions from https://www.zigbee2mqtt.io/devices/GL-B-007ZS.html
![Lonsonho_ZB-RGBCW_manal](https://user-images.githubusercontent.com/61568/168430322-23c5a1c8-3d08-419a-9bdc-91fad35bd9a2.jpg)

