### PR TITLE
Update TS0002.md

### DIFF
--- a/docs/devices/TS0002.md
+++ b/docs/devices/TS0002.md
@@ -20,11 +20,12 @@ pageClass: device-page
 | Description | 2 gang switch |
 | Exposes | switch (state), linkquality |
 | Picture | ![TuYa TS0002](https://www.zigbee2mqtt.io/images/devices/TS0002.jpg) |
-| White-label | Zemismart ZM-CSW002-D_switch, Lonsonho X702, AVATTO ZTS02 |
+| White-label | Zemismart ZM-CSW002-D_switch, Lonsonho X702, AVATTO ZTS02, Mercator Ikuü SSW02 |
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+Mercator Ikuü SSW02 installed 30/1/24 was recognised as TS0002. All functions work as per existing TS0002 description.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
Update to include additional white-label item, Mercator Ikuü SSW02, as at https://www.ikuu.com.au/product/twin-switch/.