### PR TITLE
MQTT setting clarity for seperated Z2M and HA

### DIFF
--- a/docs/guide/configuration/homeassistant.md
+++ b/docs/guide/configuration/homeassistant.md
@@ -11,6 +11,8 @@ See: [Home Assistant integration guide](../usage/integrations/home_assistant.md)
 homeassistant: true
 ```
 
+Note: If your Zigbee2MQTT server is not using the Home Assistant Addon, then you will also need to update your Zigbee2MQTT MQTT server settings to direct to the Home Assisant IP address, username and password.
+
 ## Advanced configuration
 ```yaml
 homeassistant:


### PR DESCRIPTION
Adding some clarity regarding MQTT configuration Z2M and HA; it is not clear that the user also needs to update the MQTT server settings when Z2M and HA are not co-located..