### PR TITLE
Update BSEN-C2.md

### DIFF
--- a/docs/devices/BSEN-C2.md
+++ b/docs/devices/BSEN-C2.md
@@ -25,7 +25,7 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
 
-### Indoor / Outdoor use
+### Indoor / outdoor use
 The sensor has a waterproof level IP45 and therefore is suitable for both indoor and outdoor use. (according manufacturer specification) 
 
 ### Pairing

--- a/docs/devices/BSEN-C2.md
+++ b/docs/devices/BSEN-C2.md
@@ -25,6 +25,9 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
 
+### Indoor / Outdoor use
+The sensor has a waterproof level IP45 and therefore is suitable for both indoor and outdoor use. (according manufacturer specification) 
+
 ### Pairing
 To pair this device you have to install the device via its installation code which you can get by scanning the QR-code sticker on the physical device with your smartphone. Then get the device into pairing mode. In zigbee2mqtt navigate to  "Settings" --> "Tools" and click on "Add install code". Paste the code you got from the QR-code and confirm by clicking "OK" which will get zigbee2mqtt into pairing mode automatically. Wait for your device to be joined.
 


### PR DESCRIPTION
I spent/waited quite some time (years!) to find a door sensor,Z2M compatible and suitable for outdoor use and finally found this one!  This is great for whoever want to use such sensor on a garden gate, letter box or whatever outdoor use. IP45 level is as well as "indoor/outdoor use" information is from Bosch documentation. I'm not sure if it's against any rules or best pratice to mention technical characteristics on a sensor page, but I thought it might be interesting for other people that might seek outdoor door sensor too. Feel free to cancel if not compliant.