### PR TITLE
Add note section for Müller Licht (hey-tint) turn-on transition issues

### DIFF
--- a/docs/devices/404036_45327_45317.md
+++ b/docs/devices/404036_45327_45317.md
@@ -24,6 +24,15 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Notes
+
+### Firmware issues 
+
+It has been [reported](https://github.com/Koenkk/zigbee2mqtt/issues/15832) for model 45327, a GU10-spot, (with firmware version `MGU10501`) and  model 45328, a E14-bulb, (with firmware version `MC37501`) that the  lamps have issues with turn-on transitions to brightness levels below `103`.  The bulb won't turn on and only flash once and turn off again.
+
+### Firmware issues
+
+It has been [reported](https://github.com/Koenkk/zigbee2mqtt/issues/15832) that the has issues with turn-on transitions to brightness levels below `103`. The bulb won't turn on and only flash once and turn off again.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/404065.md
+++ b/docs/devices/404065.md
@@ -24,6 +24,11 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Notes
+
+### Firmware issues
+
+It has been [reported](https://github.com/Koenkk/zigbee2mqtt/issues/15832) that firmware version `MDFIL201` has issues with turn on transitions to brightness levels below `103`. The bulb won't turn on and only flash once and turn off again.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
I've confirmed a firmware issue on three bulbs for the turn-on transition function - which I reported [here](https://github.com/Koenkk/zigbee2mqtt/issues/15832) as device quirk/firmware issue.

This PR adds this info to the docs as well.