### PR TITLE
Typo in Config Doc

### DIFF
--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -5,7 +5,7 @@ next: adapter-settings.md
 # Configuration
 
 Zigbee2MQTT is configured using [YAML](https://en.wikipedia.org/wiki/YAML) based `configuration.yaml` file.
-The file have to be located in the `data` directory within your installation. The `data` directory and the `configuration.yaml` has to be writeable for Zigbee2MQTT process because it can get updated - e.g. if you change the settings in the frontend. It's possible specify a custom data directory by setting the `ZIGBEE2MQTT_DATA` environment variable.
+The file have to be located in the `data` directory within your installation. The `data` directory and the `configuration.yaml` has to be writeable for Zigbee2MQTT process because it can get updated - e.g. if you change the settings in the frontend. If possible specify a custom data directory by setting the `ZIGBEE2MQTT_DATA` environment variable.
 
 ```yaml
 # Minimal configuration.yml example


### PR DESCRIPTION
"It's possible specify a custom data directory by setting the ZIGBEE2MQTT_DATA environment variable." seems like It's meant to be if.