### PR TITLE
Added notes on 1.2v AAA batteries for VALLHORN

### DIFF
--- a/docs/devices/E2134.md
+++ b/docs/devices/E2134.md
@@ -30,6 +30,9 @@ pageClass: device-page
 Pair the sensor to Zigbee2MQTT by long pressing the pair button for more than 10 seconds.
 The red light on the front side should flash a few times and then turn off. If the light red light does not show up and batteries are OK, try pressing the pair button 4 short times.
 After a few seconds it turns back on and pulsate. When connected, the light turns off.
+
+### Common problems
+Many has experienced using 1.2v AAA batteries (instead of the common 1.5v) makes the device behave correctly. Using 1.5v might result in unexpected behavior like unable to connect and false-positive motion detection.
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
HA forum is full of example where switching to 1.2v AAA batteries for VALLHORN fixes unexpected behavior (myself included).