### PR TITLE
Update 100.462.31.md

### DIFF
--- a/docs/devices/100.462.31.md
+++ b/docs/devices/100.462.31.md
@@ -24,15 +24,23 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
-### Pairing
+Before you can pair your Paul Neuhaus remote for Q-Lights you have to reset it / remove it from any network. Pairing process will fail otherwise.
+### Resetting remote
 You will need a paper clip or similar tool to reset the remote control.
 
 1. Turn over the remote (on and off button should always face upwards)
 1. Slide on the battery cover on the back of the remote downwards. Above the left battery you will see a small hole. This is where the reset button is located.
-2. Push the bent paper clip into the reset opening (hole) and hold down for more than 5 sec. During this time the led on the front side will blink 4 time. Keep the paper clip pressed!
+2. Push the bent paper clip into the reset opening (hole) and hold down for more than 5 seconds. During this time the led on the front side will blink 4 time. Keep the paper clip pressed!
 3. The status LED now will blink 10 times very fast. If this happens you can remove the paper clip (right after the first fast blink).
 
-The remote now is reset and pairing process will be started automatically.
+The remote now is reset and you can continue with the pairing process.
+
+### Pairing
+1. Hold the remote close to the coordinator / router you want it to pair with.
+2. Press the on button of the remote for 5 seconds.
+3. The LED of the remote will start to blink fast - pairing process is initialized.
+4. If the led stops blinking the device should be paired.
+
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
Extended description for pairing process: My previous description was valid for a brand new remote. However, if the remote already is connected to a network, trying to pair the remote with my previous description will fail. Now the description should be bullet-proof for new devices and those already connected to a Zigbee network. :)