### PR TITLE
Add factory reset sequence for AwoX 33957/EGLO 12239

### DIFF
--- a/docs/devices/33957.md
+++ b/docs/devices/33957.md
@@ -24,8 +24,18 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+### Pairing
+Factory reset the light bulb ([video](https://youtu.be/xeEryXGCfKA)).
+After resetting the bulb will automatically connect.
 
+Follow the steps with the switch:
+- Start with the bulb off
+- Toggle on/off sequence: on 1s, off 6s, 1s, 6s, 1s, 6s, 12s, 6s, 12s, 6s, final on
+  (on for: 1s, 1s, 1s, 12s, 12s with 6s off intervals)
+
+While pairing, keep the bulb close to the coordinator (adapter).
 <!-- Notes END: Do not edit below this line -->
 
 
@@ -41,7 +51,7 @@ pageClass: device-page
 
 ## Exposes
 
-### Light 
+### Light
 This light supports the following features: `state`, `brightness`, `color_temp`, `color_temp_startup`.
 - `state`: To control the state publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"state": "ON"}`, `{"state": "OFF"}` or `{"state": "TOGGLE"}`. To read the state send a message to `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"state": ""}`.
 - `brightness`: To control the brightness publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"brightness": VALUE}` where `VALUE` is a number between `0` and `254`. To read the brightness send a message to `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"brightness": ""}`.
@@ -92,4 +102,3 @@ Value can be found in the published state on the `linkquality` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `255`.
 The unit of this value is `lqi`.
-


### PR DESCRIPTION
Text adapted from IKEA device docs and tested with an EGLO 12239.