### PR TITLE
Adding a note about a current todo in the base converter

### DIFF
--- a/docs/devices/WXKG15LM.md
+++ b/docs/devices/WXKG15LM.md
@@ -30,6 +30,10 @@ Factory reset the switch by pressing and holding left and right rocker for 10 se
 
 ### Change clickmode
 If you have issues changing the click_mode with Zigbee2MQTT you can switch between click mode physically. This is done by clicking either of the two rockers quickly five times. The click mode will then toggle between fast mode and multi mode.
+
+### Binding
+Please note, that currently you will only get one endpoint for binding even though there are two rockers (see https://github.com/Koenkk/zigbee-herdsman-converters/blob/eed5fde987891f996c428339569dbff1893e62a1/devices/xiaomi.js#L2370). You will always receive the `toggle_1` event no matter whick rocker you use.
+
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
It took me a while to figure out why binding didn't work / why I always received `toggle_1` when clicking any of the rockers in `command` mode. The code comment actually made it clear that it is a current *TODO/BUG* that should be reflected in the docs to make it easier for other users..