### PR TITLE
Improve wording for reset with Hue dimmer switch

### DIFF
--- a/docs/devices/3261030P7.md
+++ b/docs/devices/3261030P7.md
@@ -38,13 +38,14 @@ When the bulb is still connected to the Hue bridge, you can simply factory reset
 by removing it from the bridge via the Hue app. Orphaned bulbs (configured to connect to a non-existing Zigbee network) can be adopted by a Hue bridge by entering the 6 character serial number in the Philips Hue app.
 
 #### Hue dimmer switch
-With [one](./324131092621.md) of the [two](./929002398602.md) Hue Dimmer switches it is possible to put the bulbs into a factory reset.
+With both [v1](./324131092621.md) and [v2](./929002398602.md) Hue dimmer switches it is possible to put the bulbs into a factory reset.
 
 1. Power-supply the bulb
 2. Bring the dimmer switch next to the bulb, as close as possible
-3. Hold the I/On and 0/Off button pressed simultaneously for 10 to 12 seconds until…
+3. Hold both outer buttons ("I" and "0" for v1, "Power" and "Hue" for v2) pressed simultaneously for 10 to 12 seconds until…
 4. The bulb flashes a couple of times. Don't release the buttons until the last flash + a safety second
-5. Switch the bulb off and on again: it can now be paired again.
+5. Switch the bulb off and on again
+6. It can now be paired again.
 
 See also the [VIDEO: Factory reset a Hue bulb with Hue dimmer switch](https://www.youtube.com/watch?v=qvlEAELiJKs).
 


### PR DESCRIPTION
It was a bit unclear if both dimmer switches work and the buttons are labeled differently on v2 switches.

Maybe this can be changed on other device pages as well.