### PR TITLE
Add section about install code for Bosch Motion Sensor

### DIFF
--- a/docs/devices/RFPR-ZB-SH-EU.md
+++ b/docs/devices/RFPR-ZB-SH-EU.md
@@ -24,6 +24,10 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Notes
+
+### Pairing
+To pair this device you have to install the device via its installation code. The installation code can be obtained by scanning the QR-code on the inside of the battery cover with your smartphone. Then get the device into pairing mode. In zigbee2mqtt navigate to  "Settings" --> "Tools" and click on "Add install code". Paste the code you got from the QR-code and confirm by clicking "OK" which will get zigbee2mqtt into pairing mode automatically. Wait for your device to be joined.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
According to the manual https://www.bosch-smarthome.com/de/media/content/10_bedienungsanleitungen/bewegungsmelder/8-750-000-920_v001_shmd_qsg_de_20200211_web.pdf you need to also scan an install code with this device. There is already an issue (https://github.com/Koenkk/zigbee2mqtt/issues/17315) because this is missing in the documentation.  The person can't test this anymore, since he already send back the product, but it seems kind of obvious that it was the problem in that case.