### PR TITLE
Add note that L1530 is known as "PWID012V24P-EU"

### DIFF
--- a/docs/devices/L1530.md
+++ b/docs/devices/L1530.md
@@ -24,7 +24,7 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
-
+The label on this device says "PWID012V24P-EU" (instead of L1530).
 
 ### Pairing
 Factory reset the light bulb ([video](https://www.youtube.com/watch?v=npxOrPxVfe0)).


### PR DESCRIPTION
On all of my L1530 devices, the type "PWID012V24P-EU" is written instead. Added it to the docs to make clear that it's the right device.