### PR TITLE
Update DDS238-2.md

### DIFF
--- a/docs/devices/DDS238-2.md
+++ b/docs/devices/DDS238-2.md
@@ -15,11 +15,11 @@ pageClass: device-page
 
 |     |     |
 |-----|-----|
-| Model | DDS238-2  |
+| Model | DDS238-2 Ver.IVAP |
 | Vendor  | TuYa  |
 | Description | Zigbee smart energy meter |
 | Exposes | switch (state), energy, power, linkquality |
-| Picture | ![TuYa DDS238-2](https://www.zigbee2mqtt.io/images/devices/DDS238-2.jpg) |
+| Picture | ![TuYa DDS238-2 Ver.IVAP](https://www.zigbee2mqtt.io/images/devices/TS0601_din.jpg) |
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->


### PR DESCRIPTION
Here the "beta" external converter, it shows also power factor, reactive energy, switch control, and AC frequency, need to update documentation too, I made some changes on the image and model version. Unfortunately it still show also voltage V and current A in the tuya app, but no datapoints, the only one that seems to be encrypted is Phase A, someone knows how to unencrypt it? Currently no firmware updates are present on tuya app.

[[](url)](https://gist.github.com/Koenkk/34e60391471f8a6333176594dd80445d)