### PR TITLE
improves IKEA E2001_E2002 pairing instructions

### DIFF
--- a/docs/devices/E2001_E2002.md
+++ b/docs/devices/E2001_E2002.md
@@ -28,7 +28,7 @@ pageClass: device-page
 
 ### Pairing
 
-Pair the switch to Zigbee2MQTT by pressing the pair button (found under the back cover next to the battery) 4 times in a row within 5 seconds. The red light on the side should flash a few times and then turn off. After a few seconds it turns back on and pulsate. When connected, the light turns off.
+Pair the switch to Zigbee2MQTT by pressing the pair button (found under the back cover next to the battery) 4 times in a row within 5 seconds. If this doesn't work, try pressing the pair button up to 10 times in very quick succession. The red light on the side should flash a few times and then turn off. After a few seconds it turns back on and pulsate. When connected, the light turns off.
 
 ### Button -> `action` mapping
 


### PR DESCRIPTION
For me pairing would only work when "spamming" the pair button multiple (more than 4) times. Based on [this](https://www.reddit.com/r/tradfri/comments/qjp3id/comment/hje4uoj/?utm_source=share&utm_medium=web2x&context=3) reddit comment, 6-7 should be enough but the remote enters pairing mode regardless of how many times you press past the "correct" amount, hence me recommanding 10.

I don't know if this is model or firmware dependent which is why I left the original instructions as there might be devices where only those work.