### PR TITLE
Add pairing information to Philips 929003017102

### DIFF
--- a/docs/devices/929003017102.md
+++ b/docs/devices/929003017102.md
@@ -23,8 +23,11 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
-
+### Pairing
+Press the reset Button for ten seconds to reset the device - the red LED flashes one time confirming the reset. Then short the pins of input one.  
+The red LED begins to flash every two seconds indicating pairing mode.
 <!-- Notes END: Do not edit below this line -->
 
 
@@ -56,7 +59,3 @@ Value can be found in the published state on the `linkquality` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `255`.
 The unit of this value is `lqi`.
-
-## Pairing
-Press the reset Button for ten seconds to reset the device - the red LED flashes one time confirming the reset. Then short the pins of input one.  
-The red LED begins to flash every two seconds indicating pairing mode. 

--- a/docs/devices/929003017102.md
+++ b/docs/devices/929003017102.md
@@ -58,4 +58,5 @@ The minimal value is `0` and the maximum value is `255`.
 The unit of this value is `lqi`.
 
 ## Pairing
-Press the reset Button for ten seconds to reset the device, then short the pins of one of the inputs.
+Press the reset Button for ten seconds to reset the device - the red LED flashes one time confirming the reset. Then short the pins of input one.  
+The red LED begins to flash every two seconds indicating pairing mode. 

--- a/docs/devices/929003017102.md
+++ b/docs/devices/929003017102.md
@@ -57,3 +57,5 @@ It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `255`.
 The unit of this value is `lqi`.
 
+## Pairing
+Press the reset Button for ten seconds to reset the device, then short the pins of one of the inputs.


### PR DESCRIPTION
Since I struggled some time to find a way to pair my new Philips Hue Wall switch modules I was happy once I learned about its mechanism.  
Please add this missing information to the documentation.