### PR TITLE
Add another whitelabel device (nous L13Z)

### DIFF
--- a/docs/devices/TS0044.md
+++ b/docs/devices/TS0044.md
@@ -20,7 +20,7 @@ pageClass: device-page
 | Description | Wireless switch with 4 buttons |
 | Exposes | battery, action, linkquality |
 | Picture | ![TuYa TS0044](https://www.zigbee2mqtt.io/images/devices/TS0044.jpg) |
-| White-label | Lonsonho TS0044, Haozee ESW-OZAA-EU, LoraTap SS6400ZB, Moes ZT-SY-EU-G-4S-WH-MS |
+| White-label | Lonsonho TS0044, Haozee ESW-OZAA-EU, LoraTap SS6400ZB, Moes ZT-SY-EU-G-4S-WH-MS, nous L13Z |
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->


### PR DESCRIPTION
Personally own this device. Bought it as "nous Smart Switch Module L13Z", paired with zigbee2mqtt without a hitch and was identified as a TS0002.