### PR TITLE
Updated documentation of SLR1b to include Schedule mode preference

### DIFF
--- a/docs/devices/SLR1b.md
+++ b/docs/devices/SLR1b.md
@@ -79,6 +79,18 @@ Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
 Note: You will also notice that `temperature_setpoint_hold_duration` automatically changes to `0` which means `not set`. `occupied_heating_setpoint` automatically changes to `1` degree C.
 
 This will also stop any native boosts that are currently active.
+
+### Set heating mode to SCHEDULE
+Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
+```js
+{
+   "system_mode":"heat",
+   "temperature_setpoint_hold":"0"
+}
+```
+Note: This will revert any deviation of ```occupied_heating_setpoint``` previously set to what is defined in the schedule of the thermostat.
+
+This will also stop any native boosts that are currently active.
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/SLR1b.md
+++ b/docs/devices/SLR1b.md
@@ -54,7 +54,7 @@ Note: For device timing reasons, the payload needs to be sent as one single comm
 
 Also, the native boost can be used as a method to pause the heating too. To do so, set the temperature to a low value.
 
-### Set heating mode to ON
+### Set heating mode to MANUAL
 Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
 ```js
 {


### PR DESCRIPTION
After testing, updated documentation for Hive SLR1b to include ```schedule``` mode preference. This provides the ability to revert back to the configured schedule on the thermostat from an ```off```/```manual``` or ```native boost``` .

Also updated docs to bring in line the three state examples with how the information is displayed on the Hive Thermostat.