### PR TITLE
Update TS011F_plug_1.md

### DIFF
--- a/docs/devices/TS011F_plug_1.md
+++ b/docs/devices/TS011F_plug_1.md
@@ -20,7 +20,7 @@ pageClass: device-page
 | Description | Smart plug (with power monitoring) |
 | Exposes | switch (state), power_outage_memory, indicator_mode, power, current, voltage, energy, lock (state), linkquality |
 | Picture | ![TuYa TS011F_plug_1](https://www.zigbee2mqtt.io/images/devices/TS011F_plug_1.jpg) |
-| White-label | LELLKI TS011F_plug, NEO NAS-WR01B, BlitzWolf BW-SHP15, Nous A1Z, BlitzWolf BW-SHP13, MatSee Plus PJ-ZSW01, MODEMIX MOD037, MODEMIX MOD048, Coswall CS-AJ-DE2U-ZG-11, Aubess TS011F_plug_1 |
+| White-label | LELLKI TS011F_plug, NEO NAS-WR01B, BlitzWolf BW-SHP15, Nous A1Z, BlitzWolf BW-SHP13, MatSee Plus PJ-ZSW01, MODEMIX MOD037, MODEMIX MOD048, Coswall CS-AJ-DE2U-ZG-11, Aubess TS011F_plug_1, Immax NEO Smart 07752L |
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->


### PR DESCRIPTION
Added a reference which also identifies as Tuya TS011F_plug_1 in Z2M : IMMAX NEO Smart 07752L
Link to the device description : https://www.immax.eu/immax-neo-smart-internal-double-socket-16a-zigbee-3-0-p15142/

Same capabilities, same data exposure/reporting.