### PR TITLE
Adjust a typo to position

### DIFF
--- a/docs/devices/GS361A-H04.md
+++ b/docs/devices/GS361A-H04.md
@@ -69,7 +69,7 @@ To control this switch publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set
 It's not possible to read (`/get`) this value.
 
 ### Position (numeric)
-Position.
+TRV valve position in %.
 Value can be found in the published state on the `position` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The unit of this value is `%`.


### PR DESCRIPTION
add more clearer that it is about the valve position and not about something else