### PR TITLE
Update ZNCZ04LM.md

### DIFF
--- a/docs/devices/ZNCZ04LM.md
+++ b/docs/devices/ZNCZ04LM.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 
 ### Issues
-- It's been reported that this plug automatically turns off by itself if it looses the connection to the coordinator (e.g.: weak signal). So, a loop task that sends a turn on cmd would be a possible workaround.
+- It's been reported that this plug automatically turns off by itself if it looses the connection to the coordinator (e.g.: weak signal). So, a loop task that sends a turn on command would be a possible workaround.
 
 ### Pairing
 Press and hold the button on the device until the blue light starts blinking, release it and and the device will automatically join.

--- a/docs/devices/ZNCZ04LM.md
+++ b/docs/devices/ZNCZ04LM.md
@@ -26,6 +26,9 @@ pageClass: device-page
 ## Notes
 
 
+### Issues
+- It's been reported that this plug automatically turns off by itself if it looses the connection to the coordinator (e.g.: weak signal). So, a loop task that sends a turn on cmd would be a possible workaround.
+
 ### Pairing
 Press and hold the button on the device until the blue light starts blinking, release it and and the device will automatically join.
 


### PR DESCRIPTION
I have added an issue that seems to be common, even with the latest FW available, which makes the plug to automatically turn if off by itself when it looses the connection from the coordinator.

Notes: I have 2 of them, and integrated using Sonoff Zigbee 3.0 Dongle Plus in Home Assistant.