### PR TITLE
Added Note for a firmware bug in Osram AC03642 bulb

### DIFF
--- a/docs/devices/AC03642.md
+++ b/docs/devices/AC03642.md
@@ -55,6 +55,9 @@ is manually switched off then on. Lights will remember their respective attribut
 }
 ```
 **INFO**: Value is true, false (boolean)
+
+**Note**: The bulb has a firmware bug. When setting a brightness value of e.g. 105, then remembering it and switching it off and on via a classic switch the bulb will light brighter than the setting when saved. Still the bulb will report a brightness of 105 when querying via `{"brightness": ""}`. After sending `{"state": "off"}` and `{"state": "on"}` it will have the save brightness as when saved and still it will report a brightness of 105 in the example.
+
 <!-- Notes END: Do not edit below this line -->
 
 ## OTA updates
@@ -123,4 +126,3 @@ Value can be found in the published state on the `linkquality` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `255`.
 The unit of this value is `lqi`.
-

--- a/docs/devices/AC03642.md
+++ b/docs/devices/AC03642.md
@@ -56,7 +56,7 @@ is manually switched off then on. Lights will remember their respective attribut
 ```
 **INFO**: Value is true, false (boolean)
 
-**Note**: The bulb has a firmware bug. When setting a brightness value of e.g. 105, then remembering it and switching it off and on via a classic switch the bulb will light brighter than the setting when saved. Still the bulb will report a brightness of 105 when querying via `{"brightness": ""}`. After sending `{"state": "off"}` and `{"state": "on"}` it will have the save brightness as when saved and still it will report a brightness of 105 in the example.
+**Note**: The bulb has a firmware bug. When setting a brightness value of e.g. 105, then remembering it and switching it off and on via a classic switch, the bulb will light brighter than the setting when saved. Still the bulb will report a brightness of 105 when querying via `{"brightness": ""}`. After sending `{"state": "off"}` and `{"state": "on"}` it will light with the same brightness as when saved and still it will report a brightness of 105 in this example.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
Added Note for a firmware bug that bulb will be brighter than saved value, when using a classic switch to turn off and on. Still the bulb will report in both cases the same brightness value. 