### PR TITLE
Update Hue Wall Switch Group Binding

### DIFF
--- a/docs/devices/929003017102.md
+++ b/docs/devices/929003017102.md
@@ -30,12 +30,14 @@ Press the reset Button for ten seconds to reset the device - the red LED flashes
 The red LED begins to flash every two seconds indicating pairing mode.
 
 ### Directly control Zigbee groups
-It's possible to configure this switch to directly control Zigbee groups. In this way the switch can control e.g. a group of light bulbs even when Zigbee2MQTT is not running. To accomplish this:
-1. In the Zigbee2MQTT frontend go to the *Groups* tab and create a new group if it does not already exist. Add devices to the groups which you like to be controlled by this switch.
-1. Add this device to the group . If this fails, wake-up the switch by triggering it and try again.
-1. In the Zigbee2MQTT frontend go to the switch -> *Bind* tab. Uncheck **all** clusters **except** `manuSpecificPhilips` (so only `manuSpecificPhilips` is checked) and click *Unbind* in the row where destination is `Coordinator`. If this fails, wake-up the switch by triggering it and try again.
+It's possible to configure this switch to directly control Zigbee groups. In this way the switch can control e.g. a group of light bulbs even when Zigbee2MQTT is not running. To accomplish this in the Zigbee2MQTT frontend:
+1. Go to the *Groups* tab and create a new group if it does not already exist. Add devices to the groups which you want to be controlled by this switch.
+1. Add this device to the group.
+1. Click on this device and go to the *Bind* tab. Uncheck **all** clusters **except** `manuSpecificPhilips` and `OnOff` (so only `manuSpecificPhilips` and `OnOff` are checked) and click *Unbind* in the row where destination is `Coordinator`.
+1. In the blank row at the bottom select endpoint 1 as the source endpoint, the group as the destination, tick `OnOff` and click bind.
 
 Notes:
+- The device needs to be awake to respond to chnages so you will need to trigger the switch to wake it up before assigning to the group or changing the bindings.
 - This device does not support direct binding (to a device instead of a group).
 - After doing this, no actions will be send to the coordinator anymore. To revert this (and stop the switch from directly controlling the group), press the yellow reconfigure button in the *About* tab.
 - Actions are only send for input 1 of the device, for input 2 no actions will be send (so a double rocker is **not** supported).

--- a/docs/devices/929003017102.md
+++ b/docs/devices/929003017102.md
@@ -37,7 +37,7 @@ It's possible to configure this switch to directly control Zigbee groups. In thi
 1. In the blank row at the bottom select endpoint 1 as the source endpoint, the group as the destination, tick `OnOff` and click bind.
 
 Notes:
-- The device needs to be awake to respond to chnages so you will need to trigger the switch to wake it up before assigning to the group or changing the bindings.
+- The device needs to be awake to respond to changes so you will need to trigger the switch to wake it up before assigning to the group or changing the bindings.
 - This device does not support direct binding (to a device instead of a group).
 - After doing this, no actions will be send to the coordinator anymore. To revert this (and stop the switch from directly controlling the group), press the yellow reconfigure button in the *About* tab.
 - Actions are only send for input 1 of the device, for input 2 no actions will be send (so a double rocker is **not** supported).


### PR DESCRIPTION
Updated instructions to ensure On/Off is bound to the group to keep Z2M in sync with the state of the group