### PR TITLE
TS0601 thermostat 2 - How to pair

### DIFF
--- a/docs/devices/TS0601_thermostat_2.md
+++ b/docs/devices/TS0601_thermostat_2.md
@@ -24,10 +24,12 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+### Pairing
+Long press left button (Auto/Manual Mode) AND right button (Comfort/Energy Saving Mode) until "Zigbee connection status"-light (the wifi icon) flashes
 
 <!-- Notes END: Do not edit below this line -->
-
 
 
 ## Exposes


### PR DESCRIPTION
A paragraph about pairing was missing. I added the Information under Notes.

I found the information in the (paper) user-manual