### PR TITLE
Add pairing instructions for the Xiaomi Radiator Thermostat E1

### DIFF
--- a/docs/devices/SRTS-A01.md
+++ b/docs/devices/SRTS-A01.md
@@ -24,6 +24,10 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Notes
+
+### Pairing
+Press and hold the center ring for 10 seconds until the blue network indicator flashes.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
Add pairing instructions for the Xiaomi Radiator Thermostat E1
Tested this myself and I can confirm this is the way it works.