### PR TITLE
Expand factory reset for Danfoss Ally

### DIFF
--- a/docs/devices/014G2461.md
+++ b/docs/devices/014G2461.md
@@ -33,9 +33,12 @@ pageClass: device-page
 * Push the "o" button for briefly to enter Pairing mode (can take upto 60 seconds).
 
 To factory reset:
-* Remove one battery.
-* Press and hold "o" button.
-* Insert battery and hold button pressed for about 3 seconds (display will flash all symbols).
+1. Remove the cover of the Ally™ Radiator Thermostat
+2. Remove one of the two batteries
+3. Press and hold the black button next to the digital display/screen while replacing the battery
+4. Insert the battery and release the button after 10 seconds
+5. The Ally™ Radiator Thermostat is now reset
+6. Place the cover of the Ally™ Radiator Thermostat back
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
Expands the factory reset steps to make them easier to follow.

The new steps are taken directly from the Danfoss' own FAQ at <https://www.danfoss.com/en/products/dhs/smart-heating/smart-heating/danfoss-ally/danfoss-ally-support/#tab-faq> "How to reset the Ally™ Radiator Thermostat?"