### PR TITLE
Update PCI_E.md with pairing instructions

### DIFF
--- a/docs/devices/PCI_E.md
+++ b/docs/devices/PCI_E.md
@@ -44,6 +44,7 @@ To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/
 If value equals `ON` state is ON, if `OFF` OFF.
 
 ### Buzzer feedback (binary)
+Enable buzzer feedback. It sounds on device actions like power state changes, child lock activation, etc.
 Value can be found in the published state on the `buzzer_feedback` property.
 It's not possible to read (`/get`) this value.
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"buzzer_feedback": NEW_VALUE}`.

--- a/docs/devices/PCI_E.md
+++ b/docs/devices/PCI_E.md
@@ -23,8 +23,12 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
 
+### Pairing
+Long press the reset button for 5s until the LED indicator flashes three times, which means the device has entered pairing mode. If buzzer feedback is on then you'll also hear 3 short beeps.
+The reset button can be found on the PCIe card.
 <!-- Notes END: Do not edit below this line -->
 
 
@@ -40,7 +44,6 @@ To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/
 If value equals `ON` state is ON, if `OFF` OFF.
 
 ### Buzzer feedback (binary)
-ON means no buzzer noise.
 Value can be found in the published state on the `buzzer_feedback` property.
 It's not possible to read (`/get`) this value.
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"buzzer_feedback": NEW_VALUE}`.


### PR DESCRIPTION
Added pairing instructions.
I also removed `ON means no buzzer noise.` Turns out I was wrong and ON in fact does mean buzzer noise is on.