### PR TITLE
Add links from zigbee-herdsman-converters to notes section

### DIFF
--- a/docs/devices/CC2530.ROUTER.md
+++ b/docs/devices/CC2530.ROUTER.md
@@ -24,6 +24,7 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
+[CC2530 router](http://ptvo.info/cc2530-based-zigbee-coordinator-and-router-112/)
 
 
 ### Pairing

--- a/docs/devices/CC2538.ROUTER.V1.md
+++ b/docs/devices/CC2538.ROUTER.V1.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[MODKAM stick СС2538 router](https://github.com/jethome-ru/zigbee-firmware/tree/master/ti/router/cc2538_cc2592)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/CC2538.ROUTER.V2.md
+++ b/docs/devices/CC2538.ROUTER.V2.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[MODKAM stick СС2538 router with temperature sensor](https://github.com/jethome-ru/zigbee-firmware/tree/master/ti/router/cc2538_cc2592)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/DIYRuZ_AirSense.md
+++ b/docs/devices/DIYRuZ_AirSense.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[Air quality sensor](https://modkam.ru/?p=1715)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/DIYRuZ_Flower.md
+++ b/docs/devices/DIYRuZ_Flower.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[Flower sensor](http://modkam.ru/?p=1700)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/DIYRuZ_FreePad.md
+++ b/docs/devices/DIYRuZ_FreePad.md
@@ -24,6 +24,7 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
+[DiY 8/12/20 button keypad](http://modkam.ru/?p=1114)
 
 
 ### Firmware

--- a/docs/devices/DIYRuZ_Geiger.md
+++ b/docs/devices/DIYRuZ_Geiger.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[DiY Geiger counter](https://modkam.ru/?p=1591)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/DIYRuZ_KEYPAD20.md
+++ b/docs/devices/DIYRuZ_KEYPAD20.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[DiY 20 button keypad](http://modkam.ru/?p=1114)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/DIYRuZ_R4_5.md
+++ b/docs/devices/DIYRuZ_R4_5.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[DiY 4 Relays + 4 switches + 1 buzzer](http://modkam.ru/?p=1054)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/DIYRuZ_R8_8.md
+++ b/docs/devices/DIYRuZ_R8_8.md
@@ -24,6 +24,7 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
+[DiY 8 Relays + 8 switches](https://modkam.ru/?p=1638)
 
 
 ### Deprecated click event

--- a/docs/devices/DIYRuZ_RT.md
+++ b/docs/devices/DIYRuZ_RT.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[DiY CC2530 Zigbee 3.0 firmware](https://habr.com/ru/company/iobroker/blog/495926/)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/DIYRuZ_Zintercom.md
+++ b/docs/devices/DIYRuZ_Zintercom.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[Matrix intercom auto opener](https://diyruz.github.io/posts/zintercom/)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/DIYRuZ_magnet.md
+++ b/docs/devices/DIYRuZ_magnet.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[DIYRuZ contact sensor](https://modkam.ru/?p=1220)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/DIYRuZ_rspm.md
+++ b/docs/devices/DIYRuZ_rspm.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[DIYRuZ relay switch power meter](https://modkam.ru/?p=1309)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/DNCKATSD001.md
+++ b/docs/devices/DNCKATSD001.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[DNCKAT single key wired wall dimmable light switch](https://github.com/dzungpv/dnckatsw00x/)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/DNCKATSW001.md
+++ b/docs/devices/DNCKATSW001.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[DNCKAT single key wired wall light switch](https://github.com/dzungpv/dnckatsw00x/)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/DNCKATSW002.md
+++ b/docs/devices/DNCKATSW002.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[DNCKAT double key wired wall light switch](https://github.com/dzungpv/dnckatsw00x/)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/DNCKATSW003.md
+++ b/docs/devices/DNCKATSW003.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[DNCKAT triple key wired wall light switch](https://github.com/dzungpv/dnckatsw00x/)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/DNCKATSW004.md
+++ b/docs/devices/DNCKATSW004.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[DNCKAT quadruple key wired wall light switch](https://github.com/dzungpv/dnckatsw00x/)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/EFEKTA_CO2_Smart_Monitor.md
+++ b/docs/devices/EFEKTA_CO2_Smart_Monitor.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[EFEKTA CO2 Smart Monitor, ws2812b indicator, can control the relay, binding](https://efektalab.com/CO2_Monitor)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/EFEKTA_PWS_Max.md
+++ b/docs/devices/EFEKTA_PWS_Max.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[Plant watering sensor EFEKTA PWS max](http://efektalab.com/PWS_Max)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/EFEKTA_PWS_MaxPro.md
+++ b/docs/devices/EFEKTA_PWS_MaxPro.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[Plant watering sensor EFEKTA PWS Max Pro,  long battery life](http://efektalab.com/PWS_MaxPro)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/EFEKTA_THP.md
+++ b/docs/devices/EFEKTA_THP.md
@@ -24,6 +24,7 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
+[DIY temperature, humidity and atmospheric pressure sensor, long battery life](http://efektalab.com/eON_THP)
 
 
 ### Build guide

--- a/docs/devices/EFEKTA_eFlower_Pro.md
+++ b/docs/devices/EFEKTA_eFlower_Pro.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[Plant Wattering Sensor with e-ink display 2.13](https://efektalab.com/eFlowerPro)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/EFEKTA_eON213wz.md
+++ b/docs/devices/EFEKTA_eON213wz.md
@@ -24,6 +24,7 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
+[Mini weather station, digital barometer, forecast, charts, temperature, humidity](http://efektalab.com/eON213wz)
 
 
 ### Build guide

--- a/docs/devices/EFEKTA_eON213z.md
+++ b/docs/devices/EFEKTA_eON213z.md
@@ -24,6 +24,7 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
+[Temperature and humidity sensor with e-ink2.13](http://efektalab.com/eON213z)
 
 
 ### Build guide

--- a/docs/devices/EFEKTA_eON29wz.md
+++ b/docs/devices/EFEKTA_eON29wz.md
@@ -24,6 +24,7 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
+[Mini weather station, barometer, forecast, charts, temperature, humidity, light](http://efektalab.com/eON290wz)
 
 
 ### Build guide

--- a/docs/devices/EFEKTA_ePWS.md
+++ b/docs/devices/EFEKTA_ePWS.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[Plant wattering sensor with e-ink display](https://efektalab.com/epws102)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/EFEKTA_eTH102.md
+++ b/docs/devices/EFEKTA_eTH102.md
@@ -24,6 +24,7 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
+[Mini digital thermometer & hygrometer with e-ink1.02](http://efektalab.com/eTH102)
 
 
 ### Build guide

--- a/docs/devices/EFEKTA_iAQ.md
+++ b/docs/devices/EFEKTA_iAQ.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[CO2 Monitor with IPS TFT Display, outdoor temperature and humidity, date and time](http://efektalab.com/iAQ)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/EFEKTA_miniPWS.md
+++ b/docs/devices/EFEKTA_miniPWS.md
@@ -24,6 +24,7 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
+[Mini plant wattering sensor](http://efektalab.com/miniPWS)
 
 
 ### Build guide

--- a/docs/devices/FreePad_LeTV_8.md
+++ b/docs/devices/FreePad_LeTV_8.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[LeTV 8key FreePad mod](https://modkam.ru/?p=1791)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/GWRJN5169.md
+++ b/docs/devices/GWRJN5169.md
@@ -24,6 +24,7 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
+[Lumi Router (JN5169)](https://github.com/igo-r/Lumi-Router-JN5169)
 
 
 ### Firmware

--- a/docs/devices/MULTI-ZIG-SW.md
+++ b/docs/devices/MULTI-ZIG-SW.md
@@ -24,6 +24,7 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
+[Multi switch from Smarthjemmet.dk](https://smarthjemmet.dk)
 ### Pairing
 If the device did not automatically start in pairing mode (LED blinking), you can start it manually by powering on and off the device four times, keeping it on the 4th time.
 

--- a/docs/devices/QUAD-ZIG-SW.md
+++ b/docs/devices/QUAD-ZIG-SW.md
@@ -24,6 +24,7 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
+[FUGA compatible switch from Smarthjemmet.dk](https://smarthjemmet.dk)
 ### Pairing
 If the device did not automatically start in pairing mode (LED blinking), you can start it manually by powering on and off the device four times, keeping it on the 4th time.
 

--- a/docs/devices/ZWallRemote0.md
+++ b/docs/devices/ZWallRemote0.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[Matts Wall Switch Remote](https://github.com/mattlokes/ZWallRemote)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/ZigUP.md
+++ b/docs/devices/ZigUP.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[CC2530 based ZigBee relais, switch, sensor and router](https://github.com/formtapez/ZigUP/)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/b-parasite.md
+++ b/docs/devices/b-parasite.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[b-parasite open source soil moisture sensor](https://github.com/rbaron/b-parasite)
+
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/ptvo.switch.md
+++ b/docs/devices/ptvo.switch.md
@@ -24,6 +24,7 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
+[Multi-functional device](https://ptvo.info/zigbee-configurable-firmware-features/)
 
 
 ### Deprecated click event

--- a/docs/devices/tubeszb.router.md
+++ b/docs/devices/tubeszb.router.md
@@ -23,6 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
+[CC2652 Router](https://github.com/tube0013/tube_gateways/tree/main/tube_cc_router)
+
 
 
 <!-- Notes END: Do not edit below this line -->


### PR DESCRIPTION
Also add "## Notes" where need.

Used this [python script](https://gist.github.com/xyzroe/c292285ebac1da970d7abe2cb33b13d9)

Than we can remove links from zigbee-herdsman-converters as mentioned [here](https://github.com/Koenkk/zigbee-herdsman-converters/pull/7077#discussion_r1495009449)