### PR TITLE
Update NLG-TW_light.md with pairing information

### DIFF
--- a/docs/devices/NLG-TW_light.md
+++ b/docs/devices/NLG-TW_light.md
@@ -23,7 +23,20 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Options
+### Pairing
+You can reset the light either with a Q-remote (recommended) or via a click sequence with a connected switch to the light. After the light has been resetted, it automatically starts the pairing process. This should be the same for all Paul Neuhaus Q-lights (though untested!).
+#### Pairing with Q-remote
+1. Hold the Q-remote VERY close to the light. The distance to the light's antenna must be less than 10cm.
+2. Press the ON and OFF switch of the Q-remote simultaneously for more than 5 secondes.
 
+The status LED of the Q-remote flashes once per second. After 5 seconds the (ceiling) light flashes multiple times to signal the successful reset. A new flash sequence signals the pairing process. If the flashing ends the light should be paired successfully.  
+#### Pairing with a click sequence
+I got the pairing right with this method once. However, it is extremley difficult to get the timing right. Therefore the pairing with the Q-remote is recommended.
+
+1. Switch on the light for 5 to 10 seconds.
+2. Switch off the light.
+3. Switch on and off the light at least 4 times untill the light starts blinking several times. In this sequence assure to wait for 1-2 seconds between each new switch-on.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
Pairing information for Paul Neuhaus Q-lights added. 
Two possibilities: Either via a Q-remote or via a switch sequence with a switch connected to the light.