### PR TITLE
Update the pairing guide for ikea motion sensor

### DIFF
--- a/docs/devices/E1525_E1745.md
+++ b/docs/devices/E1525_E1745.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 
 ### Pairing
-Pair the sensor to Zigbee2MQTT by pressing the pair button 4 times in a row.
+Pair the sensor to Zigbee2MQTT by long pressing the pair button for more than 10 seconds.
 The red light on the front side should flash a few times and then turn off.
 After a few seconds it turns back on and pulsate. When connected, the light turns off.
 


### PR DESCRIPTION
I purchased a few ikea motion sensors recently and paired four of them just now. I tried the method that is mentioned in the doc (pressing the pair button four times in a row) a few times but it didn't work. I then looked into the device's paring guide on ikea website (page 28 in [this pdf](https://www.ikea.com/nl/en/assembly_instructions/tradfri-wireless-motion-sensor-smart-white__AA-2140125-2-2.pdf)) and long pressing the pair button for 10 seconds made the device to pair with my home assistant coordinator instantly.