### PR TITLE
Update remote adapter guide to include Conbee

### DIFF
--- a/docs/advanced/remote-adapter/connect_to_a_remote_adapter.md
+++ b/docs/advanced/remote-adapter/connect_to_a_remote_adapter.md
@@ -53,6 +53,16 @@ connection: &con01
     kickolduser: true
 ```
 
+For ConBee II / RaspBee II, use the following configuration:
+
+```
+connection: &con01
+  accepter: tcp,20108
+  connector: serialdev,/dev/ttyACM0,115200n81,nobreak,local
+  options:
+    kickolduser: true
+```
+
 After this reboot the system.
 ```bash
 reboot


### PR DESCRIPTION
Conbee II indeed requires a bit different ser2net configuration, both according to an closed issue in the other [repo](https://github.com/Koenkk/zigbee2mqtt/issues/10533) and my tests as well. Z2M fails to even start as an addon in Home Assistant when `nobreak` is left out of the configration.