### PR TITLE
Update to linux installation instructions

### DIFF
--- a/docs/guide/installation/01_linux.md
+++ b/docs/guide/installation/01_linux.md
@@ -21,6 +21,8 @@ pi@raspberry:~ $ ls -l /dev/ttyACM0
 crw-rw---- 1 root dialout 166, 0 May 16 19:15 /dev/ttyACM0  # <-- adapter (CC2531 in this case) on /dev/ttyACM0
 ```
 
+Alternately, if you are using an ethernet connected adapter, follow the instructions given for your specific device.
+
 However, it is **recommended** to use "by ID" mapping of the device (see [Adapter settings](../configuration/adapter-settings.md)). This kind of device path mapping is more stable, but can also be handy if you have multiple serial devices connected to your Raspberry Pi. In the example below the device location is: `/dev/serial/by-id/usb-Texas_Instruments_TI_CC2531_USB_CDC___0X00124B0018ED3DDF-if00`
 ```bash
 pi@raspberry:/ $ ls -l /dev/serial/by-id
@@ -29,16 +31,33 @@ lrwxrwxrwx. 1 root root 13 Oct 19 19:26 usb-Texas_Instruments_TI_CC2531_USB_CDC_
 ```
 
 ## Installing
+
+Procedure using curl and apt-get:
 ```bash
 # Set up Node.js repository and install Node.js + required dependencies
 # NOTE: Older i386 hardware can work with [unofficial-builds.nodejs.org](https://unofficial-builds.nodejs.org/download/release/v16.15.0/ e.g. Version 16.15.0 should work.
 sudo curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 sudo apt-get install -y nodejs git make g++ gcc
+```
 
+Alternate procedure using snap store:
+```bash
+# Install latest nodejs from snap store
+# The --classic argument is required here as Node.js needs full access to your system in order to be useful.
+# You can also use the --channel=XX argument to install a legacy version where XX is the version you want to install (we need 14+).
+sudo snap install node --classic
+```
+
+Continue installation in both cases
+```bash
 # Verify that the correct nodejs and npm (automatically installed with nodejs)
 # version has been installed
 node --version  # Should output v14.X, V16.x, V17.x or V18.X
 npm --version  # Should output 6.X, 7.X or 8.X
+
+# If you encounter an error at this stage and used the snap store instructions, adjust the BIN path as follows:
+## PATH=$PATH:/snap/node/current/bin
+# then re-verify nodejs and npm versions as above
 
 # Create a directory for zigbee2mqtt and set your user as owner of it
 sudo mkdir /opt/zigbee2mqtt

--- a/docs/guide/installation/01_linux.md
+++ b/docs/guide/installation/01_linux.md
@@ -31,8 +31,6 @@ lrwxrwxrwx. 1 root root 13 Oct 19 19:26 usb-Texas_Instruments_TI_CC2531_USB_CDC_
 ```
 
 ## Installing
-
-Procedure using curl and apt-get:
 ```bash
 # Set up Node.js repository and install Node.js + required dependencies
 # NOTE: Older i386 hardware can work with [unofficial-builds.nodejs.org](https://unofficial-builds.nodejs.org/download/release/v16.15.0/ e.g. Version 16.15.0 should work.
@@ -40,25 +38,29 @@ sudo curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 sudo apt-get install -y nodejs git make g++ gcc
 ```
 
-Note: the above doesn't work on ubuntu.
-Alternate procedure using snap store for ubuntu or similar:
+::: tip TIP
+On Ubuntu, Node.js can be installed through Snap
+
 ```bash
 # Install latest nodejs from snap store
 # The --classic argument is required here as Node.js needs full access to your system in order to be useful.
 # You can also use the --channel=XX argument to install a legacy version where XX is the version you want to install (we need 14+).
 sudo snap install node --classic
+
+# Verify node has been installed
+# If you encounter an error at this stage and used the snap store instructions, adjust the BIN path as follows:
+## PATH=$PATH:/snap/node/current/bin
+# then re-verify nodejs and npm versions as above
+node --version
 ```
 
-Continue installation in both cases
+:::
+
 ```bash
 # Verify that the correct nodejs and npm (automatically installed with nodejs)
 # version has been installed
 node --version  # Should output v14.X, V16.x, V17.x or V18.X
 npm --version  # Should output 6.X, 7.X or 8.X
-
-# If you encounter an error at this stage and used the snap store instructions, adjust the BIN path as follows:
-## PATH=$PATH:/snap/node/current/bin
-# then re-verify nodejs and npm versions as above
 
 # Create a directory for zigbee2mqtt and set your user as owner of it
 sudo mkdir /opt/zigbee2mqtt

--- a/docs/guide/installation/01_linux.md
+++ b/docs/guide/installation/01_linux.md
@@ -33,30 +33,11 @@ lrwxrwxrwx. 1 root root 13 Oct 19 19:26 usb-Texas_Instruments_TI_CC2531_USB_CDC_
 ## Installing
 ```bash
 # Set up Node.js repository and install Node.js + required dependencies
-# NOTE: Older i386 hardware can work with [unofficial-builds.nodejs.org](https://unofficial-builds.nodejs.org/download/release/v16.15.0/ e.g. Version 16.15.0 should work.
+# NOTE 1: Older i386 hardware can work with [unofficial-builds.nodejs.org](https://unofficial-builds.nodejs.org/download/release/v16.15.0/ e.g. Version 16.15.0 should work.
+# NOTE 2: For Ubuntu see tip below
 sudo curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 sudo apt-get install -y nodejs git make g++ gcc
-```
 
-::: tip TIP
-On Ubuntu, Node.js can be installed through Snap
-
-```bash
-# Install latest nodejs from snap store
-# The --classic argument is required here as Node.js needs full access to your system in order to be useful.
-# You can also use the --channel=XX argument to install a legacy version where XX is the version you want to install (we need 14+).
-sudo snap install node --classic
-
-# Verify node has been installed
-# If you encounter an error at this stage and used the snap store instructions, adjust the BIN path as follows:
-## PATH=$PATH:/snap/node/current/bin
-# then re-verify nodejs and npm versions as above
-node --version
-```
-
-:::
-
-```bash
 # Verify that the correct nodejs and npm (automatically installed with nodejs)
 # version has been installed
 node --version  # Should output v14.X, V16.x, V17.x or V18.X
@@ -81,6 +62,23 @@ added 383 packages in 111.613s
 ```
 
 Note that the `npm ci` produces some `warning` which can be ignored.
+
+::: tip TIP
+On Ubuntu, Node.js can be installed through Snap
+
+```bash
+# Install latest nodejs from snap store
+# The --classic argument is required here as Node.js needs full access to your system in order to be useful.
+# You can also use the --channel=XX argument to install a legacy version where XX is the version you want to install (we need 14+).
+sudo snap install node --classic
+
+# Verify node has been installed
+# If you encounter an error at this stage and used the snap store instructions, adjust the BIN path as follows:
+## PATH=$PATH:/snap/node/current/bin
+# then re-verify nodejs and npm versions as above
+node --version
+```
+:::
 
 ## Configuring
 Before we can start Zigbee2MQTT we need to edit the `configuration.yaml` file. This file contains the configuration which will be used by Zigbee2MQTT.

--- a/docs/guide/installation/01_linux.md
+++ b/docs/guide/installation/01_linux.md
@@ -40,7 +40,8 @@ sudo curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 sudo apt-get install -y nodejs git make g++ gcc
 ```
 
-Alternate procedure using snap store:
+Note: the above doesn't work on ubuntu.
+Alternate procedure using snap store for ubuntu or similar:
 ```bash
 # Install latest nodejs from snap store
 # The --classic argument is required here as Node.js needs full access to your system in order to be useful.


### PR DESCRIPTION
Ran into problems trying to follow the original instructions as written in ubuntu 22. Added ethernet adapter note, snap store instructions and bin path adjustments that I required in order to make the install work.

Wondering if the snap instructions should come first as they are actually more direct.