### PR TITLE
Move legacy_entity_attributes to advanced key

### DIFF
--- a/docs/guide/configuration/homeassistant.md
+++ b/docs/guide/configuration/homeassistant.md
@@ -19,15 +19,17 @@ homeassistant:
   # Optional: Home Assistant status topic (default: shown below)
   # Note: in addition to the `status_topic`, 'homeassistant/status' will also be used
   status_topic: 'hass/status'
+  # Optional: Home Assistant legacy triggers (default: shown below), when enabled:
+  # - Zigbee2mqt will send an empty 'action' or 'click' after one has been send
+  # - A 'sensor_action' and 'sensor_click' will be discoverd
+  legacy_triggers: true
+
+advanced:
   # Optional: Home Assistant legacy entity attributes, (default: shown below), when enabled:
   # Zigbee2MQTT will send additional states as attributes with each entity. For example,
   # A temperature & humidity sensor will have 2 entities for the temperature and
   # humidity, with this setting enabled both entities will also have
   # an temperature and humidity attribute.
   # Note: Disabling this option, requires a Home Assistant restart
-  legacy_entity_attributes: true
-  # Optional: Home Assistant legacy triggers (default: shown below), when enabled:
-  # - Zigbee2mqt will send an empty 'action' or 'click' after one has been send
-  # - A 'sensor_action' and 'sensor_click' will be discoverd
-  legacy_triggers: true
+  homeassistant_legacy_entity_attributes: false
 ```

--- a/docs/guide/configuration/homeassistant.md
+++ b/docs/guide/configuration/homeassistant.md
@@ -19,7 +19,7 @@ homeassistant:
   # Optional: Home Assistant status topic (default: shown below)
   # Note: in addition to the `status_topic`, 'homeassistant/status' will also be used
   status_topic: 'hass/status'
-  # Optional: Home Assistant legacy triggers (default: shown below), however when enabled:
+  # Optional: Home Assistant legacy triggers (default: true), however when enabled:
   # - Zigbee2mqt will send an empty 'action' or 'click' after one has been send
   # - A 'sensor_action' and 'sensor_click' will be discoverd
   legacy_triggers: false

--- a/docs/guide/configuration/homeassistant.md
+++ b/docs/guide/configuration/homeassistant.md
@@ -19,7 +19,7 @@ homeassistant:
   # Optional: Home Assistant status topic (default: shown below)
   # Note: in addition to the `status_topic`, 'homeassistant/status' will also be used
   status_topic: 'hass/status'
-  # Optional: Home Assistant legacy triggers (default: true), however when enabled:
+  # Optional: Home Assistant legacy triggers (default: true), when enabled:
   # - Zigbee2mqt will send an empty 'action' or 'click' after one has been send
   # - A 'sensor_action' and 'sensor_click' will be discoverd
   legacy_triggers: false

--- a/docs/guide/configuration/homeassistant.md
+++ b/docs/guide/configuration/homeassistant.md
@@ -19,10 +19,10 @@ homeassistant:
   # Optional: Home Assistant status topic (default: shown below)
   # Note: in addition to the `status_topic`, 'homeassistant/status' will also be used
   status_topic: 'hass/status'
-  # Optional: Home Assistant legacy triggers (default: shown below), when enabled:
+  # Optional: Home Assistant legacy triggers (default: shown below), however when enabled:
   # - Zigbee2mqt will send an empty 'action' or 'click' after one has been send
   # - A 'sensor_action' and 'sensor_click' will be discoverd
-  legacy_triggers: true
+  legacy_triggers: false
 
 advanced:
   # Optional: Home Assistant legacy entity attributes, (default: shown below), when enabled:


### PR DESCRIPTION
I just installed the addon and noticed this key moved.

Additionally, the default for me seems to be `false`.