### PR TITLE
Added note to clarify lack of router support in Moes SZ-EUB wall switches

### DIFF
--- a/docs/devices/ZS-EUB_1gang.md
+++ b/docs/devices/ZS-EUB_1gang.md
@@ -25,7 +25,7 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
 
-This device does not act as a Zigbee router, even when the optional Neutral is connected. In addition the vendor does not provide a firmware update to enable the functionality.
+This device does not act as a Zigbee router, even when the optional neutral connection is used. In addition the vendor does not provide a firmware update to enable the router functionality.
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/ZS-EUB_1gang.md
+++ b/docs/devices/ZS-EUB_1gang.md
@@ -23,8 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
-
+This device does not act as a Zigbee router, even when the optional Neutral is connected. In addition the vendor does not provide a firmware update to enable the functionality.
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
These wall switches provide an optional neutral cable connection, but even when connected the device always reports itself as EndDevice and does not work as a router. This has been confirmed by the vendor customer support:

> **I bought three ZS-EUB 1-gang switches with optional neutral. The devices are detected as EndDevice and do not work as routers, even when Neutral is connected. Is there a firmware upgrade for the device that allows it to work as router?**
> 
> Thanks for your feedback, our zigbee products need to be connected to a zigbee gateway.
> In addition, our zigbee switch cannot be used as a repeater. If you want to expand the zigbee signal, you need a zigbee gateway.
> 