### PR TITLE
Update HG08164.md

### DIFF
--- a/docs/devices/HG08164.md
+++ b/docs/devices/HG08164.md
@@ -23,8 +23,10 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
-
+### Battery value
+If battery value is not showing in Zigbee2MQTT briefly pressing reset button AFTER device is fully paired usually resolves the issue.
 <!-- Notes END: Do not edit below this line -->
 
 
@@ -53,7 +55,6 @@ Value can be found in the published state on the `battery` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `100`.
 The unit of this value is `%`.
-If battery value is not showing in zigbee2mqtt briefly pressing reset button AFTER device is fully paired usually resolves the issue.
 
 ### Linkquality (numeric)
 Link quality (signal strength).

--- a/docs/devices/HG08164.md
+++ b/docs/devices/HG08164.md
@@ -53,6 +53,7 @@ Value can be found in the published state on the `battery` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `100`.
 The unit of this value is `%`.
+If battery value is not showing in zigbee2mqtt briefly pressing reset button AFTER device is fully paired usually resolves the issue.
 
 ### Linkquality (numeric)
 Link quality (signal strength).


### PR DESCRIPTION
added
If battery value is not showing in zigbee2mqtt briefly pressing reset button AFTER device is fully paired usually resolves the issue.