### PR TITLE
Update IH-K009.md

### DIFF
--- a/docs/devices/IH-K009.md
+++ b/docs/devices/IH-K009.md
@@ -49,7 +49,7 @@ Remaining battery in %.
 Value can be found in the published state on the `battery` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `100`.
-The unit of this value is `%`.
+The unit of this value is `%` (takes about 30 minutes to be displayed after pairing).
 
 ### Temperature (numeric)
 Measured temperature value.


### PR DESCRIPTION
Short note that battery value takes 30 minutes to show up (I thought there was a fault - but they just take a while).