### PR TITLE
fix: correct hass docs yaml entry

### DIFF
--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -246,7 +246,6 @@ mqtt:
     - name: Zigbee2MQTT Bridge state
       unique_id: zigbee2mqtt_bridge_state_sensor
       state_topic: "zigbee2mqtt/bridge/state"
-      value_template: "{{ value_json.state }}"
       icon: mdi:router-wireless
     # Sensor for Showing the Zigbee2MQTT Version
     - name: Zigbee2MQTT Version


### PR DESCRIPTION
`zigbee2mqtt/bridge/state` gives a state, not a json object, so template is not required and produces an error in hass logs

```Template variable error: 'value_json' is undefined when rendering '{{ value_json.state }}'```