### PR TITLE
Add note section for Müller Licht (hey-tint) turn-on transition issues

### DIFF
--- a/docs/devices/404036_45327_45317_45328.md
+++ b/docs/devices/404036_45327_45317_45328.md
@@ -24,6 +24,11 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Notes
+
+### Firmware issues
+
+Model 45327 (with firmware version `MGU10501`), a GU10-spot, and model 45328 (with firmware version `MC37501`), an E14-bulb, are [known](https://github.com/Koenkk/zigbee2mqtt/issues/15832) to have a firmware issue: The lamp won't turn-on with a transition, if the requested brightness is below `103`. Instead the bulb will only flash shortly, turn off and report an `off` state.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/404065.md
+++ b/docs/devices/404065.md
@@ -24,6 +24,11 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Notes
+
+### Firmware issues
+
+This device (with firmware version `MDFIL201`) is [known](https://github.com/Koenkk/zigbee2mqtt/issues/15832) to have a firmware issue: The lamp won't turn-on with a transition, if the requested brightness is below `103`. Instead the bulb will only flash shortly, turn off and report an `off` state.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
I've confirmed a firmware issue on three bulbs for the turn-on transition function - which I reported [here](https://github.com/Koenkk/zigbee2mqtt/issues/15832) as device quirk/firmware issue.

This PR adds this info to the docs as well.

_This PR supersedes https://github.com/Koenkk/zigbee2mqtt.io/pull/1799_