### PR TITLE
Bosch `BSP-FZ2`, `BSP-EZ2` and `BTH-RA`: Add notes on how to pair and factory reset

### DIFF
--- a/docs/devices/BSP-EZ2.md
+++ b/docs/devices/BSP-EZ2.md
@@ -23,8 +23,14 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+
+### Pairing
+To pair this device you have to install the device via its installation code which you can get by scanning the QR-code sticker on the physical device with your smartphone. Then get the device into pairing mode. In zigbee2mqtt navigate to  "Settings" --> "Tools" and click on "Add install code". Paste the code you got from the QR-code and confirm by clicking "OK" which will get zigbee2mqtt into pairing mode automatically. Wait for your device to be joined.
 
 
+### Factory resetting
+To factory reset the device unplug it from the mains. While pressing and holding the device's main button on the top, plug it in again. As soon as the device's LED is starting to blink orange, release the main button and press and hold it again until the device's LED is lighting up green. The device will then restart and look for a Zigbee network to join. In case something went wrong, the device's LED will start to blink red. The process has then to be start all over again.
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/BSP-FZ2.md
+++ b/docs/devices/BSP-FZ2.md
@@ -23,10 +23,15 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+
+### Pairing
+To pair this device you have to install the device via its installation code which you can get by scanning the QR-code sticker on the physical device with your smartphone. Then get the device into pairing mode. In zigbee2mqtt navigate to  "Settings" --> "Tools" and click on "Add install code". Paste the code you got from the QR-code and confirm by clicking "OK" which will get zigbee2mqtt into pairing mode automatically. Wait for your device to be joined.
 
 
+### Factory resetting
+To factory reset the device unplug it from the mains. While pressing and holding the device's main button on the top, plug it in again. As soon as the device's LED is starting to blink orange, release the main button and press and hold it again until the device's LED is lighting up green. The device will then restart and look for a Zigbee network to join. In case something went wrong, the device's LED will start to blink red. The process has then to be start all over again.
 <!-- Notes END: Do not edit below this line -->
-
 
 ## Options
 *[How to use device type specific configuration](../guide/configuration/devices-groups.md#specific-device-options)*

--- a/docs/devices/BTH-RA.md
+++ b/docs/devices/BTH-RA.md
@@ -26,7 +26,7 @@ pageClass: device-page
 ## Notes
 
 ### Pairing
-To pair this device you have to install the device via its installation code which you can get by scanning the QR-code sticker on the physical device with your smartphone. Then get the device into pairing mode. In zigbee2mqtt navigate to  "Settings" --> "Tools" and click on "Add install code". Paste the code you got from the QR-code and confirm by clicking "OK" which will get zigbee2mqtt into pairing mode automatically. Wait for your device to be joined.
+To pair this device you have to install the device via its installation code. The installation code can be obtained by scanning the QR-code on the inside of the battery cover with your smartphone. Then get the device into pairing mode. In zigbee2mqtt navigate to  "Settings" --> "Tools" and click on "Add install code". Paste the code you got from the QR-code and confirm by clicking "OK" which will get zigbee2mqtt into pairing mode automatically. Wait for your device to be joined.
 
 
 ### Factory resetting

--- a/docs/devices/BTH-RA.md
+++ b/docs/devices/BTH-RA.md
@@ -23,8 +23,14 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+
+### Pairing
+To pair this device you have to install the device via its installation code which you can get by scanning the QR-code sticker on the physical device with your smartphone. Then get the device into pairing mode. In zigbee2mqtt navigate to  "Settings" --> "Tools" and click on "Add install code". Paste the code you got from the QR-code and confirm by clicking "OK" which will get zigbee2mqtt into pairing mode automatically. Wait for your device to be joined.
 
 
+### Factory resetting
+To factory reset the device remove one of the batteries. While pressing and holding the device's main button on the front, insert the battery back. As soon as the device's LED is starting to blink orange while showing "RES", release the main button and press and hold it again until the device's LED is lighting up green. The device will then restart into the calibration process and look for a Zigbee network to join. In case something went wrong, the device's LED will start to blink red. The process has then to be start all over again.
 <!-- Notes END: Do not edit below this line -->
 
 ## OTA updates


### PR DESCRIPTION
The Bosch `BSP-FZ2` and `BSP-EZ2` plugs as well as `BTH-RA` thermostat are missing notes on how to pair and factory reset them. This PR is adding them. I based my text on the already-existing notes on the Bosch `8750001213` device.