### PR TITLE
Improve Z3-1BR pairing instructions

### DIFF
--- a/docs/devices/Z3-1BRL.md
+++ b/docs/devices/Z3-1BRL.md
@@ -26,16 +26,19 @@ pageClass: device-page
 ## Notes
 
 ### Enter pairing mode
-Enter pairing mode by quickly double tapping the dimmer button.
 
-### Factory reset
-If the dimmer was previously paired to another hub, you will need to factory reset it using the following procedure:
+For new devices:
+* Quickly double tap the dimmer button.
 
-1. Quickly tap the dimmer button 3x
-2. On the third tap, continue holding until the LED begins to blink
-3. Quickly tap the dimmer button 3 more times
+For previously paired devices:
+1. Quickly tap the dimmer button 4x.
+2. On the fourth tap, hold until the LED begins to blink.
+3. Immediately, quickly tap the dimmer button 3 more times.
 
 See this [configuration guide](https://www.lutron.com/TechnicalDocumentLibrary/0301916_Aurora_Advanced_Install_Guide.pdf#page=7) for more information.
+
+If a red light flashes, the battery is low and must be replaced before pairing.
+
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
* Fix "3x" to "4x"
* Make more succinct: "### Factory reset..." -> "For previously paired devices:"
* Add instruction for red light = low battery