### PR TITLE
Green power, broadcasts and congestion

### DIFF
--- a/docs/advanced/zigbee/01_zigbee_network.md
+++ b/docs/advanced/zigbee/01_zigbee_network.md
@@ -31,6 +31,17 @@ Zigbee2MQTT logs the device type of your devices on startup, e.g.:
 2018-5-28 20:39:46 INFO 0x00158d0001b79111 (0x00158d0001b79111): WSDCGQ01LM - Xiaomi MiJia temperature & humidity sensor (EndDevice)
 ```
 
+### Green Power devices
+Zigbee Green Power devices are special end devices that are designed to be very energy efficient. Messages from Green Power devices cannot be "understood" by normal Zigbee devices, therefore they need to be "translated" first by a Green Power "proxy". This means the Green Power device must be in range of a regular Zigbee device that supports the Green Power proxy role. Examples are Philips Hue and (at least some) Ikea Tradfri bulbs.
+
+Green Power devices don't support binding and are not included in network scans.
+
+When pairing a Green Power device, you must choose whether translated messages should be re-transmitted by unicast or broadcast. Only [enable join](../../guide/usage/pairing_devices.md) on a specific device to use unicast for this Green Power device. Enable join on all devices to use broadcast. Do note that each proxy will generate a unique broadcast for each Green Power event, and a single keypress may generate more than one event (e.g. "key down" then "key up"). If there are multiple proxies paired with a Green Power device, this may generate *a lot* of traffic.
+
+*Example Green Power devices: PTM 215Z, SR-ZGP2801K-5C, SR-ZGP2801K2-DIM, SR-ZGP2801K4-DIM*
+
+*Note: Heavy use of broadcasts can negatively impact performance of your network (See [Broadcasts](./02_improve_network_range_and_stability.md)).*
+
 ## Zigbee networking
 
 This section is an overview of how the Zigbee protocol stack divides into layers (See [Wikipedia - IP layers](https://en.wikipedia.org/wiki/Internet_protocol_suite#Layer_names_and_number_of_layers_in_the_literature) ).  The number of layers in this type of description often varies; this discussion uses 4:

--- a/docs/advanced/zigbee/02_improve_network_range_and_stability.md
+++ b/docs/advanced/zigbee/02_improve_network_range_and_stability.md
@@ -56,3 +56,15 @@ For more technical details on Zigbee routing, see the ["5. Routing" in the TI Z-
 
 ## Hardware
 Although Zigbee2MQTT does not require many resources, the hardware you are running Zigbee2MQTT on can impact the performance. This is especially true when using low-power hardware like the Raspbery Pi 3. Make sure that enough resources (CPU/memory) is free. For example, running Home Assistant + Zigbee2MQTT Home Assistant addon on the Raspberry Pi 3 may give bad performance.
+
+## Broadcasts
+Zigbee traffic can be categorized as either *Unicast* or *Broadcast*:
+
+- *Unicast* is an addressed message, usually between a Zigbee device and the coordinator, possibly through some intermediate devices
+- *Broadcast* is a special type of message that is designed to reach **all** devices in the network
+
+When a device receives a broadcast message for the first time, it will re-transmit it at least once. The device keeps track of broadcasts that have recently been re-transmitted to prevent repeating messages forever. For large networks, broadcasts can generate a lot of traffic, and it takes time for the message to propagate to all devices. 
+
+Zigbee can only sustain an average rate of 1 broadcast per second, and multiple broadcasts within a short timespan increases latency. For more information, [see this application note by Silicon Labs](https://www.silabs.com/documents/login/application-notes/an1138-zigbee-mesh-network-performance.pdf). 
+
+Broadcasts are mostly used for network management tasks such as finding routes to devices, but also by [Zigbee Groups](../../guide/usage/groups.md) and [Green Power devices](./01_zigbee_network.md). It is generally recommended to use broadcasts sparingly.


### PR DESCRIPTION
Highlight different types of green power device pairing and performance cost of broadcasts. Copy Green Power device intro from misc devices to "Zigbee network".

I've spent some time debugging why my green power switches performed so poorly (started a discussion with myself here: https://github.com/Koenkk/zigbee2mqtt/discussions/17263). This is an attempt to spare others from the same headache.

I'm not sure in which cases broadcasting green power device events is a good idea, perhaps someone else could shed some light on that? In my case at least it would be better if green power device events were just always re-transmitted by the proxy as unicast...