### PR TITLE
Add troubleshoot note for random automation exceptions

### DIFF
--- a/docs/devices/E1524_E1810.md
+++ b/docs/devices/E1524_E1810.md
@@ -37,6 +37,9 @@ It may help to remove the battery for a few seconds and after that reconfigure i
 ### Troubleshooting: Device didn't respond to OTA request
 To resolve the `Device didn't respond to OTA request` error, you can try to push a button on it, shortly before you start the update, to wake up the Remote.
 
+### Troubleshooting: Automations triggered by button presses throw exceptions
+Make sure that automations that are triggered by the 'action' attribute of the remote are not configured in the 'restart' mode. Since there is an event for the button press (e.g. `arrow_left_click`) as well as for the release (e.g. `arrow_left_release`) the trigger will fire two times in rapid succession which may result in the automation being cancelled before it can finish its first run.
+
 ### Binding
 The [binding](../guide/usage/binding.md) functionallity of this remote varies per firmware version:
 - < 2.3.014: binding is not supported, OTA update your device to get binding functionallity


### PR DESCRIPTION
Automations in restart mode will often crash when being triggered by changes of the action attribute of the remote, because of the release action that happens immediately after the button press itself.

This problem is analog to what is described in this [issue](https://github.com/home-assistant/core/issues/98664).