### PR TITLE
Update payload documentation for Busch-Jaeger 6735/6736/6737

### DIFF
--- a/docs/devices/6735_6736_6737.md
+++ b/docs/devices/6735_6736_6737.md
@@ -90,16 +90,20 @@ If you are using Home Assistant auto-discovery you'll notice that the device is 
 **Always use the `light` entity!** The `switch` entity is only there for historic (compatibility) reasons and can be safely ignored. The main issue with the `switch` entity is that it does not update it's state when the Busch-Jaeger device is controlled directly through it's top-row rockers.
 
 ### Action values
-This device send the following `action` values in its payload:
 
-| Left buttons                | (long-hold-release) | Right buttons            |
-|-----------------------------|---------------------|--------------------------|
-| `row_1_off`<br>`row_1_down` | `row_1_stop`        | `row_1_on`<br>`row_1_up` |
-| `row_2_off`<br>`row_2_down` | `row_2_stop`        | `row_2_on`<br>`row_2_up` |
-| `row_3_off`<br>`row_3_down` | `row_3_stop`        | `row_3_on`<br>`row_3_up` |
-| `row_4_off`<br>`row_4_down` | `row_4_stop`        | `row_4_on`<br>`row_4_up` |
+This device sends the following `action` values in its payload:
 
-Briefly pressing and releasing a button triggers the `off` resp. `on` actions for the given row, long-pressing triggers the `down`/`up` state respectively (after about one second). When releasing then, a `stop` will be issued with no distinction between the left or right button.
+| Left buttons                                | (long-hold-release)     | Right buttons                            |
+|---------------------------------------------|-------------------------|------------------------------------------|
+| `off_row_1`<br>`brightness_step_down_row_1` | `brightness_stop_row_1` | `on_row_1`<br>`brightness_step_up_row_1` |
+| `off_row_2`<br>`brightness_step_down_row_2` | `brightness_stop_row_2` | `on_row_2`<br>`brightness_step_up_row_2` |
+| `off_row_3`<br>`brightness_step_down_row_3` | `brightness_stop_row_3` | `on_row_3`<br>`brightness_step_up_row_3` |
+| `off_row_4`<br>`brightness_step_down_row_4` | `brightness_stop_row_4` | `on_row_4`<br>`brightness_step_up_row_4` |
+
+
+Briefly pressing and releasing a button triggers the `off_row_X` resp. `on_row_X` actions for the given row, long-pressing triggers the `brightness_step_down_row_X`/`brightness_step_up_row_X` state respectively (after about one second). When releasing the button after a long-press action, a `brightness_stop_row_X` will be issued with no distinction between the left or right button. Note that the action payload may be different when you have set the `legacy` flag for the device (not recommended).
+
+Depending on the device configuration not all actions may be sent.
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
Document the current action payload in the docs instead of the legacy payload.

Related: Koenkk/zigbee-herdsman-converters/issues/6444