### PR TITLE
Move information from device description into notes

### DIFF
--- a/docs/devices/DLKZMK12LM.md
+++ b/docs/devices/DLKZMK12LM.md
@@ -23,7 +23,13 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+### Router functionality
+This device **does not** work as a Zigbee router.
+
+### Power meter functionality
+This device **does not** support power metering.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/QBKG03LM.md
+++ b/docs/devices/QBKG03LM.md
@@ -28,6 +28,9 @@ pageClass: device-page
 ### Router functionality
 This device **does not** work as a Zigbee router.
 
+### Power meter functionality
+This device **does not** support power metering.
+
 ### Deprecated click event
 By default this device exposes a deprecated `click` event. It's recommended to use the `action` event instead.
 

--- a/docs/devices/QBKG04LM.md
+++ b/docs/devices/QBKG04LM.md
@@ -28,6 +28,9 @@ pageClass: device-page
 ### Router functionality
 This device **does not** work as a Zigbee router.
 
+### Power meter functionality
+This device **does not** support power metering.
+
 ### Debounce
 It is recommended to not use the `debounce` option for this device since this will prevent the `single` and `hold_release` actions from being sent.
 

--- a/docs/devices/SSM-U02.md
+++ b/docs/devices/SSM-U02.md
@@ -23,7 +23,13 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+### Router functionality
+This device **does not** work as a Zigbee router.
+
+### Power meter functionality
+This device **does not** support power metering.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
As mentioned in this [PR](https://github.com/Koenkk/zigbee-herdsman-converters/pull/6969), moved relevant information from device descriptions into notes section for Aqara `DLKZMK12LM`, `SSM-U02`, `QBKG04LM` and `QBKG03LM`.