### PR TITLE
Add Dresden Electronic Kobold dimmer information

### DIFF
--- a/docs/devices/BN-600110.md
+++ b/docs/devices/BN-600110.md
@@ -24,6 +24,9 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Notes
+
+[Product info](https://phoscon.de/en/kobold/) on the Phoscon website.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
Add link to device info in markdown file, as well as add an image.