### PR TITLE
Fix undefined 'value_json' error

### DIFF
--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -233,7 +233,6 @@ mqtt:
     - name: Zigbee2MQTT Bridge state
       unique_id: zigbee2mqtt_bridge_state_sensor
       state_topic: "zigbee2mqtt/bridge/state"
-      value_template: "{{ value_json.state }}"
       icon: mdi:router-wireless
     # Sensor for Showing the Zigbee2MQTT Version
     - name: Zigbee2MQTT Version


### PR DESCRIPTION
With zigbee2mqtt 1.29.1 and Home Assistant 2023.1.1 the bridge state sensor spammed the Home Assistant logs with the following error:
```
ERROR (MainThread) [homeassistant.helpers.template] Template variable error: 'value_json' is undefined when rendering '{{ value_json.state }}'
```

The `zigbee2mqtt/bridge/state` topic returns a plain string instead of a JSON payload. Removing the `value_template` fixed the errors and the sensor value shows up as `online` correctly.