### PR TITLE
Remove information from docs; integration

### DIFF
--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -334,8 +334,3 @@ entities:
 
 ## Zigbee Network Map (Custom Card)
 [Zigbee Network Map Home Assistant Custom Card](https://github.com/azuwis/zigbee2mqtt-networkmap/).
-
-## Zigbee Network Map (Custom Component)
-[Zigbee Network Map Home Assistant addon](https://github.com/rgruebel/ha_zigbee2mqtt_networkmap).
-
-**NOTE:** This addon is not password protected (if you have provided external access to your Home Assistant instance **EVERYONE** can access your Network Map).


### PR DESCRIPTION
Why should this be removed?
integration broken for HA >= 2021.12

Problem detailed here
https://github.com/rgruebel/ha_zigbee2mqtt_networkmap/issues/42
and here,  https://github.com/hacs/integration/issues/2517