### PR TITLE
Add WSDCGQ11LM pairing tip: use nearby router to connect to

### DIFF
--- a/docs/devices/WSDCGQ11LM.md
+++ b/docs/devices/WSDCGQ11LM.md
@@ -34,7 +34,9 @@ After this the device will automatically join. If this doesn't work, try with a 
 
 ![WSDCGQ11LM pairing](../images/pairing/WSDCGQ11LM_pairing.jpg)
 
-*Note: When you fail to pair a device, try replacing the battery, this could solve the problem.*
+If the device fails to pair:
+* Instead of using "Permit join (All)" use the drop-down arrow to select a Zigbee router device near where the sensor will be located to pair to.
+* Try replacing the battery.
 
 ### Troubleshooting: device stops sending messages/disconnects from network
 Since Xiaomi devices do not fully comply to the Zigbee standard, it sometimes happens that they disconnect from the network.


### PR DESCRIPTION
Add a tip to the pairing instructions.

These devices are notoriously bad for pairing.

After trying many, many times to pair one of these sensors, I was able to immediately pair it by selecting a specific Zigbee router device rather than using "All" or "coordinator". 

<img width="438" alt="Screenshot 2024-01-13 at 11 14 33 AM" src="https://github.com/Koenkk/zigbee2mqtt.io/assets/4720401/4bd1f8d9-704f-4115-b1a0-ed98ef91d259">

<img width="553" alt="Screenshot 2024-01-13 at 11 14 43 AM" src="https://github.com/Koenkk/zigbee2mqtt.io/assets/4720401/9ff5072f-a51f-432d-b4b2-42bd9146535c">