### PR TITLE
Update 701721.md

### DIFF
--- a/docs/devices/701721.md
+++ b/docs/devices/701721.md
@@ -78,7 +78,7 @@ To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/
 If value equals `true` thermostat_vertical_orientation is ON, if `false` OFF.
 
 ### Viewing_direction (binary)
-Viewing/Display Direction. `false` Horizontal or `true` Vertical.
+Viewing/Display Direction. `false` normal or `true` upside-down.
 Value can be found in the published state on the `viewing_direction` property.
 To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"viewing_direction": ""}`.
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"viewing_direction": NEW_VALUE}`.


### PR DESCRIPTION
Viewing direction documentation is wrong. There is no horizontal mode on this device, both modes are vertical (I own the device and I tryed). ‚False‘ is normal and ‚true‘ is upside-down.