### PR TITLE
Update Weiser SmartCode 10 docs with more details on pin codes

### DIFF
--- a/docs/devices/9GED21500-005.md
+++ b/docs/devices/9GED21500-005.md
@@ -56,7 +56,7 @@ To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME
 - `user` (numeric): User ID to set or clear the pincode for 
 - `user_type` (enum): Type of user, unrestricted: owner (default), (year|week)_day_schedule: user has ability to open lock based on specific time period, master: user has ability to both program and operate the door lock, non_access: user is recognized by the lock but does not have the ability to open the lock allowed values: `unrestricted`, `year_day_schedule`, `week_day_schedule`, `master`, `non_access`
 - `user_enabled` (binary): Whether the user is enabled/disabled allowed values: `true` or `false`
-- `pin_code` (numeric): Pincode to set, set pincode to null to clear 
+- `pin_code` (numeric): Pincode to set, set pincode to null to clear. Because this is a numeric and not a string, it's not possible to set pin codes that start with a zero (e.g. 0999 will be sent to the lock as 999). As a workaround, you can skip using the Z2M UI and publish an MQTT message manually with the pin code passed as a string. See example below.
 
 ### Action (enum)
 Triggered action on the lock.
@@ -82,3 +82,7 @@ It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `255`.
 The unit of this value is `lqi`.
 
+## Example MQTT message to set pin code
+Topic: `zigbee2mqtt/FREIDNLY_NAME/set`
+
+Payload: `{"pin_code":{"pin_code":"0999","user":1,"user_enabled":true,"user_type":"unrestricted"}}`

--- a/docs/devices/9GED21500-005.md
+++ b/docs/devices/9GED21500-005.md
@@ -54,9 +54,9 @@ The unit of this value is `%`.
 Can be set by publishing to `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"pin_code": {"user": VALUE, "user_type": VALUE, "user_enabled": VALUE, "pin_code": VALUE}}`
 To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"pin_code": ""}`.
 - `user` (numeric): User ID to set or clear the pincode for 
-- `user_type` (enum): Type of user, unrestricted: owner (default), (year|week)_day_schedule: user has ability to open lock based on specific time period, master: user has ability to both program and operate the door lock, non_access: user is recognized by the lock but does not have the ability to open the lock allowed values: `unrestricted`, `year_day_schedule`, `week_day_schedule`, `master`, `non_access`
+- `user_type` (enum): Type of user, unrestricted: owner (default), (year|week)_day_schedule: user has ability to open lock based on specific time period, master: user has ability to both program and operate the door lock, non_access: user is recognized by the lock but does not have the ability to open the lock allowed values: `unrestricted`, `year_day_schedule`, `week_day_schedule`, `master`, `non_access`. year_day_schedule and week_day_schedule are not documented and may not be supported by this lock.
 - `user_enabled` (binary): Whether the user is enabled/disabled allowed values: `true` or `false`
-- `pin_code` (numeric): Pincode to set, set pincode to null to clear. Because this is a numeric and not a string, it's not possible to set pin codes that start with a zero (e.g. 0999 will be sent to the lock as 999). As a workaround, you can skip using the Z2M UI and publish an MQTT message manually with the pin code passed as a string. See example below.
+- `pin_code` (numeric): Pincode to set, set pincode to null to clear. Because this is a numeric and not a string, it's not possible to set pin codes via UI that start with a zero (e.g. 0999 will be sent to the lock as 999). As a workaround, you can bypass the Z2M UI and publish an MQTT message manually as above with the pin code passed as a string.
 
 ### Action (enum)
 Triggered action on the lock.
@@ -81,8 +81,3 @@ Value can be found in the published state on the `linkquality` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `255`.
 The unit of this value is `lqi`.
-
-## Example MQTT message to set pin code
-Topic: `zigbee2mqtt/FREIDNLY_NAME/set`
-
-Payload: `{"pin_code":{"pin_code":"0999","user":1,"user_enabled":true,"user_type":"unrestricted"}}`


### PR DESCRIPTION
Note on how to set pin codes starting with a number; provide an example MQTT message to set PIN code