### PR TITLE
The bridge state is not json, so don't treat it as such

### DIFF
--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -218,7 +218,6 @@ mqtt:
     - name: Zigbee2MQTT Bridge state
       unique_id: zigbee2mqtt_bridge_state_sensor
       state_topic: "zigbee2mqtt/bridge/state"
-      value_template: "{{ value_json.state }}"
       icon: mdi:router-wireless
     # Sensor for Showing the Zigbee2MQTT Version
     - name: Zigbee2MQTT Version


### PR DESCRIPTION
The data for zigbee2mqtt/bridge/state is one of `online/offline`, and not JSON.  With the example setup, if you include the value_template, the logs will be filled with errors such as:
```
ERROR (MainThread) [homeassistant.helpers.template] Template variable error: 'value_json' is undefined when rendering '{{ value_json.state }}'
```

Removing value_template causes the error to go away AND the sensor contains the proper (text) value.