### PR TITLE
Update 'switch as light' example to prevent warning in HA

### DIFF
--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -118,7 +118,7 @@ devices:
         type: light
         object_id: light
       light:
-        name: my_switch
+        name: null
         value_template: null
         state_value_template: '{{ value_json.state }}'
       # OR if your devices has multiple endpoints (e.g. left/right)


### PR DESCRIPTION
Update docs for switch as light configuration to prevent warning in HA. Related to https://github.com/Koenkk/zigbee2mqtt/issues/18896