### PR TITLE
Failure for the Current_summation

### DIFF
--- a/docs/devices/ZHEMI101.md
+++ b/docs/devices/ZHEMI101.md
@@ -68,7 +68,7 @@ Current summation value sent to the display. e.g. 570 = 0,570 kWh.
 Value will **not** be published in the state.
 It's not possible to read (`/get`) this value.
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"current_summation": NEW_VALUE}`.
-The minimal value is `0` and the maximum value is `10000`.
+The minimal value is `0` and the maximum value is `268435455`.
 
 ### Check_meter (binary)
 Is true if communication problem with meter is experienced.


### PR DESCRIPTION
From my point of view ther is a failure for the Current_summation. In the technical documentation, which i found here: http://docplayer.net/135845279-Technical-manual-for-zhemi101-zigbee-external-meter-interface-ha.html the range for the CurrentSummation is defined as 0x000000 - 0xFFFFFFF. This should be 0-268435455.
And this makes much more sense as it is more realistic to set initial counter from the electricity meter. So the value of 1000 = 1,0 kWh
10.000 = 10,0 kWH and so on.