### PR TITLE
Update LLKZMK12LM.md

### DIFF
--- a/docs/devices/LLKZMK12LM.md
+++ b/docs/devices/LLKZMK12LM.md
@@ -143,7 +143,7 @@ The possible values are: `decoupled`, `control_relay`.
 Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
-The possible values are: `single`.
+The possible values are: `single_l1`, `off_l1`, `single_l2`,  `off_l2`.
 
 ### Interlock (binary)
 Enabling prevents both relays being on at the same time (Interlock).


### PR DESCRIPTION
Actions depend on what input (S1 or S2) is triggered. Have not been able to trigger just 'single' according to previous documentation, only the following values: `single_l1`, `off_l1`, `single_l2` and `off_l2`.

At the very least the documentation should be appended with the values above.