### PR TITLE
Add pairing information for WS-USC03

### DIFF
--- a/docs/devices/WS-USC03.md
+++ b/docs/devices/WS-USC03.md
@@ -28,7 +28,7 @@ pageClass: device-page
 ## Notes
 
 ### Pairing
-Hold the top button for 5 seconds, until the LED flashes.
+Hold the top button for 5 seconds, until the LED turns red.
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/WS-USC03.md
+++ b/docs/devices/WS-USC03.md
@@ -25,6 +25,12 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
 
+## Notes
+
+### Pairing
+Hold the top button for 5 seconds, until the LED flashes.
+
+
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
It was difficult to find pairing information for this model online, partly because the other Aqara smart switch seems more popular.

A different Aqara device had "hold for 5 seconds" to enter pairing mode, so I tried that and it worked, so I thought I should document it here.