### PR TITLE
Add more instructions on how to bind an E1745

### DIFF
--- a/docs/devices/E1525_E1745.md
+++ b/docs/devices/E1525_E1745.md
@@ -32,7 +32,14 @@ The red light on the front side should flash a few times and then turn off.
 After a few seconds it turns back on and pulsate. When connected, the light turns off.
 
 ### Binding
-The E1745 can be bound to groups using [binding](../guide/usage/binding.md).
+The E1745 can be bound to groups. Although it is not possible to set the groupID at which the E1745 sends messages. But you can watch out in the log files for following debug messages:
+
+```
+debug Received Zigbee message from 'device', type 'commandOnWithTimedOff', cluster 'genOnOff', data '{"ctrlbits":0,"offwaittime":0,"ontime":600}' from endpoint 1 with groupID 123
+```
+
+Now you can create a group with a groupID of 123 and add yur devices that should receive the message.
+
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
According to issue  #5778 it is not possible to directly bind a device or a group. Nevertheless the device actually sends messages to a groupID. Knowing this groupID one can set up a Group to receive them. I had appreciated it if it was explained here on zigbee2mqtt.