### PR TITLE
Update Philips Hue wall switch actions

### DIFF
--- a/docs/devices/929003017102.md
+++ b/docs/devices/929003017102.md
@@ -45,7 +45,7 @@ The unit of this value is `%`.
 Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
-The possible values are: `left_press`, `left_press_release`, `right_press`, `right_press_release`.
+The possible values are: `left_press`, `left_press_release`, `left_hold`, `left_hold_release`, `right_press`, `right_press_release`, `right_hold`, `right_hold_release`.
 
 ### Device_mode (enum)
 Value can be found in the published state on the `device_mode` property.


### PR DESCRIPTION
When pressing and holding the switch buttons there are 4 more `hold` -actions send