### PR TITLE
feat: add endpoints description for wb multisensors

### DIFF
--- a/docs/devices/WB-MSW-ZIGBEE_v.3.md
+++ b/docs/devices/WB-MSW-ZIGBEE_v.3.md
@@ -28,6 +28,14 @@ pageClass: device-page
 ### Description
 Wiren Board WB-MSW v.3 — hybrid digital sensor of motion, temperature, humidity, illumination, noise, CO2 and VOC level. It is equipped with the IR blaster (and the receiver for learning). Designed for climate control in residential and office premises.
 
+### Switch endpoints
+The device allways exposes 3 on/off endpoints named `l1`, `l2` and `l3`. Frist two of them only work if illuminannce + IR blaster addon is installed. Their finctuons as follows:
+- `l1` – controls blinking red led
+- `l2` – controls blinking green led
+- `l3` – controlls buzzer
+
+Warning, the installed buzzer is very loud.
+
 ### Configuring IR
 The sensor contains 32 banks for storing IR commands. Training takes place through the built-in IR receiver.
 

--- a/docs/devices/WB-MSW-ZIGBEE_v.4.md
+++ b/docs/devices/WB-MSW-ZIGBEE_v.4.md
@@ -28,7 +28,7 @@ pageClass: device-page
 ### Description
 Wiren Board WB-MSW v.4 — hybrid digital sensor of motion, temperature, humidity, illumination, noise, CO2 and VOC level. It is equipped with the IR blaster (and the receiver for learning). Designed for climate control in residential and office premises.
 
-## Switch endpoints
+### Switch endpoints
 The device allways exposes 3 on/off endpoints named `l1`, `l2` and `l3`. Frist two of them only work if illuminannce + IR blaster addon is installed. Their finctuons as follows:
 - `l1` – controls blinking red led
 - `l2` – controls blinking green led

--- a/docs/devices/WB-MSW-ZIGBEE_v.4.md
+++ b/docs/devices/WB-MSW-ZIGBEE_v.4.md
@@ -28,6 +28,14 @@ pageClass: device-page
 ### Description
 Wiren Board WB-MSW v.4 — hybrid digital sensor of motion, temperature, humidity, illumination, noise, CO2 and VOC level. It is equipped with the IR blaster (and the receiver for learning). Designed for climate control in residential and office premises.
 
+## Switch endpoints
+The device allways exposes 3 on/off endpoints named `l1`, `l2` and `l3`. Frist two of them only work if illuminannce + IR blaster addon is installed. Their finctuons as follows:
+- `l1` – controls blinking red led
+- `l2` – controls blinking green led
+- `l3` – controlls buzzer
+
+Warning, the installed buzzer is very loud.
+
 ### Configuring IR
 The sensor contains 80 banks for storing IR commands. Training takes place through the built-in IR receiver.
 


### PR DESCRIPTION
Since changing endpoint names will introduce breaking changes, adding endpoints description is the best thing in terms of quicker endpoint identification. Especially with the loud buzzer.