### PR TITLE
Add FAQ note that deconz, ezsp, and zigate not yet supporting adapter migration

### DIFF
--- a/docs/guide/faq/README.md
+++ b/docs/guide/faq/README.md
@@ -38,7 +38,9 @@ This problem can be divided in 2 categories; no logging is shown at all OR inter
 
 Want to migrate from e.g. a CC2530/CC2531 to a more powerful adapter (e.g. CC2652/CC1352)? Then follow these instructions below:
 
-Note! Migration from one adapter to another requires backup and restore support which is so far only implemented for the zstack adapter (e.i. Texas Instruments based adapters). The code implementations in the zigbee-herdsman library Zigbee2MQTT depends on does not yet feature Zigbee Coordinator / Zigbee network backup and restore for [deconz adapter](https://github.com/Koenkk/zigbee-herdsman/issues/665) (e.i. ConBee/RaspBee adapters from dresden elektronik), [ezsp adapter](https://github.com/Koenkk/zigbee-herdsman/issues/319) (e.i. Silicon Labs based adapters), or [zigate adapter](https://github.com/Koenkk/zigbee-herdsman/issues/242) (e.i. ZiGate from fairecasoimeme).
+::: warning
+Migration from one adapter to another requires backup and restore support which is so far only implemented for the Zstack adapter (Texas Instruments adapters). Backup and restore is **not supported** for any other adapters (ConBee/Raspbee, EZSP and Zigate).
+:::
 
 1. First make sure you are running the latest version of Zigbee2MQTT
 1. Stop Zigbee2MQTT

--- a/docs/guide/faq/README.md
+++ b/docs/guide/faq/README.md
@@ -35,7 +35,11 @@ This problem can be divided in 2 categories; no logging is shown at all OR inter
 - Try pairing close to a bulb (light) router instead of the coordinator.
 
 ## How do I migrate from one adapter to another?
-Want to migrate from e.g. a CC2531 to a more powerful adapter (e.g. ZZH)? Then follow these instructions:
+
+Want to migrate from e.g. a CC2530/CC2531 to a more powerful adapter (e.g. CC2652/CC1352)? Then follow these instructions below:
+
+Note! Migration requires backup and restore support which is so far only implemented for zstack adapter and deconz adapter. [ezsp adapter](https://github.com/Koenkk/zigbee-herdsman/issues/319) and [zigate adapter](https://github.com/Koenkk/zigbee-herdsman/issues/242) support is experimental so backup and restore has not yet been implemented.
+
 1. First make sure you are running the latest version of Zigbee2MQTT
 1. Stop Zigbee2MQTT
 1. Determine whether migrating [requires re-pairing of your devices](#what-does-and-does-not-require-repairing-of-all-devices)

--- a/docs/guide/faq/README.md
+++ b/docs/guide/faq/README.md
@@ -38,7 +38,7 @@ This problem can be divided in 2 categories; no logging is shown at all OR inter
 
 Want to migrate from e.g. a CC2530/CC2531 to a more powerful adapter (e.g. CC2652/CC1352)? Then follow these instructions below:
 
-Note! Migration requires backup and restore support which is so far only implemented for zstack adapter and deconz adapter. [ezsp adapter](https://github.com/Koenkk/zigbee-herdsman/issues/319) and [zigate adapter](https://github.com/Koenkk/zigbee-herdsman/issues/242) support is experimental so backup and restore has not yet been implemented.
+Note! Migration from one adapter to another requires backup and restore support which is so far only implemented for the zstack adapter (e.i. Texas Instruments based adapters). The code implementations in the zigbee-herdsman library Zigbee2MQTT depends on does not yet feature Zigbee Coordinator / Zigbee network backup and restore for [deconz adapter](https://github.com/Koenkk/zigbee-herdsman/issues/665) (e.i. ConBee/RaspBee adapters from dresden elektronik), [ezsp adapter](https://github.com/Koenkk/zigbee-herdsman/issues/319) (e.i. Silicon Labs based adapters), or [zigate adapter](https://github.com/Koenkk/zigbee-herdsman/issues/242) (e.i. ZiGate from fairecasoimeme).
 
 1. First make sure you are running the latest version of Zigbee2MQTT
 1. Stop Zigbee2MQTT


### PR DESCRIPTION
Add note that deconz, ezsp, and zigate do not yet support backup and restore required for migration from adapter to adapter.

See deconz feature request for backup and restore -> https://github.com/Koenkk/zigbee-herdsman/issues/665

And related discussion about migrations -> https://github.com/Koenkk/zigbee2mqtt/discussions/16478