### PR TITLE
Updated with 'duration' parameter

### DIFF
--- a/docs/devices/MEG5113-0300_MEG5165-0000.md
+++ b/docs/devices/MEG5113-0300_MEG5165-0000.md
@@ -30,12 +30,11 @@ pageClass: device-page
 To get the device into pairing mode, press the up button 3 times briefly and then hold it for a long time (almost 20s). After about 10s the LED starts blinking slowly, continue to hold until it starts blinking rapidly. Now you can release it. Pairing will take a while to complete. The LED will blink and change color during this process.
 
 ### Control
-The shutter control uses a simple timer to control the duration to open/close the shutter. Unfortunately the Zigbee command to set the timer is not known yet. Even if you set the timer via Bluetooth, it will be reset to the default 2 minutes every time you bring it back to Zigbee mode.
-The consequence is, that if your shutter is faster than 2 minutes, the position information will not match with the shutter position (since the transition from 0% to 100% takes 120s).
-Example: If your shutter motor needs 20 seconds to move from open to closed, it will already be closed at 1/6 of the time, i.e. at position 85. It will still take 120s for the position information to go from 100 down to 0.
+The shutter control uses a simple timer to control the duration to open/close the shutter. The timer duration can be set via 'duration'.   
+Be aware, that the controller has no physical position information. Therefore, whenever the shutter is somewhere between fully open and fully closed and you send a command to move to any position other than fully open, the shutter will first move to the fully open position, wait for the timer to elapse and then move to the position you selected.
 
-If you use a shutter motor with positional switches, that stops at the Open or closed position, this will not be an issue. If you rely on the control to shut of the motor, the current implementation will keep the motor pulling until the timer has elapsed, that might not be a good idea.
-If your shutter motor needs more than 2 minutes, I suppose it will stop before reaching the final position.
+Example: You have set a duration of 20s. The shutter is half closed and you send a command to fully close it. It will first fully open (within e.g. 10s) then wait another 10s until the timer has elapsed and then close the shutter completely (taking another 20s).     
+This behavior is designed like this and probably chosen to prevent positioning problems due to motion backlash. It cannot be changed.
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
I removed the info in the documentation describing the missing duration setting, which was now added.
I also added a description of the specific behavior of the shutter control, that moves the shutters to fully open to "home" the position, if a move from partly open to another partly open position is sent.