### PR TITLE
feat: update H1 notes to mention remote sensor binding and fix now incorrect vacation_mode info

### DIFF
--- a/docs/devices/H1.md
+++ b/docs/devices/H1.md
@@ -51,13 +51,26 @@ You can turn off the H1 by setting the `system_mode` to `off` or by using the on
 You can turn on the device again by setting `system_mode` to `heat` or by turning the dial on the device.
 
 ### Vacation Mode
-You cannot put the device in vacation mode over zigbee. This will always have to be done using the on device menu. The status will be visible in the device state.
-
 When in vacation mode (occupied heating) setpoint and schedule will be ignored. It will keep the room at 16ºC by default, however this can be changed by setting the unoccupied heating setpoint.
 
 ```bash
 mosquitto_pub -t zigbee2mqtt/<friendly_name>/set/unoccupied_heating_setpoint -m 14
 ```
+
+### Scheduling
+You can configure a schedule for the thermostat as wel, when the schedule ends the TRV will revert to the value configured in `occupied_heating_default_setpoint`.:w
+
+### Remote Temperature
+When running on a firmware version that is 1.5.0 or higher, you can now bind a sensor supporting `msTemperatureMeasurement` to the TRV.
+
+```bash
+# NOTE: if the msTemperatureMeasurement is not on endpoint 1, change the endpoint number on the sensor_friendly_name device.
+mosquitto_pub -t zigbee2mqtt/bridge/request/device/bind -m '{"clusters":["msTemperatureMeasurement"],"from":"<sensor_friendly_name>/1","to":"<trv_friendly_name>/1"}'
+```
+
+You can configure how long the remote temperature remains valid by setting `remote_temperature_duration` which defaults to 1 hour. You can manually read the `remote_temperature` attribute to see what value the device is using.
+It does not support reporting, when the value is not set or expire it will read as `-327.68`.
+
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
Should be merged after https://github.com/Koenkk/zigbee-herdsman-converters/pull/6810