### PR TITLE
Added gradient and hue effects documentation to some Hue lights

### DIFF
--- a/docs/devices/4090330P9.md
+++ b/docs/devices/4090330P9.md
@@ -151,7 +151,7 @@ Triggers an effect on the light (e.g. make light blink for a few seconds).
 Value will **not** be published in the state.
 It's not possible to read (`/get`) this value.
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"effect": NEW_VALUE}`.
-The possible values are: `blink`, `breathe`, `okay`, `channel_change`, `finish_effect`, `stop_effect`.
+The possible values are: `blink`, `breathe`, `okay`, `channel_change`, `candle`, `fireplace`, `colorloop`, `sunrise`, `finish_effect`, `stop_effect`, `stop_hue_effect`.
 
 ### Power_on_behavior (enum)
 Controls the behavior when the device is powered on after power loss.

--- a/docs/devices/4090331P9.md
+++ b/docs/devices/4090331P9.md
@@ -151,7 +151,7 @@ Triggers an effect on the light (e.g. make light blink for a few seconds).
 Value will **not** be published in the state.
 It's not possible to read (`/get`) this value.
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"effect": NEW_VALUE}`.
-The possible values are: `blink`, `breathe`, `okay`, `channel_change`, `finish_effect`, `stop_effect`.
+The possible values are: `blink`, `breathe`, `okay`, `channel_change`, `candle`, `fireplace`, `colorloop`, `sunrise`, `finish_effect`, `stop_effect`, `stop_hue_effect`.
 
 ### Power_on_behavior (enum)
 Controls the behavior when the device is powered on after power loss.

--- a/docs/devices/929002994901.md
+++ b/docs/devices/929002994901.md
@@ -146,19 +146,28 @@ To do this send a payload like below to `zigbee2mqtt/FRIENDLY_NAME/set`
 }
 ````
 
-### Effect (enum)
-Triggers an effect on the light (e.g. make light blink for a few seconds).
-Value will **not** be published in the state.
-It's not possible to read (`/get`) this value.
-To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"effect": NEW_VALUE}`.
-The possible values are: `blink`, `breathe`, `okay`, `channel_change`, `finish_effect`, `stop_effect`.
-
 ### Power_on_behavior (enum)
 Controls the behavior when the device is powered on after power loss.
 Value can be found in the published state on the `power_on_behavior` property.
 To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"power_on_behavior": ""}`.
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"power_on_behavior": NEW_VALUE}`.
 The possible values are: `off`, `on`, `toggle`, `previous`.
+
+### Gradient_scene (enum)
+Value will **not** be published in the state.
+It's not possible to read (`/get`) this value.
+To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"gradient_scene": NEW_VALUE}`.
+The possible values are: `blossom`, `crocus`, `precious`, `narcissa`, `beginnings`, `first_light`, `horizon`, `valley_dawn`, `sunflare`, `emerald_flutter`, `memento`, `resplendent`, `scarlet_dream`, `lovebirds`, `smitten`, `glitz_and_glam`, `promise`, `ruby_romance`, `city_of_love`, `honolulu`, `savanna_sunset`, `golden_pond`, `runy_glow`, `tropical_twilight`, `miami`, `cancun`, `rio`, `chinatown`, `ibiza`, `osaka`, `tokyo`, `motown`, `fairfax`, `galaxy`, `starlight`, `blood moon`, `artic_aurora`, `moonlight`, `nebula`, `sundown`, `blue_lagoon`, `palm_beach`, `lake_placid`, `mountain_breeze`, `lake_mist`, `ocean_dawn`, `frosty_dawn`, `sunday_morning`, `emerald_isle`, `spring_blossom`, `midsummer_sun`, `autumn_gold`, `spring_lake`, `winter_mountain`, `midwinter`, `amber_bloom`, `lily`, `painted_sky`, `winter_beauty`, `orange_fields`, `forest_adventure`, `blue_planet`, `soho`, `vapor_wave`, `magneto`, `tyrell`, `disturbia`, `hal`, `golden_star`, `under_the_tree`, `silent_night`, `rosy_sparkle`, `festive_fun`, `colour_burst`, `crystalline`.
+
+### Gradient (list)
+List of RGB HEX colors.
+Can be set by publishing to `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"gradient": []}`
+
+### Effect (enum)
+Value will **not** be published in the state.
+It's not possible to read (`/get`) this value.
+To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"effect": NEW_VALUE}`.
+The possible values are: `blink`, `breathe`, `okay`, `channel_change`, `candle`, `fireplace`, `colorloop`, `sunrise`, `finish_effect`, `stop_effect`, `stop_hue_effect`.
 
 ### Linkquality (numeric)
 Link quality (signal strength).


### PR DESCRIPTION
Adding gradient documentation for the Hue gradient lightstrip (this is already supported in the dev branch of zigbee2mqtt). Also, adding hue effects documentation in line with https://github.com/Koenkk/zigbee-herdsman-converters/pull/5267.