### PR TITLE
Add LEGRAND 064882 pairing process description and some troobleshoot

### DIFF
--- a/docs/devices/064882.md
+++ b/docs/devices/064882.md
@@ -97,3 +97,7 @@ It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `255`.
 The unit of this value is `lqi`.
 
+## Pairing process
+Step 1 - Reset the device, press the reset button for 8 seconds (it's the hole on the device). The light will be static red when the reset is complete
+Step 2 - Allow join on your coordinator and simple press (not a long press) the reset button. The light blinks green in pairing mode.
+Troobleshooting: The Legrand bridge shall be power off if you have one. If it is on, the interview will complete with zigbee2MQTT, but the device won't communicate after that

--- a/docs/devices/064882.md
+++ b/docs/devices/064882.md
@@ -23,8 +23,12 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
-
+## Pairing process
+Step 1 - Reset the device, press the reset button for 8 seconds (it's the hole on the device). The light will be static red when the reset is complete.
+Step 2 - Allow join on your coordinator and simple press (not a long press) the reset button. The light blinks green in pairing mode.
+Troobleshooting: The Legrand bridge shall be power off if you have one. If it is on, the interview will complete with zigbee2MQTT, but the device won't communicate after that.
 <!-- Notes END: Do not edit below this line -->
 
 
@@ -97,7 +101,3 @@ It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `255`.
 The unit of this value is `lqi`.
 
-## Pairing process
-Step 1 - Reset the device, press the reset button for 8 seconds (it's the hole on the device). The light will be static red when the reset is complete
-Step 2 - Allow join on your coordinator and simple press (not a long press) the reset button. The light blinks green in pairing mode.
-Troobleshooting: The Legrand bridge shall be power off if you have one. If it is on, the interview will complete with zigbee2MQTT, but the device won't communicate after that


### PR DESCRIPTION
I copy the pairing process from the Cartage post (author of this plugin) on the french home assistant forum 
[https://forum.hacf.fr/t/integration-legrand-cable-outlet-064882-a-zigbee2mqtt/8952/31](url)