### PR TITLE
Correct link to "coordinator check"

### DIFF
--- a/docs/guide/faq/README.md
+++ b/docs/guide/faq/README.md
@@ -15,7 +15,7 @@ This problem can be divided in 2 categories; no logging is shown at all OR inter
 ### No logging is shown at all
 - Make sure [joining is enabled](../usage/pairing_devices.md).
 - There can be too much interference, try connecting the coordinator USB through an USB extension cable. This problem occurs a lot when used in combination with a Raspberry Pi 3 and 4.
-- If you are using a Texas Instruments CC2652 or CC1352 based adapter, routers might be missing from the coordinator memory. Do a [coordinator check](../usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestcoordinator_check) and re-pair the missing routers.
+- If you are using a Texas Instruments CC2652 or CC1352 based adapter, routers might be missing from the coordinator memory. Do a [coordinator check](../usage/mqtt_topics_and_messages.md#zigbee2mqtt-bridge-request-coordinator-check) and re-pair the missing routers.
 - If you are using a Raspberry Pi, try disconnecting any other USB devices. If after that pairing works, try connecting the USB devices via a powered USB hub.
 - Make sure that any other Zigbee networks/hubs are powered down. When you e.g. want to pair an IKEA bulb which was first paired to the IKEA gateway make sure to power down the IKEA gateway. If that doesn't help also try powering down all devices that are connected to the IKEA hub.
 - If it's a battery powered device, try replacing the battery.


### PR DESCRIPTION
used an old anchor, should jump to the desired topic now.