### PR TITLE
FUT089Z General ON & OFF set Group ID 108 & Amazing Zigbee  emergency…

### DIFF
--- a/docs/devices/FUT089Z.md
+++ b/docs/devices/FUT089Z.md
@@ -26,20 +26,37 @@ pageClass: device-page
 ## Notes
 
 ### Pairing
-To pair the device, press the ON and OFF buttons simultaneously until the central red LED flashes quickly.
+To pair the device:
+- Allow Zigbee2MQTT pairing
+- Press the Master ON and OFF buttons simultaneously until the central red LED flashes quickly.
 
 ### Working principle
-The remote has 7 zone switches plus an eighth zone being controlled by the ON and OFF buttons. Each zone sends commands to a ZigBee group which is currently hardcoded. Zone 1 is mapped to ZigBee group 101, Zone 2 to 102 and so forth. This means that currently each remote controls the same ZigBee groups. To control a light, first create a ZigBee group with the correct ID (10X), then add the device you intend to control to that group. Do NOT add the remote itself.
 
-There is no support for sending events instead of commands.
+The remote has 7 zone switches plus an eighth zone being controlled by the ON and OFF buttons + 1 Master zone ON and OFF buttons.
+Each zone sends commands to a ZigBee group which is currently hardcoded. Zone 1 is mapped to ZigBee group 101, Zone 2 to 102 and so forth. This means that currently each remote controls the same ZigBee groups. To control lights or smartplugs, first create a ZigBee group with the correct ID (10X), name it like you wish then add the devices you intend to control to that group (pay attention to use the right termination point).
+
+Very important : do NOT add the remote itself to the group.
+
+ON and OFF Master Button on top of the remote will command an extra zone with Group ID 108. 
+You can for instance use it as a master switch or just as an add on zone.
+
+Obviously you can only have 1 FUT089Z remote per Zigbee network as it always command groups with 101 to 108 ID
+
+There is no support for sending events instead of commands. Which means that there is no other automation you can build out of the group assignement described above.
+
+Beauty is that after you pair remote and define up to 8 zones, the command will work even with Zigbee2MQTT down, ... even better without any alive Zigbee controller.
+It looks like a perfect emergency backup.
+
 
 ### Quirks
-The remote does not seem to respond to any ZigBee commands sent after initial configuration without taking out the battery and putting it back in. To send any command to it (like a Leave or configure command), take out the battery, send the command and quickly put it back in.
+Like most of battery powered devices, the remote does not respond to any ZigBee commands sent after initial configuration without taking out the battery and putting it back in.
+To send any command to it (like a Leave or configure command), take out the battery, send the command and quickly put it back in.
 
 It does also not support binding its light output clusters or manually joining it to a group.
 
 ### Touchlink
 The remote supports Touchlink. It is unclear how the Touchlink configuration interacts with the regular group configuration so if you intend to use Touchlink it would probably best not to pair it to a network.
+
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
… backup option

There is an extra group commended by Master ON/OFF: Debug 2023-01-12 14:38:33Received Zigbee message from 'Miboxer Remote', type 'commandOff', cluster 'genOnOff', data '{}' from endpoint 1 with groupID 108 Debug 2023-01-12 14:38:33No converter available for 'FUT089Z' with cluster 'genOnOff' and type 'commandOff' and data '{}' Debug 2023-01-12 14:38:34Received Zigbee message from 'Miboxer Remote', type 'commandOn', cluster 'genOnOff', data '{}' from endpoint 1 with groupID 108 Debug 2023-01-12 14:38:34No converter available for 'FUT089Z' with cluster 'genOnOff' and type 'commandOn' and data '{}'

Even without Zigbee radio controller, the remote send commands wich are properly interpreted by groups members... So I bought this remote expecting to be able to command my hue lights iand other switches in case of a disaster on my system (even if I have a PI3 standalone backup). It is eve,n better thant I was excpecting ...