### PR TITLE
Update ZVG1.md

### DIFF
--- a/docs/devices/ZVG1.md
+++ b/docs/devices/ZVG1.md
@@ -36,7 +36,7 @@ After this the device will automatically join.
 
 ### Switch 
 The current state of this switch is in the published state under the `state` property (value is `ON` or `OFF`).
-To control this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"state": "ON"}`, `{"state": "OFF"}` or `{"state": "TOGGLE"}`.
+To control this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `ON`, `OFF` or `TOGGLE`.
 It's not possible to read (`/get`) this value.
 
 ### Battery (numeric)
@@ -49,14 +49,14 @@ The unit of this value is `%`.
 ### Timer_state (enum)
 Value can be found in the published state on the `timer_state` property.
 It's not possible to read (`/get`) this value.
-To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"timer_state": NEW_VALUE}`.
+To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set/timer_state` with payload `NEW_VALUE`.
 The possible values are: `disabled`, `active`, `enabled`.
 
 ### Timer (numeric)
 Auto off after specific time.
 Value can be found in the published state on the `timer` property.
 It's not possible to read (`/get`) this value.
-To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"timer": NEW_VALUE}`.
+To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set/timer` with payload `NEW_VALUE`.
 The minimal value is `0` and the maximum value is `240`.
 The unit of this value is `min`.
 


### PR DESCRIPTION
Sending one message directly to /set with timer _state or timer and switch on did not work (with a JSON payload)
I had to send 3 messages :
 - one on .../set/timer_state to set enabled (before opening the valve in order to work), if you set it to disabled, the valve will be opened and closed instantly
 - one on .../set/timer to set the time I wanted the valve to be open, if you set it to 0 it will opened and closed instantly
 - one on .../set to set on/off/toggle