### PR TITLE
Corrected patch version in the Binding section for IKEA ON/OFF Switch (E1743)

### DIFF
--- a/docs/devices/E1743.md
+++ b/docs/devices/E1743.md
@@ -50,7 +50,7 @@ To resolve the `Device didn't respond to OTA request` error, you can try to push
 
 ### Binding
 The [binding](../guide/usage/binding.md) functionallity of this remote varies per firmware version:
-- below 2.3.75: suppports binding to groups only. It can only be bound to 1 group at a time. By default this remote is bound to the default bind group which you first have to unbind it from. This can be done by sending to `zigbee2mqtt/bridge/request/device/unbind` payload `{"from": "DEVICE_FRIENDLY_NAME", "to": "default_bind_group"}`. Wake up the device right before sending the commands by pressing a button on it.
+- below 2.3.075: suppports binding to groups only. It can only be bound to 1 group at a time. By default this remote is bound to the default bind group which you first have to unbind it from. This can be done by sending to `zigbee2mqtt/bridge/request/device/unbind` payload `{"from": "DEVICE_FRIENDLY_NAME", "to": "default_bind_group"}`. Wake up the device right before sending the commands by pressing a button on it.
 - 2.3.075 and greater: supports binding to devices only
 
 ### Battery Replacement


### PR DESCRIPTION
`2.3.75` is a bit misleading, when IKEA uses `2.3.075` Which is also used in the line below