### PR TITLE
Update herdsman debug log section for Home Assistant OS

### DIFF
--- a/docs/guide/usage/debug.md
+++ b/docs/guide/usage/debug.md
@@ -37,5 +37,7 @@ To grab all the logs, log in via SSH and execute:
 docker logs CONTAINER_ID > log.txt 2>&1
 ```
 
+To determine the `CONTAINER_ID` execute `docker ps`.
+
 ## Change log level during runtime
 See [MQTT topics and message structure](./mqtt_topics_and_messages.md)

--- a/docs/guide/usage/debug.md
+++ b/docs/guide/usage/debug.md
@@ -24,21 +24,12 @@ To enable debug logging for Zigbee-herdman start Zigbee2MQTT with: `DEBUG=zigbee
 To enable debug logging in the Zigbee2MQTT Docker container add `-e DEBUG=zigbee-herdsman*` to your `docker run` command. The logging can be retrieved via `docker logs ZIGBEE2MQTT_CONTAINER_NAME > log.txt 2>&1`.
 
 ### Home Assistant OS/Supervised addon
-- Go to `Supervisor` in the main menu and click on the `Zigbee2MQTT` addon.
+- Go to `Supervisor` in the main menu and click on the `Zigbee2MQTT` addon or follow this deep [link](https://my.home-assistant.io/redirect/supervisor_addon/?addon=45df7312_zigbee2mqtt&repository_url=https%3A%2F%2Fgithub.com%2Fzigbee2mqtt%2Fhassio-zigbee2mqtt) 
 - In the top tabs, click on `Configuration`
-- Add the following to the end of the file, with no spaces or tabs preceding it:
-  `zigbee_herdsman_debug: true`
+- Toggle the option: `zigbee_herdsman_debug`
 - Click `Save`, and when prompted to restart, click `Restart add-on`
 
-Herdsman debug logs should now sow up on the `Logs` tab for the addon.
-
-To grab all the logs, log in via SSH and execute:
-
-```
-docker logs CONTAINER_ID > log.txt 2>&1
-```
-
-To determine the `CONTAINER_ID` execute `docker ps`.
+Herdsman debug logs should now be available in the log tab.
 
 ## Change log level during runtime
 See [MQTT topics and message structure](./mqtt_topics_and_messages.md)

--- a/docs/guide/usage/debug.md
+++ b/docs/guide/usage/debug.md
@@ -29,7 +29,13 @@ To enable debug logging in the Zigbee2MQTT Docker container add `-e DEBUG=zigbee
 - Toggle the option: `zigbee_herdsman_debug`
 - Click `Save`, and when prompted to restart, click `Restart add-on`
 
-Herdsman debug logs should now be available in the log tab.
+Herdsman debug logs should now show up on the `Logs` tab for the addon.
+
+To grab all the logs, log in via SSH and execute:
+
+```
+docker logs CONTAINER_ID > log.txt 2>&1
+```
 
 ## Change log level during runtime
 See [MQTT topics and message structure](./mqtt_topics_and_messages.md)


### PR DESCRIPTION
Update the instructions.
We now have a button available and not configuration text. Also add a deep link to the zigbee2mqtt addon