### PR TITLE
Update connect_to_a_remote_adapter.md

### DIFF
--- a/docs/advanced/remote-adapter/connect_to_a_remote_adapter.md
+++ b/docs/advanced/remote-adapter/connect_to_a_remote_adapter.md
@@ -43,7 +43,7 @@ connection: &con01
     kickolduser: true
 ```
 
-For a Slaesh coordinator, use the following configuration:
+With a Slaesh coordinator, you need to set the DTR and RTS pins of the RS232 interfece in a specific way. The current (2023-02-04) version of Raspberry Pi OS does not have recent enough of ser2net to do that correctly, see https://github.com/cminyard/ser2net/issues/46. You might need to build the "gensi" and the "ser2net" packages on your rpi yourself. Other distributions might already have a more recent version. Once you have a version of ser2net that supports the "dtr=off" setting, use the following configuration:
 
 ```
 connection: &con01


### PR DESCRIPTION
Spent a day figuring out why my rpi did not work with slesh adapter. Perhaps it will help someone in the future to know that really, the current raspbian cannot be used as such with the stick.