### PR TITLE
Update homeassistant.md - HASS discovery topic note

### DIFF
--- a/docs/guide/configuration/homeassistant.md
+++ b/docs/guide/configuration/homeassistant.md
@@ -15,6 +15,7 @@ homeassistant: true
 ```yaml
 homeassistant:
   # Optional: Home Assistant discovery topic (default: shown below)
+  # Note: should be different from [MQTT base topic](../mqtt.md) to prevent errors in HA software
   discovery_topic: 'homeassistant'
   # Optional: Home Assistant status topic (default: shown below)
   # Note: in addition to the `status_topic`, 'homeassistant/status' will also be used


### PR DESCRIPTION
Added a note to HASS discovery topic to prevent errors due to using the same topic for HASS discovery and base topic. (error made by me... https://github.com/domoticz/domoticz/issues/5859)