### PR TITLE
Update copy IEEE instructions

### DIFF
--- a/docs/guide/adapters/flashing/copy_ieeaddr.md
+++ b/docs/guide/adapters/flashing/copy_ieeaddr.md
@@ -15,7 +15,7 @@ Note that the *primary* ieee address will remain the same and these instructions
 ## ZigStar Multi Tool
 Supports: CC2652, CC1352, CC2538
 1. [Download](https://github.com/xyzroe/ZigStarGW-MT/releases) and run the tool
-1. Plug in your adapter and put it in BSL mode, consult your adapters manual on how to put it in BSL mode mode
+1. Plug in your adapter and put it in BSL mode, consult your adapters manual on how to put it in BSL mode
 1. Click refresh icon and select your adapter
 1. Fill in the old coordinators ieee address under "IEEE" (first `0x` can be skipped)
 1. Check "Write IEEE" and click "Write IEEE"
@@ -24,7 +24,7 @@ Supports: CC2652, CC1352, CC2538
 ## cc2538-bsl
 Supports: CC2652, CC1352, CC2538
 1. [Download](https://github.com/JelmerT/cc2538-bsl) the tool
-1. Plug in your adapter and put it in BSL mode, consult your adapters manual on how to put it in BSL mode
+1. Plug in your adapter and put it in BSL mode, consult your adapters manual on how to put it in BSL mode (if necessary, some adapters have an autobootloader, e.g. [this one](https://slae.sh/projects/cc2652/#flash-it))
 1. Run `./cc2538-bsl.py -evw --ieee-address 00:12:4b:aa:bb:cc:dd:ee -p /dev/tty.usbserial-10 ./fw.hex`, replace:
     - `00:12:4b:aa:bb:cc:dd:ee` with your coordinator ieee address (first `0x` can be skipped)
     - `/dev/tty.usbserial-10` with the path to your adapter


### PR DESCRIPTION
Added a note that some adapters have an autobootloader and don't require being put into bsl mode.