### PR TITLE
Update documentation to include the pairing process via install code for Bosch Water Sensor

### DIFF
--- a/docs/devices/BWA-1.md
+++ b/docs/devices/BWA-1.md
@@ -24,6 +24,10 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Notes
+
+### Pairing
+To pair this device you have to install the device via its installation code. The installation code can be obtained by scanning the QR-code on the inside of the battery cover with your smartphone. Then get the device into pairing mode. In zigbee2mqtt navigate to  "Settings" --> "Tools" and click on "Add install code". Paste the code you got from the QR-code and confirm by clicking "OK" which will get zigbee2mqtt into pairing mode automatically. Wait for your device to be joined.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
According to the manual https://www.bosch-smarthome.com/de/de/service/hilfe/hilfe-zum-produkt/hilfe-zum-wassermelder/ you need to also scan an install code with this device. There was already an issue (Koenkk/zigbee2mqtt#17315) on the motion sensor because this is missing in the documentation. I think all currently supported Bosch devices that need an Install Code should have this in their documentation now.  @Koenkk is there any way to make sure this is added for new Bosch devices in the future (as they will probably keep this going).