### PR TITLE
Fix Wireshark filter in Zigbee sniffing

### DIFF
--- a/docs/advanced/zigbee/04_sniff_zigbee_traffic.md
+++ b/docs/advanced/zigbee/04_sniff_zigbee_traffic.md
@@ -128,6 +128,6 @@ Once you have the application running, you should see it connect to and start sn
 
 After that, open up Wireshark and start capturing on the loopback adapter.
 
-Then, apply a filter `udp.port == 17754` in order to filter down to only Zigbee traffic.
+Then, apply a filter `udp port 17754` in order to filter down to only Zigbee traffic.
 
 Lastly, follow the steps of the CC2531 instructions above to set up your encryption keys the same.


### PR DESCRIPTION
Without this change, the _Start_ button is grayed out and an error message is shown:

![image](https://github.com/Koenkk/zigbee2mqtt.io/assets/318490/f09a63a3-a7d2-4fb3-950f-b5bfbdf20a60)

![image](https://github.com/Koenkk/zigbee2mqtt.io/assets/318490/52a9880a-6c2b-4a7b-8197-8fe629412c68)
