### PR TITLE
Log location on HA OS

### DIFF
--- a/docs/guide/usage/debug.md
+++ b/docs/guide/usage/debug.md
@@ -30,15 +30,11 @@ To enable debug logging in the Zigbee2MQTT Docker container add `-e DEBUG=zigbee
   `zigbee_herdsman_debug: true`
 - Click `Save`, and when prompted to restart, click `Restart add-on`
 
-Herdsman debug logs should now sow up on the `Logs` tab for the addon.
+Herdsman debug logs should now show up on the `Logs` tab for the addon. 
 
-To grab all the logs, log in via SSH and execute:
+Logs are also stored in timestamped folders under `/config/zigbee2mqtt/log` directory. 
 
-```
-docker logs CONTAINER_ID > log.txt 2>&1
-```
-
-To determine the `CONTAINER_ID` execute `docker ps`.
+You can access those logging in via SSH or via an HA Add-On editor of your choice, for example File Editor or Studio Code Server.
 
 ## Change log level during runtime
 See [MQTT topics and message structure](./mqtt_topics_and_messages.md)


### PR DESCRIPTION
Adding details on means to access logs for Home Assistant OS (no docker involved)