### PR TITLE
Add link to adapter firmware for `CC2538` (develop)

### DIFF
--- a/docs/devices/GZCGQ01LM.md
+++ b/docs/devices/GZCGQ01LM.md
@@ -29,6 +29,7 @@ pageClass: device-page
 In order for this device to work (fully), at least the following firmware is required on your adapter:
 - CC2530/CC2531: [`20211115`](https://github.com/Koenkk/Z-Stack-firmware/tree/Z-Stack_Home_1.2_20211115/20211116/coordinator/Z-Stack_Home_1.2/bin)
 - CC1352/CC2652: [`20211114`](https://github.com/Koenkk/Z-Stack-firmware/tree/7c5a6da0c41855d42b5e6506e5e3b496be097ba3/coordinator/Z-Stack_3.x.0/bin)
+- CC2538: [`20211222`](https://github.com/jethome-ru/zigbee-firmware/tree/master/ti/coordinator/cc2538_cc2592)
 - Conbee II: [`0x26720700`]( http://deconz.dresden-elektronik.de/deconz-firmware/deCONZ_ConBeeII_0x26720700.bin.GCF)
 
 *Note that if you have already paired the device you will need to repair it after upgrading your adapter firmware.*

--- a/docs/devices/ZNCLBL01LM.md
+++ b/docs/devices/ZNCLBL01LM.md
@@ -29,6 +29,7 @@ pageClass: device-page
 In order for this device to work, at least the following firmware is required on your adapter:
 - CC2530/CC2531: [`20211115`](https://github.com/Koenkk/Z-Stack-firmware/tree/Z-Stack_Home_1.2_20211115/20211116/coordinator/Z-Stack_Home_1.2/bin)
 - CC1352/CC2652: [`20211114`](https://github.com/Koenkk/Z-Stack-firmware/tree/7c5a6da0c41855d42b5e6506e5e3b496be097ba3/coordinator/Z-Stack_3.x.0/bin)
+- CC2538: [`20211222`](https://github.com/jethome-ru/zigbee-firmware/tree/master/ti/coordinator/cc2538_cc2592)
 - Conbee II: [`0x26720700`]( http://deconz.dresden-elektronik.de/deconz-firmware/deCONZ_ConBeeII_0x26720700.bin.GCF)
 
 *Note that if you have already paired the device you will need to repair it after upgrading your adapter firmware.*


### PR DESCRIPTION
[Changelog](https://github.com/jethome-ru/zigbee-firmware/tree/master/ti/coordinator/cc2538_cc2592#firmware-version-20211222):

**Firmware version 20211222**

- _Fixed work with devices Aqara E1_;
- Added GREEN POWER cluster;
- CODE_REVISION_NUMBER changed to 20211222