### PR TITLE
Fix device card description size and text overflow problems

### DIFF
--- a/supported-devices-component/components/device.vue
+++ b/supported-devices-component/components/device.vue
@@ -90,6 +90,8 @@ $bgColor: #F2F2F2;
   .desc {
     padding: 0.3rem 0.5rem;
     font-size: 12px;
+    overflow: hidden;
+    max-height: 3.24rem;
   }
 
   .model {


### PR DESCRIPTION
Small fix that turns this

![Снимок экрана 2024-02-03 в 21 51 53](https://github.com/Koenkk/zigbee2mqtt.io/assets/32013287/630fe96c-052c-457e-90fa-1aae3f49f083)

into this

![Снимок экрана 2024-02-03 в 21 52 33](https://github.com/Koenkk/zigbee2mqtt.io/assets/32013287/d9495f98-3951-4ada-a1f3-b0b7b9567abf)

for all devices with long list of exposes.