### PR TITLE
Fix permission error by cloning with sudo

### DIFF
--- a/docs/guide/installation/01_linux.md
+++ b/docs/guide/installation/01_linux.md
@@ -40,8 +40,12 @@ sudo apt-get install -y nodejs git make g++ gcc
 node --version  # Should output v14.X, V16.x, V17.x or V18.X
 npm --version  # Should output 6.X, 7.X or 8.X
 
+# Create a directory for zigbee2mqtt and set your user as owner of it. Supplement "pi" for your own in case it differs
+sudo mkdir /opt/zigbee2mqtt
+sudo chown -R pi: /opt/zigbee2mqtt
+
 # Clone Zigbee2MQTT repository
-sudo git clone --depth 1 https://github.com/Koenkk/zigbee2mqtt.git /opt/zigbee2mqtt
+git clone --depth 1 https://github.com/Koenkk/zigbee2mqtt.git /opt/zigbee2mqtt
 
 # Install dependencies (as user "pi")
 cd /opt/zigbee2mqtt

--- a/docs/guide/installation/01_linux.md
+++ b/docs/guide/installation/01_linux.md
@@ -40,9 +40,9 @@ sudo apt-get install -y nodejs git make g++ gcc
 node --version  # Should output v14.X, V16.x, V17.x or V18.X
 npm --version  # Should output 6.X, 7.X or 8.X
 
-# Create a directory for zigbee2mqtt and set your user as owner of it. Supplement "pi" for your own in case it differs
+# Create a directory for zigbee2mqtt and set your user as owner of it
 sudo mkdir /opt/zigbee2mqtt
-sudo chown -R pi: /opt/zigbee2mqtt
+sudo chown -R ${USER}: /opt/zigbee2mqtt
 
 # Clone Zigbee2MQTT repository
 git clone --depth 1 https://github.com/Koenkk/zigbee2mqtt.git /opt/zigbee2mqtt


### PR DESCRIPTION
Cloning via `sudo` leads to a reproduceable permission error like this
```
cd && sudo rm -rf /opt/zigbee2mqtt/
sudo git clone --depth 1 https://github.com/Koenkk/zigbee2mqtt.git /opt/zigbee2mqtt
cd /opt/zigbee2mqtt
npm ci
```
```
npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /opt/zigbee2mqtt/node_modules
npm ERR! errno -13
npm ERR! Error: EACCES: permission denied, mkdir '/opt/zigbee2mqtt/node_modules'
npm ERR!  [Error: EACCES: permission denied, mkdir '/opt/zigbee2mqtt/node_modules'] {
npm ERR!   errno: -13,
npm ERR!   code: 'EACCES',
npm ERR!   syscall: 'mkdir',
npm ERR!   path: '/opt/zigbee2mqtt/node_modules'
npm ERR! }
npm ERR!
npm ERR! The operation was rejected by your operating system.
npm ERR! It is likely you do not have the permissions to access this file as the current user
npm ERR!
npm ERR! If you believe this might be a permissions issue, please double-check the
npm ERR! permissions of the file and its containing directories, or try running
npm ERR! the command again as root/Administrator.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/impact/.npm/_logs/2022-07-13T22_50_43_959Z-debug-0.log
```

Please rewrite the commit message to not be that verbose in case this gets merged.