### PR TITLE
Update Philips 929003017102 Hue Wall Switch Module docs

### DIFF
--- a/docs/devices/929003017102.md
+++ b/docs/devices/929003017102.md
@@ -32,7 +32,7 @@ Out of the box, the device enters pairing mode, as soon as the pins of input 1 a
 If the device has not been paired yet, it can also be put into pairing mode by short pressing the reset button.
 
 ### Directly control Zigbee groups
-It's possible to configure this switch to directly control Zigbee groups. In this way, the switch can control e.g. a group of light bulbs even when Zigbee2MQTT is not running. To accomplish this in the Zigbee2MQTT frontend:
+It's possible to configure this switch to directly control Zigbee groups. In this way, the switch can control e.g. a group of light bulbs even when Zigbee2MQTT is not running, and it can also make controlling the lights feel a bit more responsive. To accomplish this in the Zigbee2MQTT frontend:
 1. Go to the *Groups* tab and create a new group if it does not already exist. Add devices to the groups that you want to be controlled by this switch.
 1. Add this device to the group. Note that this device will not show up in the group, but this step is important.
 1. Click on this device and go to the *Bind* tab. Modify the checkboxes so that only `manuSpecificPhilips`, `OnOff`, and `LevelCtrl` (optional ¹) are checked, and click *Unbind* in the row where the destination is `Coordinator`.

--- a/docs/devices/929003017102.md
+++ b/docs/devices/929003017102.md
@@ -34,7 +34,7 @@ If the device has not been paired yet, it can also be put into pairing mode by s
 ### Directly control Zigbee groups
 It's possible to configure this switch to directly control Zigbee groups. In this way, the switch can control e.g. a group of light bulbs even when Zigbee2MQTT is not running, and it can also make controlling the lights feel a bit more responsive. This switch can also act as a dimmer: for each successive long press of the switch, it will alternate between increasing and decreasing brightness. To set this all up, follow these steps in the Zigbee2MQTT frontend:
 1. Go to the *Groups* tab and create a new group if it does not already exist. Add devices to the groups that you want to be controlled by this switch.
-1. Add this Hue Wall Switch Module to the group. Note that this device will not show up in the group, but this step is important.
+1. Add this Hue Wall Switch Module to the group. Note that this device might not show up in the group, but this step is important.
 1. Click on this device and go to the *Bind* tab. Modify the checkboxes so that only `manuSpecificPhilips`, `OnOff`, and `LevelCtrl` (optional ¹) are checked, and click *Unbind* in the row where the destination is `Coordinator`.
 1. In the blank row at the bottom select endpoint 1 as the source endpoint, the group as the destination, tick `OnOff` and `LevelCtrl` (optional ¹), and click bind.
 

--- a/docs/devices/929003017102.md
+++ b/docs/devices/929003017102.md
@@ -28,22 +28,22 @@ pageClass: device-page
 ### Pairing
 Press the reset button for ten seconds to reset the device - the red LED flashes one time confirming the reset. Then short the pins of input one.  
 The red LED begins to flash every two seconds indicating pairing mode.
-Out of the box, the device enters pairing mode, as soon as the pins of input one are shortened - the red LED starts to flash.
+Out of the box, the device enters pairing mode, as soon as the pins of input 1 are shortened - the red LED starts to flash.
 If the device has not been paired yet, it can also be put into pairing mode by short pressing the reset button.
 
 ### Directly control Zigbee groups
-It's possible to configure this switch to directly control Zigbee groups. In this way the switch can control e.g. a group of light bulbs even when Zigbee2MQTT is not running. To accomplish this in the Zigbee2MQTT frontend:
-1. Go to the *Groups* tab and create a new group if it does not already exist. Add devices to the groups which you want to be controlled by this switch.
+It's possible to configure this switch to directly control Zigbee groups. In this way, the switch can control e.g. a group of light bulbs even when Zigbee2MQTT is not running. To accomplish this in the Zigbee2MQTT frontend:
+1. Go to the *Groups* tab and create a new group if it does not already exist. Add devices to the groups that you want to be controlled by this switch.
 1. Add this device to the group. Note that this device will not show up in the group, but this step is important.
-1. Click on this device and go to the *Bind* tab. Uncheck **all** clusters **except** `manuSpecificPhilips` and `OnOff` (so only `manuSpecificPhilips` and `OnOff` are checked) and click *Unbind* in the row where destination is `Coordinator`.
-1. In the blank row at the bottom select endpoint 1 as the source endpoint, the group as the destination, tick `OnOff` and click bind.
+1. Click on this device and go to the *Bind* tab. Modify the checkboxes so that only `manuSpecificPhilips`, `OnOff`, and `LevelCtrl` (optional ¹) are checked, and click *Unbind* in the row where the destination is `Coordinator`.
+1. In the blank row at the bottom select endpoint 1 as the source endpoint, the group as the destination, tick `OnOff` and `LevelCtrl` (optional ¹), and click bind.
 
 Notes:
-- The device needs to be awake to respond to changes so you will need to trigger the switch to wake it up before assigning to the group or changing the bindings.
+- The device needs to be awake to respond to changes, so you will need to trigger the switch to wake it up before assigning it to the group or changing the bindings.
 - This device does not support direct binding (to a device instead of a group).
 - After doing this, the power events are still sent and can hence be used for automation.
 - Pressing the yellow reconfigure button in the *About* tab will reset the bindings of the coordinator, but it will not unbind any groups - they have to be unbound explicitly.
-- Actions are only sent for input 1 of the device, for input 2 no actions will be sent (so a double rocker is **not** supported).
+- Actions are only sent for input 1 of the device. For input 2 no actions will be sent (so a double rocker is **not** supported).
 <!-- Notes END: Do not edit below this line -->
 
 
@@ -52,7 +52,7 @@ Notes:
 ## Exposes
 
 ### Battery (numeric)
-Remaining battery in %, can take up to 24 hours before reported..
+Remaining battery in %, can take up to 24 hours before reported.
 Value can be found in the published state on the `battery` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `100`.

--- a/docs/devices/929003017102.md
+++ b/docs/devices/929003017102.md
@@ -32,13 +32,14 @@ Out of the box, the device enters pairing mode, as soon as the pins of input 1 a
 If the device has not been paired yet, it can also be put into pairing mode by short pressing the reset button.
 
 ### Directly control Zigbee groups
-It's possible to configure this switch to directly control Zigbee groups. In this way, the switch can control e.g. a group of light bulbs even when Zigbee2MQTT is not running, and it can also make controlling the lights feel a bit more responsive. To accomplish this in the Zigbee2MQTT frontend:
+It's possible to configure this switch to directly control Zigbee groups. In this way, the switch can control e.g. a group of light bulbs even when Zigbee2MQTT is not running, and it can also make controlling the lights feel a bit more responsive. This switch can also act as a dimmer: for each successive long press of the switch, it will alternate between increasing and decreasing brightness. To set this all up, follow these steps in the Zigbee2MQTT frontend:
 1. Go to the *Groups* tab and create a new group if it does not already exist. Add devices to the groups that you want to be controlled by this switch.
 1. Add this device to the group. Note that this device will not show up in the group, but this step is important.
 1. Click on this device and go to the *Bind* tab. Modify the checkboxes so that only `manuSpecificPhilips`, `OnOff`, and `LevelCtrl` (optional ¹) are checked, and click *Unbind* in the row where the destination is `Coordinator`.
 1. In the blank row at the bottom select endpoint 1 as the source endpoint, the group as the destination, tick `OnOff` and `LevelCtrl` (optional ¹), and click bind.
 
 Notes:
+- ¹ If you don't want to use the brightness control capabilities of the switch, ignore `LevelCtrl` in the steps.
 - The device needs to be awake to respond to changes, so you will need to trigger the switch to wake it up before assigning it to the group or changing the bindings.
 - This device does not support direct binding (to a device instead of a group).
 - After doing this, the power events are still sent and can hence be used for automation.

--- a/docs/devices/929003017102.md
+++ b/docs/devices/929003017102.md
@@ -34,7 +34,7 @@ If the device has not been paired yet, it can also be put into pairing mode by s
 ### Directly control Zigbee groups
 It's possible to configure this switch to directly control Zigbee groups. In this way, the switch can control e.g. a group of light bulbs even when Zigbee2MQTT is not running, and it can also make controlling the lights feel a bit more responsive. This switch can also act as a dimmer: for each successive long press of the switch, it will alternate between increasing and decreasing brightness. To set this all up, follow these steps in the Zigbee2MQTT frontend:
 1. Go to the *Groups* tab and create a new group if it does not already exist. Add devices to the groups that you want to be controlled by this switch.
-1. Add this device to the group. Note that this device will not show up in the group, but this step is important.
+1. Add this Hue Wall Switch Module to the group. Note that this device will not show up in the group, but this step is important.
 1. Click on this device and go to the *Bind* tab. Modify the checkboxes so that only `manuSpecificPhilips`, `OnOff`, and `LevelCtrl` (optional ¹) are checked, and click *Unbind* in the row where the destination is `Coordinator`.
 1. In the blank row at the bottom select endpoint 1 as the source endpoint, the group as the destination, tick `OnOff` and `LevelCtrl` (optional ¹), and click bind.
 


### PR DESCRIPTION
I discovered that [this device](https://www.zigbee2mqtt.io/devices/929003017102.html) supports the `LevelCtrl` cluster for bound groups! I extended the binding instructions accordingly.

(I also did some boy scouting and put some effort into improving the documentation's phrasing and grammar, I hope I didn't make it worse :sweat_smile:)