### PR TITLE
Hue dimmer switch: Provide specific instructions and mention more compatible devices

### DIFF
--- a/docs/devices/324131092621.md
+++ b/docs/devices/324131092621.md
@@ -37,7 +37,7 @@ You can let go when the light on the front flashes red/green briefly.
 Many devices can be factory reset / re-paired with a help of Hue dimmer switch:
 1. Make sure your device is powered on.
 2. Take the dimmer and hold the ON and OFF buttons close to your device for approximately 10 seconds. 
-3. After about 10 seconds both the ZBMINI (and whatever device you control by it) and the dimmer should flash.
+3. After about 10 seconds both your Zigbee device and the Hue dimmer should flash.
 4. Hold it down for a further one second.
 5. Your device should now be discoverable by your network.
 

--- a/docs/devices/324131092621.md
+++ b/docs/devices/324131092621.md
@@ -32,13 +32,19 @@ Factory reset the Hue dimmer switch by pressing and holding the setup button on 
 Restart the Hue dimmer switch by holding all 4 buttons of the Hue dimmer switch.
 You can let go when the light on the front flashes red/green briefly.
 
-#### Using the dimmer to reset a Hue light bulb
+#### Using the dimmer to reset other Zigbee devices
+
+Many devices can be factory reset / re-paired with a help of Hue dimmer switch:
+1. Make sure your device is powered on.
+2. Take the dimmer and hold the ON and OFF buttons close to your device for approximately 10 seconds. 
+3. After about 10 seconds both the ZBMINI (and whatever device you control by it) and the dimmer should flash.
+4. Hold it down for a further one second.
+5. Your device should now be discoverable by your network.
 
 To use the Hue dimmer switch to factory reset a Hue light bulb see
 [HOWTO: Factory reset a Hue bulb](https://www.youtube.com/watch?v=qvlEAELiJKs).
-After resetting the bulb will automatically connect.
-This method also works for Philips Hue Lightstrips.
-Hue dimmer switch can also be used to factory reset Ikea Trådfri light bulbs using the same method described above.
+
+This method also works for Philips Hue Lightstrips, IKEA Trådfri, Sonoff ZBMINI, and Tuya light bulbs.
 
 ### Binding
 If you want to bind the dimmer to a (Hue) lamp you'll have to *[bind it to the lamp through MQTT](../guide/usage/binding.md)* and unbind it from the coordinator. Use the dimmer as source and a literal `coordinator` as target for that.


### PR DESCRIPTION
> ⚠️ Note this PR is specifically for the [old version](https://www.zigbee2mqtt.io/devices/324131092621.html) of the dimmer. These instructions very likely apply to the [new one](https://www.zigbee2mqtt.io/devices/929002398602.html) as well but I don't have one to test.

Updating copy as I have tested this with the following:
- [Tuya](https://www.zigbee2mqtt.io/devices/TS0505B_1_1.html#tuya-ts0505b_1_1). Note I've actually tested it with a [Tuya LED ceiling lamp](https://www.aliexpress.com/item/1005005754093751.html) rather than a bulb but the zigbee module is recognised as [Tuya TS0505B_1_1](https://www.zigbee2mqtt.io/devices/TS0505B_1_1.html#tuya-ts0505b_1_1). There's probably an opportunity here to mention the ceiling lamp in the docs but I'd need some guidance as of what's needed and where to get the exact data from. It's a LED panel that's recognised as "Zigbee 3.0 18W led light bulb E27 RGBCW".
- [ZBMINI](https://www.zigbee2mqtt.io/devices/ZBMINI.html#sonoff-zbmini). This is a gamechanger given what I've [read on the Internet](https://www.reddit.com/r/sonoff/comments/r90s27/is_it_possible_to_force_zbmini_into_pairing_mode/) with people having trouble accessing their ZBMINI in their backboxes, or even a sealed outdoor units.