### PR TITLE
Update npm version in python installation

### DIFF
--- a/docs/guide/installation/06_python_virtual_environment.md
+++ b/docs/guide/installation/06_python_virtual_environment.md
@@ -29,7 +29,7 @@ pip install --upgrade pip wheel setuptools
 pip install nodeenv
 
 # Init node environment
-nodeenv -p -n 10.15.1
+nodeenv -p -n 16.15.0
 
 # Deactivate and activate environment to be sure
 deactivate


### PR DESCRIPTION
The instructions are still on 10.15.1, which is ancient. The [docker builds](https://github.com/Koenkk/zigbee2mqtt/blob/master/docker/Dockerfile) are based on 16.15.0, which is also old... but less old. This PR brings those two versions in line. At least for now.