### PR TITLE
Update touchlink.md Touchlink is also supported by Silabs ezsp on EFR32

### DIFF
--- a/docs/guide/usage/touchlink.md
+++ b/docs/guide/usage/touchlink.md
@@ -1,6 +1,6 @@
 # Touchlink
 
-**Important:** Only works with Zigbee Coordinator that has Touchlink enabled in firmware and support for touchlinking in [zigbee-herdsman adapter code](https://github.com/Koenkk/zigbee-herdsman).
+**Important:** The touchlinking function **only** works with Zigbee Coordinator adapters based on a Texas Instruments ZNP adapters (TI chips starting with "CC", e.g. CC2652) and Silicon Labs EZSP adapters (Silabs chips starting with "EFR32", e.g. EFR32MG21) with touchlink enabled in the Zigbee Coordinator firmware.
 
 Touchlink is a feature of Zigbee which allows devices physically close to each other to communicate with each other **without** being in the same network.
 

--- a/docs/guide/usage/touchlink.md
+++ b/docs/guide/usage/touchlink.md
@@ -1,6 +1,6 @@
 # Touchlink
 
-**Important:** Touchlink **only** works for adapters based on a Texas Instruments chip (chips starting with CC, e.g. CC2652).
+**Important:** Only works with Zigbee Coordinator that has Touchlink enabled in firmware and support for touchlinking in [zigbee-herdsman adapter code](https://github.com/Koenkk/zigbee-herdsman).
 
 Touchlink is a feature of Zigbee which allows devices physically close to each other to communicate with each other **without** being in the same network.
 
@@ -20,7 +20,7 @@ This allows to identify (e.g. bulb blinking) a device via Touchlink. To identify
 ## Factory reset device
 Zigbee2MQTT allows to factory reset devices through Touchlink. This is especially handy for e.g. Philips Hue bulbs as they cannot be factory reset by turning them on/off 5 times. Demo: [video](https://www.youtube.com/watch?v=kcRj77YGyKk)
 
-To factory reset a device through Touchlink bring the device close (< 10 cm) to your coordinator (e.g. CC2531 adapter). After this send a MQTT message to `zigbee2mqtt/bridge/request/touchlink/factory_reset` with an empty payload.
+To factory reset a device through Touchlink bring the device close (< 10 cm) to your Zigbee Coordinator (e.g. Zigbee USB adapter). After this send a MQTT message to `zigbee2mqtt/bridge/request/touchlink/factory_reset` with an empty payload.
 
 Zigbee2MQTT will now start scanning, this can take up to 1 minute and during this scan **your network cannot be used**. After some time the device will identify itself (e.g. a bulb will start to blink).
 


### PR DESCRIPTION
Touchlink is also supported by EZSP adapters (all Silicon Labs EFR32 series) if enabled in its Zigbee Coordinator firmware.

Reference @kirovilya and others who confirmed this:

https://github.com/Koenkk/zigbee2mqtt/discussions/13893

https://github.com/Koenkk/zigbee-herdsman/issues/319

https://github.com/grobasoz/zigbee-firmware/issues/32

https://github.com/xsp1989/zigbeeFirmware/issues/26