### PR TITLE
Update 8719514440937_8719514440999.md

### DIFF
--- a/docs/devices/8719514440937_8719514440999.md
+++ b/docs/devices/8719514440937_8719514440999.md
@@ -26,7 +26,7 @@ pageClass: device-page
 ## Notes
 
 ### Pairing
-The device can be set to pairing mode by removing the device's back cover. There is a small "setup" button next to the battery which must be pressed for a few seconds by using a paperclip or something similiar, which will bring the device into pairing mode.
+The device can be set to pairing mode by removing the device's back cover. There is a small "setup" button next to the battery which must be pressed for a few seconds by using a paperclip or something similiar, which will bring the device into pairing mode. If this is a brand new device, hold button 1 for 3 sec to pair. 
 <!-- Notes END: Do not edit below this line -->
 
 ## OTA updates


### PR DESCRIPTION
When pairing a brand new tap, the setup button doesn’t work. The manual states you must hold button 1 for 3 sec. After that the device will pair. If you unpair the device, the setup button can then be used to reset/pair the device again.