### PR TITLE
Added Lidl/Silvercrest/Livarno 14158704L pairing notes

### DIFF
--- a/docs/devices/14158704L.md
+++ b/docs/devices/14158704L.md
@@ -24,6 +24,27 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Notes
+
+### Pairing
+Turn the lamp off, then on 3x with 1 second delay between each action.  
+The delay between on/off actions is critical. Quickly turning the device on/off will not put it in pairing mode. A good rule of thumb is ponouncing "Missisipi" between each on/off action.  
+
+1. Start with the lamp off
+2. Wait for 1 second
+3. On
+4. Wait for 1 second
+5. Off
+6. Wait for 1 second
+7. On
+8. Wait for 1 second
+9. Off
+10. Wait for 1 second
+11. On
+12. Wait for 1 second
+13. The device should now slowly glow brigher and dimmer and is now in pairing mode.
+
+If you do not succeed, try slightly increasing the time between on/off actions, and leave it off for several seconds before attempting again.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/14158704L.md
+++ b/docs/devices/14158704L.md
@@ -28,7 +28,7 @@ pageClass: device-page
 
 ### Pairing
 Turn the lamp off, then on 3x with 1 second delay between each action.  
-The delay between on/off actions is critical. Quickly turning the device on/off will not put it in pairing mode. A good rule of thumb is ponouncing "Missisipi" between each on/off action.  
+The delay between on/off actions is critical. Quickly turning the device on/off will not put it in pairing mode. A good rule of thumb is ponouncing "Mississippi" between each on/off action.
 
 1. Start with the lamp off
 2. Wait for 1 second


### PR DESCRIPTION
These Lidl lights are very picky about how to go into pairing mode. Best way I found is to say "Mississippi" between each on/off toggle so I mention it as a rule of thumb, but this might not be a good recommendation for international audiences, please do comment.