### PR TITLE
Update home_assistant.md

### DIFF
--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -281,11 +281,12 @@ mqtt:
     - name: Zigbee2mqtt Networkmap
       unique_id: zigbee2mqtt_networkmap_sensor
       # if you change base_topic of Zigbee2mqtt, change state_topic accordingly
-      state_topic: zigbee2mqtt/bridge/networkmap/raw
+      state_topic: zigbee2mqtt/bridge/response/networkmap
       value_template: >-
         {{ now().strftime('%Y-%m-%d %H:%M:%S') }}
       # again, if you change base_topic of Zigbee2mqtt, change json_attributes_topic accordingly
-      json_attributes_topic: zigbee2mqtt/bridge/networkmap/raw
+      json_attributes_topic: zigbee2mqtt/bridge/response/networkmap
+      json_attributes_template: "{{ value_json.data.value | tojson }}"
       entity_category: diagnostic
       device:
         identifiers: zigbee2mqtt


### PR DESCRIPTION
Example mqtt entity configuration for the networkmap is (no longer) correct. Used the example values from @azuwis [documentation](https://github.com/azuwis/zigbee2mqtt-networkmap).

Topic changed to: `zigbee2mqtt/bridge/response/networkmap` and needed additional setting: 
`json_attributes_template: "{{ value_json.data.value | tojson }}"`