### PR TITLE
Note NodeJS 18 is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Docgen includes some scripts to help testing the page.
 
 ## VuePress
 
+Use Node.js 16 for building VuePress. Node.js 18 is not supported.
+
 ```bash
 # Install dependencies
 npm ci

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Docgen includes some scripts to help testing the page.
 
 ## VuePress
 
-Use Node.js 16 for building VuePress. Node.js 18 is not supported.
+Use Node.js 16 for building VuePress (other versions like Node.js 18 are not supported)
 
 ```bash
 # Install dependencies


### PR DESCRIPTION
When using node 18:

```
$ npm run dev

> vp@1.0.0 dev
> cross-env EXCLUDE_DEVICES=yes vuepress dev docs

info Initializing VuePress and preparing data...
⠋ Compiling with webpack...node:internal/crypto/hash:67
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:67:19)
    at Object.createHash (node:crypto:133:10)
    at BulkUpdateDecorator.hashFactory (/Users/andrew/workspace/zigbee2mqtt.io/node_modules/webpack/lib/util/createHash.js:155:18)
    at BulkUpdateDecorator.digest (/Users/andrew/workspace/zigbee2mqtt.io/node_modules/webpack/lib/util/createHash.js:80:21)
    at /Users/andrew/workspace/zigbee2mqtt.io/node_modules/webpack/lib/DefinePlugin.js:595:38
    at Hook.eval [as call] (eval at create (/Users/andrew/workspace/zigbee2mqtt.io/node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:102:1)
    at Hook.CALL_DELEGATE [as _call] (/Users/andrew/workspace/zigbee2mqtt.io/node_modules/tapable/lib/Hook.js:14:14)
    at Compiler.newCompilation (/Users/andrew/workspace/zigbee2mqtt.io/node_modules/webpack/lib/Compiler.js:1053:26)
    at /Users/andrew/workspace/zigbee2mqtt.io/node_modules/webpack/lib/Compiler.js:1097:29
    at Hook.eval [as callAsync] (eval at create (/Users/andrew/workspace/zigbee2mqtt.io/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1) {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v18.4.0
```

I see GitHub actions are using Node 16, so I've suggested that as the version to use even though older ones may work. I'm assuming upgrading webpack will fix this, but that's more than I have time for today, and node 16 is supported for some time yet.