### PR TITLE
Remove Quotes from Hive Temperature Values

### DIFF
--- a/docs/devices/SLR1.md
+++ b/docs/devices/SLR1.md
@@ -45,9 +45,9 @@ To start one, or modify an already active one, send the following payload to the
 ```js
 {
    "system_mode":"emergency_heating",
-   "temperature_setpoint_hold_duration":"30",  // Replace with desired duration in minutes. Max 360. 0 to stop
-   "temperature_setpoint_hold":"1",
-   "occupied_heating_setpoint":"18"  // Replace with desired temperature. Between 5 and 32 C
+   "temperature_setpoint_hold_duration":30,  // Replace with desired duration in minutes. Max 360. 0 to stop
+   "temperature_setpoint_hold":1,
+   "occupied_heating_setpoint":18  // Replace with desired temperature. Between 5 and 32 C
 }
 ```
 Note: For device timing reasons, the payload needs to be sent as one single command. Sending individual commands or settings attributes manually using the Frontend will not work.
@@ -59,8 +59,8 @@ Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
 ```js
 {
    "system_mode":"heat",
-   "temperature_setpoint_hold":"1",
-   "occupied_heating_setpoint":"20" // Replace with desired temperature. Between 5 and 32 C
+   "temperature_setpoint_hold":1,
+   "occupied_heating_setpoint":20 // Replace with desired temperature. Between 5 and 32 C
 }
 ```
 Note: You will also notice that `temperature_setpoint_hold_duration` automatically changes to `65535` which means `undefined` (indefinite).
@@ -73,7 +73,7 @@ Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
 ```js
 {
    "system_mode":"off",
-   "temperature_setpoint_hold":"0"
+   "temperature_setpoint_hold":0
 }
 ```
 Note: You will also notice that `temperature_setpoint_hold_duration` automatically changes to `0` which means `not set`. `occupied_heating_setpoint` automatically changes to `1` degree C.

--- a/docs/devices/SLR1b.md
+++ b/docs/devices/SLR1b.md
@@ -45,9 +45,9 @@ To start one, or modify an already active one, send the following payload to the
 ```js
 {
    "system_mode":"emergency_heating",
-   "temperature_setpoint_hold_duration":"30",  // Replace with desired duration in minutes. Max 360. 0 to stop
-   "temperature_setpoint_hold":"1",
-   "occupied_heating_setpoint":"18"  // Replace with desired temperature. Between 5 and 32 C
+   "temperature_setpoint_hold_duration":30,  // Replace with desired duration in minutes. Max 360. 0 to stop
+   "temperature_setpoint_hold":1,
+   "occupied_heating_setpoint":18  // Replace with desired temperature. Between 5 and 32 C
 }
 ```
 Note: For device timing reasons, the payload needs to be sent as one single command. Sending individual commands or settings attributes manually using the Frontend will not work.
@@ -59,8 +59,8 @@ Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
 ```js
 {
    "system_mode":"heat",
-   "temperature_setpoint_hold":"1",
-   "occupied_heating_setpoint":"20" // Replace with desired temperature. Between 5 and 32 C
+   "temperature_setpoint_hold":1,
+   "occupied_heating_setpoint":20 // Replace with desired temperature. Between 5 and 32 C
 }
 ```
 Note: You will also notice that `temperature_setpoint_hold_duration` automatically changes to `65535` which means `undefined` (indefinite).
@@ -73,7 +73,7 @@ Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
 ```js
 {
    "system_mode":"off",
-   "temperature_setpoint_hold":"0"
+   "temperature_setpoint_hold":0
 }
 ```
 Note: You will also notice that `temperature_setpoint_hold_duration` automatically changes to `0` which means `not set`. `occupied_heating_setpoint` automatically changes to `1` degree C.
@@ -85,7 +85,7 @@ Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
 ```js
 {
    "system_mode":"heat",
-   "temperature_setpoint_hold":"0"
+   "temperature_setpoint_hold":0
 }
 ```
 Note: This will revert any deviation of ```occupied_heating_setpoint``` previously set to what is defined in the schedule of the thermostat.

--- a/docs/devices/SLR2.md
+++ b/docs/devices/SLR2.md
@@ -64,9 +64,9 @@ To start one, or modify an already active one, send the following payload to the
 ```js
 {
    "system_mode_heat":"emergency_heating",
-   "temperature_setpoint_hold_duration_heat":"30",  // Replace with desired duration in minutes. Max 360. 0 to stop
-   "temperature_setpoint_hold_heat":"1",
-   "occupied_heating_setpoint_heat":"18"  // Replace with desired temperature. Between 5 and 32 C
+   "temperature_setpoint_hold_duration_heat":30,  // Replace with desired duration in minutes. Max 360. 0 to stop
+   "temperature_setpoint_hold_heat":1,
+   "occupied_heating_setpoint_heat":18  // Replace with desired temperature. Between 5 and 32 C
 }
 ```
 Note: For device timing reasons, the payload needs to be sent as one single command. Sending individual commands or settings attributes manually using the Frontend will not work.
@@ -78,8 +78,8 @@ Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
 ```js
 {
    "system_mode_heat":"heat",
-   "temperature_setpoint_hold_heat":"1",
-   "occupied_heating_setpoint_heat":"20" // Replace with desired temperature. Between 5 and 32 C
+   "temperature_setpoint_hold_heat":1,
+   "occupied_heating_setpoint_heat":20 // Replace with desired temperature. Between 5 and 32 C
 }
 ```
 Note: You will also notice that `temperature_setpoint_hold_duration_heat` automatically changes to `65535` which means `undefined` (indefinite).
@@ -92,7 +92,7 @@ Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
 ```js
 {
    "system_mode_heat":"off",
-   "temperature_setpoint_hold_heat":"0"
+   "temperature_setpoint_hold_heat":0
 }
 ```
 Note: You will also notice that `temperature_setpoint_hold_duration_heat` automatically changes to `0` which means `not set`. `occupied_heating_setpoint_heat` automatically changes to `1` degree C.
@@ -107,8 +107,8 @@ To start one, or modify an already active one, send the following payload to the
 ```js
 {
    "system_mode_water":"emergency_heating",
-   "temperature_setpoint_hold_duration_water":"30",  // Replace with desired duration in minutes. Max 360. 0 to stop
-   "temperature_setpoint_hold_water":"1"
+   "temperature_setpoint_hold_duration_water":30,  // Replace with desired duration in minutes. Max 360. 0 to stop
+   "temperature_setpoint_hold_water":1
 }
 ```
 Note: For device timing reasons, the payload needs to be sent as one single command. Sending individual commands or settings attributes manually using the Frontend will not work.
@@ -118,7 +118,7 @@ Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
 ```js
 {
    "system_mode_water":"heat",
-   "temperature_setpoint_hold_water":"1"
+   "temperature_setpoint_hold_water":1
 }
 ```
 Note: You will also notice that `temperature_setpoint_hold_duration_heat` automatically changes to `65535` which means `undefined` (indefinite).
@@ -131,7 +131,7 @@ Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
 ```js
 {
    "system_mode_water":"off",
-   "temperature_setpoint_hold_water":"0"
+   "temperature_setpoint_hold_water":0
 }
 ```
 Note: You will also notice that `temperature_setpoint_hold_duration_heat` automatically changes to `0` which means `not set`.

--- a/docs/devices/SLR2b.md
+++ b/docs/devices/SLR2b.md
@@ -64,9 +64,9 @@ To start one, or modify an already active one, send the following payload to the
 ```js
 {
    "system_mode_heat":"emergency_heating",
-   "temperature_setpoint_hold_duration_heat":"30",  // Replace with desired duration in minutes. Max 360. 0 to stop
-   "temperature_setpoint_hold_heat":"1",
-   "occupied_heating_setpoint_heat":"18"  // Replace with desired temperature. Between 5 and 32 C
+   "temperature_setpoint_hold_duration_heat":30,  // Replace with desired duration in minutes. Max 360. 0 to stop
+   "temperature_setpoint_hold_heat":1,
+   "occupied_heating_setpoint_heat":18  // Replace with desired temperature. Between 5 and 32 C
 }
 ```
 Note: For device timing reasons, the payload needs to be sent as one single command. Sending individual commands or settings attributes manually using the Frontend will not work.
@@ -78,8 +78,8 @@ Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
 ```js
 {
    "system_mode_heat":"heat",
-   "temperature_setpoint_hold_heat":"1",
-   "occupied_heating_setpoint_heat":"20" // Replace with desired temperature. Between 5 and 32 C
+   "temperature_setpoint_hold_heat":1,
+   "occupied_heating_setpoint_heat":20 // Replace with desired temperature. Between 5 and 32 C
 }
 ```
 Note: You will also notice that `temperature_setpoint_hold_duration_heat` automatically changes to `65535` which means `undefined` (indefinite).
@@ -92,7 +92,7 @@ Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
 ```js
 {
    "system_mode_heat":"off",
-   "temperature_setpoint_hold_heat":"0"
+   "temperature_setpoint_hold_heat":0
 }
 ```
 Note: You will also notice that `temperature_setpoint_hold_duration_heat` automatically changes to `0` which means `not set`. `occupied_heating_setpoint_heat` automatically changes to `1` degree C.
@@ -107,8 +107,8 @@ To start one, or modify an already active one, send the following payload to the
 ```js
 {
    "system_mode_water":"emergency_heating",
-   "temperature_setpoint_hold_duration_water":"30",  // Replace with desired duration in minutes. Max 360. 0 to stop
-   "temperature_setpoint_hold_water":"1"
+   "temperature_setpoint_hold_duration_water":30,  // Replace with desired duration in minutes. Max 360. 0 to stop
+   "temperature_setpoint_hold_water":1
 }
 ```
 Note: For device timing reasons, the payload needs to be sent as one single command. Sending individual commands or settings attributes manually using the Frontend will not work.
@@ -118,7 +118,7 @@ Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
 ```js
 {
    "system_mode_water":"heat",
-   "temperature_setpoint_hold_water":"1"
+   "temperature_setpoint_hold_water":1
 }
 ```
 Note: You will also notice that `temperature_setpoint_hold_duration_heat` automatically changes to `65535` which means `undefined` (indefinite).
@@ -131,7 +131,7 @@ Send the following payload to the topic `zigbee2mqtt/FRIENDLY_NAME/set`:
 ```js
 {
    "system_mode_water":"off",
-   "temperature_setpoint_hold_water":"0"
+   "temperature_setpoint_hold_water":0
 }
 ```
 Note: You will also notice that `temperature_setpoint_hold_duration_heat` automatically changes to `0` which means `not set`.


### PR DESCRIPTION
Updating Hive Documentation per below issue. Removes quotes from Temperature values.

 [Issue](https://github.com/Koenkk/zigbee2mqtt/issues/19951)

