### PR TITLE
Update E1766.md

### DIFF
--- a/docs/devices/E1766.md
+++ b/docs/devices/E1766.md
@@ -48,6 +48,7 @@ When connected, the light turns off.
 ### Binding
 The [binding](../guide/usage/binding.md) functionallity of this remote varies per firmware version:
 - below 2.3.75: suppports binding to groups only. It can only be bound to 1 group at a time. By default this remote is bound to the default bind group which you first have to unbind it from. This can be done by sending to `zigbee2mqtt/bridge/request/device/unbind` payload `{"from": "DEVICE_FRIENDLY_NAME", "to": "default_bind_group"}`. Wake up the device right before sending the commands by pressing a button on it.
+- Devices on 2.3.079 appear to support binding to devices.
 - 2.3.75 and greater: supports binding to devices only
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
I have an E1766 which I set up today, on firmware 2.3.079 and was unable to bind it to a group. It did however bind to the device directly, so I dont think the binding statement in this doc is 100% accurate.