### PR TITLE
fix: update Opple dimmers

### DIFF
--- a/docs/devices/WXCJKG11LM.md
+++ b/docs/devices/WXCJKG11LM.md
@@ -41,12 +41,12 @@ As the device is sleeping by default, you need to wake it up after sending the b
 When bound to a light or a group of lights, the behavior is as follows (for a single band model):
 | Button | Click | Action | Comment |
 |-----|-----|-----|-----|
-| Left | Single  | Turn off ||
-| Right  | Single  | Turn on ||
-| Left | Double | Step up brightness | In steps of 33% using `step` command. |
-| Right | Double | Step down brightness | In steps of 33% using `step` command. |
-| Left | Long | Step color temperature down | In steps of 69 mired using `stepColorTemp` command. I.e., make it warmer. |
-| Right | Long | Step color temperature up | In steps of 69 mired using `stepColorTemp` command. I.e., make it colder. |
+| Left | Single  | Turn off | Using the `commandOff` command. |
+| Right  | Single  | Turn on | Using the `commandOn` command. |
+| Left | Double | Step up the brightness | In steps of 85 points (33%), using the `step` command. |
+| Right | Double | Step down the brightness | In steps of 85 points (33%), using the `step` command. |
+| Left | Long | Step the color temperature down | In steps of 69 mired using the `stepColorTemp` command.<br>I.e., make it warmer. |
+| Right | Long | Step the color temperature up | In steps of 69 mired using the `stepColorTemp` command.<br>I.e., make it colder. |
 
 ### Battery Replacement
 All devices in the Opple line share the same internal design. First, you will need to remove the wireless switch part from its mount.

--- a/docs/devices/WXCJKG11LM.md
+++ b/docs/devices/WXCJKG11LM.md
@@ -25,7 +25,6 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
 
-
 ### Pairing Instructions
 Press and hold the button on the backside of the device until the blue light starts blinking, release it and the pairing should begin.
 
@@ -39,14 +38,21 @@ To do this send to `zigbee2mqtt/FRIENDLY_NAME/set` payload `{"operation_mode": "
 
 As the device is sleeping by default, you need to wake it up after sending the bind/unbind command by pressing the reset button once.
 
+When bound to a light or a group of lights, the behavior is as follows (for a single band model):
+| Button | Click | Action | Comment |
+|-----|-----|-----|-----|
+| Left | Single  | Turn off ||
+| Right  | Single  | Turn on ||
+| Left | Double | Step up brightness | In steps of 33% using `step` command. |
+| Right | Double | Step down brightness | In steps of 33% using `step` command. |
+| Left | Long | Step color temperature down | In steps of 69 mired using `stepColorTemp` command. I.e., make it warmer. |
+| Right | Long | Step color temperature up | In steps of 69 mired using `stepColorTemp` command. I.e., make it colder. |
 
-When bound to a lamp, the behavior is as follows (for WXCJKG11LM Aqara Opple switch 1 band):
-- left click: turn off
-- right click: turn on
-- left double click: light dim down (by steps of 33%)
-- right double click: light dim up (by steps of 33%)
-- long left click: warm white
-- long right click: cold white
+### Battery replacement
+All devices in the Opple line share the same internal design. First, you will need to remove the wireless switch part from its mount.
+Then use a long and thin object (preferably a plastic spudger, as the plastic is soft) to unclip the front button(s) from the frame by reaching underneath and carefully prying up.
+For the triple-band model, removing the side buttons will help with the center one. After removing buttons, the black frame must be unscrewed using a small Phillips screwdriver and then unclipped from the device case on the sides.
+When the logic board is exposed, simply remove it and turn it upside down, where a **single CR2032** battery is located. Be careful with the logic board removed, as it also holds a small pairing button in place on the other side.
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/WXCJKG11LM.md
+++ b/docs/devices/WXCJKG11LM.md
@@ -26,15 +26,15 @@ pageClass: device-page
 ## Notes
 
 ### Pairing Instructions
-Press and hold the button on the backside of the device until the blue light starts blinking, release it and the pairing should begin.
+Press and hold the button on the backside of the device until the blue light starts blinking; release it, and the pairing should begin.
 
 ### Binding
-By default the switch is bound to the coordinator but this device can also be used to directly control other lights and switches in the network.
+By default, the device is bound to the coordinator, but it can also be used to directly control other lights and switches in the network (see [guide on binding](https://www.zigbee2mqtt.io/guide/usage/binding.html)).
 
-First unbind it from the coordinator, then you can bind it to any other device or group. (see ../guide/usage/binding.md )
+Note that this device can only be bound to one device or group at a time.
 
-Now change the operation mode of the device, by default it is in `event` mode, but when binding we need to change it to `command` mode.
-To do this send to `zigbee2mqtt/FRIENDLY_NAME/set` payload `{"operation_mode": "command"}`, right before doing this make sure to wakeup the device.
+For proper commands, you will need to change the operation mode of the device; by default, it is in `event` mode, but when binding, we need to change it to `command` mode.
+To do this, send the `{"operation_mode": "command"}` payload to `zigbee2mqtt/FRIENDLY_NAME/set` (or use the `operation_mode` parameter in the GUI). Right before doing this, make sure to wake up the device.
 
 As the device is sleeping by default, you need to wake it up after sending the bind/unbind command by pressing the reset button once.
 
@@ -48,7 +48,7 @@ When bound to a light or a group of lights, the behavior is as follows (for a si
 | Left | Long | Step color temperature down | In steps of 69 mired using `stepColorTemp` command. I.e., make it warmer. |
 | Right | Long | Step color temperature up | In steps of 69 mired using `stepColorTemp` command. I.e., make it colder. |
 
-### Battery replacement
+### Battery Replacement
 All devices in the Opple line share the same internal design. First, you will need to remove the wireless switch part from its mount.
 Then use a long and thin object (preferably a plastic spudger, as the plastic is soft) to unclip the front button(s) from the frame by reaching underneath and carefully prying up.
 For the triple-band model, removing the side buttons will help with the center one. After removing buttons, the black frame must be unscrewed using a small Phillips screwdriver and then unclipped from the device case on the sides.

--- a/docs/devices/WXCJKG11LM.md
+++ b/docs/devices/WXCJKG11LM.md
@@ -38,13 +38,13 @@ To do this, send the `{"operation_mode": "command"}` payload to `zigbee2mqtt/FRI
 
 As the device is sleeping by default, you need to wake it up after sending the bind/unbind command by pressing the reset button once.
 
-When bound to a light or a group of lights, the behavior is as follows (for a single band model):
+When endpoint `1` is bound to a light or a group of lights, the behavior is as follows (for a single band model):
 | Button | Click | Action | Comment |
 |-----|-----|-----|-----|
 | Left | Single  | Turn off | Using the `commandOff` command. |
 | Right  | Single  | Turn on | Using the `commandOn` command. |
-| Left | Double | Step up the brightness | In steps of 85 points (33%), using the `step` command. |
-| Right | Double | Step down the brightness | In steps of 85 points (33%), using the `step` command. |
+| Left | Double | Step down the brightness | In steps of 85 points (33%), using the `step` command. |
+| Right | Double | Step up the brightness | In steps of 85 points (33%), using the `step` command. |
 | Left | Long | Step the color temperature down | In steps of 69 mired using the `stepColorTemp` command.<br>I.e., make it warmer. |
 | Right | Long | Step the color temperature up | In steps of 69 mired using the `stepColorTemp` command.<br>I.e., make it colder. |
 

--- a/docs/devices/WXCJKG12LM.md
+++ b/docs/devices/WXCJKG12LM.md
@@ -25,30 +25,34 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
 
-
 ### Pairing Instructions
-Press and hold the button on the backside of the device until the blue light starts blinking, release it and the pairing should begin.
+Press and hold the button on the backside of the device until the blue light starts blinking; release it, and the pairing should begin.
 
 ### Binding
-By default the switch is bound to the coordinator but this device can also be used to directly control other lights and switches in the network.
+By default, the device is bound to the coordinator, but it can also be used to directly control other lights and switches in the network (see [guide on binding](https://www.zigbee2mqtt.io/guide/usage/binding.html)).
 
-First unbind it from the coordinator, then you can bind it to any other device or group. (see ../guide/usage/binding.md )
+Note that this device can only be bound to one device or group at a time.
 
-Now change the operation mode of the device, by default it is in `event` mode, but when binding we need to change it to `command` mode.
-To do this send to `zigbee2mqtt/FRIENDLY_NAME/set` payload `{"operation_mode": "command"}`, right before doing this make sure to wakeup the device.
+For proper commands, you will need to change the operation mode of the device; by default, it is in `event` mode, but when binding, we need to change it to `command` mode.
+To do this, send the `{"operation_mode": "command"}` payload to `zigbee2mqtt/FRIENDLY_NAME/set` (or use the `operation_mode` parameter in the GUI). Right before doing this, make sure to wake up the device.
 
 As the device is sleeping by default, you need to wake it up after sending the bind/unbind command by pressing the reset button once.
 
+When bound to a light or a group of lights, the behavior is as follows (for a double band model):
+| Button | Click | Action | Comment |
+|-----|-----|-----|-----|
+| Top left | Single  | Turn off ||
+| Top right | Single  | Turn on ||
+| Bottom left | Single | Step up brightness | In steps of 33%, using `step` command. |
+| Bottom right | Single | Step down brightness | In steps of 33%, using `step` command. |
+| Bottom left | Double | Step color temperature down | In steps of 69 mired, using `stepColorTemp` command. I.e., make it warmer. |
+| Bottom right | Double | Step color temperature up | In steps of 69 mired, using `stepColorTemp` command. I.e., make it colder. |
 
-Note that the WXCJKG12LM can only be bound to one device at a time.
-
-When bound to a lamp, the behavior is as follows (for WXCJKG12LM Aqara Opple switch 2 band).
-- up left click: turn off
-- up right click: turn on
-- down left click: light dim down (by steps of 33%)
-- down right click: light dim up (by steps of 33%)
-- down left double click: warm white
-- down right double click: cold white
+### Battery Replacement
+All devices in the Opple line share the same internal design. First, you will need to remove the wireless switch part from its mount.
+Then use a long and thin object (preferably a plastic spudger, as the plastic is soft) to unclip the front button(s) from the frame by reaching underneath and carefully prying up.
+For the triple-band model, removing the side buttons will help with the center one. After removing buttons, the black frame must be unscrewed using a small Phillips screwdriver and then unclipped from the device case on the sides.
+When the logic board is exposed, simply remove it and turn it upside down, where a **single CR2032** battery is located. Be careful with the logic board removed, as it also holds a small pairing button in place on the other side.
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/WXCJKG12LM.md
+++ b/docs/devices/WXCJKG12LM.md
@@ -41,12 +41,12 @@ As the device is sleeping by default, you need to wake it up after sending the b
 When bound to a light or a group of lights, the behavior is as follows (for a double band model):
 | Button | Click | Action | Comment |
 |-----|-----|-----|-----|
-| Top left | Single  | Turn off ||
-| Top right | Single  | Turn on ||
-| Bottom left | Single | Step up brightness | In steps of 33%, using `step` command. |
-| Bottom right | Single | Step down brightness | In steps of 33%, using `step` command. |
-| Bottom left | Double | Step color temperature down | In steps of 69 mired, using `stepColorTemp` command. I.e., make it warmer. |
-| Bottom right | Double | Step color temperature up | In steps of 69 mired, using `stepColorTemp` command. I.e., make it colder. |
+| Top left | Single<br>Double<br>Long  | Turn off | Using the `commandOff` command. |
+| Top right | Single<br>Double<br>Long  | Turn on | Using the `commandOn` command. |
+| Bottom left | Single | Step up the brightness | In steps of 85 points (33%), using the `step` command.  |
+| Bottom right | Single | Step down the brightness | In steps of 85 points (33%), using the `step` command.  |
+| Bottom left | Double | Step the color temperature down | In steps of 69 mired, using the `stepColorTemp` command.<br>I.e., make it warmer. |
+| Bottom right | Double | Step the color temperature up | In steps of 69 mired, using the `stepColorTemp` command.<br>I.e., make it colder. |
 
 ### Battery Replacement
 All devices in the Opple line share the same internal design. First, you will need to remove the wireless switch part from its mount.

--- a/docs/devices/WXCJKG12LM.md
+++ b/docs/devices/WXCJKG12LM.md
@@ -38,13 +38,13 @@ To do this, send the `{"operation_mode": "command"}` payload to `zigbee2mqtt/FRI
 
 As the device is sleeping by default, you need to wake it up after sending the bind/unbind command by pressing the reset button once.
 
-When bound to a light or a group of lights, the behavior is as follows (for a double band model):
+When endpoint `1` is bound to a light or a group of lights, the behavior is as follows (for a double band model):
 | Button | Click | Action | Comment |
 |-----|-----|-----|-----|
 | Top left | Single<br>Double<br>Long  | Turn off | Using the `commandOff` command. |
 | Top right | Single<br>Double<br>Long  | Turn on | Using the `commandOn` command. |
-| Bottom left | Single | Step up the brightness | In steps of 85 points (33%), using the `step` command.  |
-| Bottom right | Single | Step down the brightness | In steps of 85 points (33%), using the `step` command.  |
+| Bottom left | Single | Step down the brightness | In steps of 85 points (33%), using the `step` command.  |
+| Bottom right | Single | Step up the brightness | In steps of 85 points (33%), using the `step` command.  |
 | Bottom left | Double | Step the color temperature down | In steps of 69 mired, using the `stepColorTemp` command.<br>I.e., make it warmer. |
 | Bottom right | Double | Step the color temperature up | In steps of 69 mired, using the `stepColorTemp` command.<br>I.e., make it colder. |
 

--- a/docs/devices/WXCJKG13LM.md
+++ b/docs/devices/WXCJKG13LM.md
@@ -45,8 +45,8 @@ When bound to a light or a group of lights, the behavior is as follows (for a tr
 | Top<br>right | Single<br>Double<br>Long  | Turn on | Using `commandOn` command. |
 | Middle<br>left | Single<br>Double | Step up brightness | In steps of 33%, using `step` command. |
 | Middle<br>right | Single<br>Double | Step down brightness | In steps of 33%, using `step` command. |
-| Middle<br>left | Long | Smoothly increase brightness | In steps of 15 ponts (around 6%), using `commandMove` command.<br>Change stops only after the button released, using `commandStop` command. |
-| Middle<br>right | Long | Smoothly decrease brightness | In steps of 15 ponts (around 6%), using `commandMove` command.<br>Change stops only after the button released, using `commandStop` command. |
+| Middle<br>left | Long | Smoothly increase brightness | In steps of 15 points (around 6%), using `commandMove` command.<br>Change stops, using `commandStop` command, only after the button is released. |
+| Middle<br>right | Long | Smoothly decrease brightness | In steps of 15 points (around 6%), using `commandMove` command.<br>Change stops, using `commandStop` command, only after the button is released. |
 | Bottom<br>left | Single<br>Double | Step color temperature down | In steps of 69 mired, using `stepColorTemp` command.<br>I.e., make it warmer. |
 | Bottom<br>right | Single<br>Double | Step color temperature up | In steps of 69 mired, using `stepColorTemp` command.<br>I.e., make it colder. |
 | Bottom<br>left | Double | Smoothly decrease color temperature | In steps of 15 mired, using `commandMoveColorTemp` command.<br>I.e., make it warmer. |

--- a/docs/devices/WXCJKG13LM.md
+++ b/docs/devices/WXCJKG13LM.md
@@ -25,28 +25,38 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
 
-
 ### Pairing Instructions
-Press and hold the button on the backside of the device until the blue light starts blinking, release it and the pairing should begin.
+Press and hold the button on the backside of the device until the blue light starts blinking; release it, and the pairing should begin.
 
 ### Binding
-By default the switch is bound to the coordinator but this device can also be used to directly control other lights and switches in the network.
+By default, the device is bound to the coordinator, but it can also be used to directly control other lights and switches in the network (see [guide on binding](https://www.zigbee2mqtt.io/guide/usage/binding.html)).
 
-First unbind it from the coordinator, then you can bind it to any other device or group. (see ../guide/usage/binding.md )
+Note that this device can only be bound to one device or group at a time.
 
-Now change the operation mode of the device, by default it is in `event` mode, but when binding we need to change it to `command` mode.
-To do this send to `zigbee2mqtt/FRIENDLY_NAME/set` payload `{"operation_mode": "command"}`, right before doing this make sure to wakeup the device.
+For proper commands, you will need to change the operation mode of the device; by default, it is in `event` mode, but when binding, we need to change it to `command` mode.
+To do this, send the `{"operation_mode": "command"}` payload to `zigbee2mqtt/FRIENDLY_NAME/set` (or use the `operation_mode` parameter in the GUI). Right before doing this, make sure to wake up the device.
 
 As the device is sleeping by default, you need to wake it up after sending the bind/unbind command by pressing the reset button once.
 
+When bound to a light or a group of lights, the behavior is as follows (for a triple band model):
+| Button | Click | Action | Comment |
+|-----|-----|-----|-----|
+| Top<br>left | Single<br>Double<br>Long  | Turn off | Using `commandOff` command. |
+| Top<br>right | Single<br>Double<br>Long  | Turn on | Using `commandOn` command. |
+| Middle<br>left | Single<br>Double | Step up brightness | In steps of 33%, using `step` command. |
+| Middle<br>right | Single<br>Double | Step down brightness | In steps of 33%, using `step` command. |
+| Middle<br>left | Long | Smoothly increase brightness | In steps of 15 ponts (around 6%), using `commandMove` command.<br>Change stops only after the button released, using `commandStop` command. |
+| Middle<br>right | Long | Smoothly decrease brightness | In steps of 15 ponts (around 6%), using `commandMove` command.<br>Change stops only after the button released, using `commandStop` command. |
+| Bottom<br>left | Single<br>Double | Step color temperature down | In steps of 69 mired, using `stepColorTemp` command.<br>I.e., make it warmer. |
+| Bottom<br>right | Single<br>Double | Step color temperature up | In steps of 69 mired, using `stepColorTemp` command.<br>I.e., make it colder. |
+| Bottom<br>left | Double | Smoothly decrease color temperature | In steps of 15 mired, using `commandMoveColorTemp` command.<br>I.e., make it warmer. |
+| Bottom<br>right | Double | Smoothly increase color temperature | In steps of 15 mired, using `commandMoveColorTemp` command.<br>I.e., make it colder. |
 
-When bound to a lamp, the behavior is as follows (for WXCJKG11LM Aqara Opple switch 1 band):
-- left click: turn off
-- right click: turn on
-- left double click: light dim down (by steps of 33%)
-- right double click: light dim up (by steps of 33%)
-- long left click: warm white
-- long right click: cold white
+### Battery Replacement
+All devices in the Opple line share the same internal design. First, you will need to remove the wireless switch part from its mount.
+Then use a long and thin object (preferably a plastic spudger, as the plastic is soft) to unclip the front button(s) from the frame by reaching underneath and carefully prying up.
+For the triple-band model, removing the side buttons will help with the center one. After removing buttons, the black frame must be unscrewed using a small Phillips screwdriver and then unclipped from the device case on the sides.
+When the logic board is exposed, simply remove it and turn it upside down, where a **single CR2032** battery is located. Be careful with the logic board removed, as it also holds a small pairing button in place on the other side.
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/WXCJKG13LM.md
+++ b/docs/devices/WXCJKG13LM.md
@@ -38,15 +38,15 @@ To do this, send the `{"operation_mode": "command"}` payload to `zigbee2mqtt/FRI
 
 As the device is sleeping by default, you need to wake it up after sending the bind/unbind command by pressing the reset button once.
 
-When bound to a light or a group of lights, the behavior is as follows (for a triple band model):
+When endpoint `1` is bound to a light or a group of lights, the behavior is as follows (for a triple band model):
 | Button | Click | Action | Comment |
 |-----|-----|-----|-----|
 | Top<br>left | Single<br>Double<br>Long  | Turn off | Using the `commandOff` command. |
 | Top<br>right | Single<br>Double<br>Long  | Turn on | Using the `commandOn` command. |
-| Middle<br>left | Single<br>Double | Step up the brightness | In steps of 85 points (33%), using the `step` command. |
-| Middle<br>right | Single<br>Double | Step down the brightness | In steps of 85 points (33%), using the `step` command. |
-| Middle<br>left | Long | Smoothly increase the brightness | In steps of 15 points (around 6%), using the `commandMove` command.<br>Sends the `commandStop` command, on button release. |
-| Middle<br>right | Long | Smoothly decrease the brightness | In steps of 15 points (around 6%), using the `commandMove` command.<br>Sends the `commandStop` command, on button release. |
+| Middle<br>left | Single<br>Double | Step down the brightness | In steps of 85 points (33%), using the `step` command. |
+| Middle<br>right | Single<br>Double | Step up the brightness | In steps of 85 points (33%), using the `step` command. |
+| Middle<br>left | Long | Smoothly decrease the brightness | In steps of 15 points (around 6%), using the `commandMove` command.<br>Sends the `commandStop` command, on button release. |
+| Middle<br>right | Long | Smoothly increase the brightness | In steps of 15 points (around 6%), using the `commandMove` command.<br>Sends the `commandStop` command, on button release. |
 | Bottom<br>left | Single<br>Double | Step color the temperature down | In steps of 69 mired, using the `stepColorTemp` command.<br>I.e., make it warmer. |
 | Bottom<br>right | Single<br>Double | Step color the temperature up | In steps of 69 mired, using the `stepColorTemp` command.<br>I.e., make it colder. |
 | Bottom<br>left | Double | Smoothly decrease the color temperature | In steps of 15 mired, using the `commandMoveColorTemp` command.<br>I.e., make it warmer. |

--- a/docs/devices/WXCJKG13LM.md
+++ b/docs/devices/WXCJKG13LM.md
@@ -41,16 +41,16 @@ As the device is sleeping by default, you need to wake it up after sending the b
 When bound to a light or a group of lights, the behavior is as follows (for a triple band model):
 | Button | Click | Action | Comment |
 |-----|-----|-----|-----|
-| Top<br>left | Single<br>Double<br>Long  | Turn off | Using `commandOff` command. |
-| Top<br>right | Single<br>Double<br>Long  | Turn on | Using `commandOn` command. |
-| Middle<br>left | Single<br>Double | Step up brightness | In steps of 33%, using `step` command. |
-| Middle<br>right | Single<br>Double | Step down brightness | In steps of 33%, using `step` command. |
-| Middle<br>left | Long | Smoothly increase brightness | In steps of 15 points (around 6%), using `commandMove` command.<br>Change stops, using `commandStop` command, only after the button is released. |
-| Middle<br>right | Long | Smoothly decrease brightness | In steps of 15 points (around 6%), using `commandMove` command.<br>Change stops, using `commandStop` command, only after the button is released. |
-| Bottom<br>left | Single<br>Double | Step color temperature down | In steps of 69 mired, using `stepColorTemp` command.<br>I.e., make it warmer. |
-| Bottom<br>right | Single<br>Double | Step color temperature up | In steps of 69 mired, using `stepColorTemp` command.<br>I.e., make it colder. |
-| Bottom<br>left | Double | Smoothly decrease color temperature | In steps of 15 mired, using `commandMoveColorTemp` command.<br>I.e., make it warmer. |
-| Bottom<br>right | Double | Smoothly increase color temperature | In steps of 15 mired, using `commandMoveColorTemp` command.<br>I.e., make it colder. |
+| Top<br>left | Single<br>Double<br>Long  | Turn off | Using the `commandOff` command. |
+| Top<br>right | Single<br>Double<br>Long  | Turn on | Using the `commandOn` command. |
+| Middle<br>left | Single<br>Double | Step up the brightness | In steps of 85 points (33%), using the `step` command. |
+| Middle<br>right | Single<br>Double | Step down the brightness | In steps of 85 points (33%), using the `step` command. |
+| Middle<br>left | Long | Smoothly increase the brightness | In steps of 15 points (around 6%), using the `commandMove` command.<br>Sends the `commandStop` command, on button release. |
+| Middle<br>right | Long | Smoothly decrease the brightness | In steps of 15 points (around 6%), using the `commandMove` command.<br>Sends the `commandStop` command, on button release. |
+| Bottom<br>left | Single<br>Double | Step color the temperature down | In steps of 69 mired, using the `stepColorTemp` command.<br>I.e., make it warmer. |
+| Bottom<br>right | Single<br>Double | Step color the temperature up | In steps of 69 mired, using the `stepColorTemp` command.<br>I.e., make it colder. |
+| Bottom<br>left | Double | Smoothly decrease the color temperature | In steps of 15 mired, using the `commandMoveColorTemp` command.<br>I.e., make it warmer. |
+| Bottom<br>right | Double | Smoothly increase the color temperature | In steps of 15 mired, using the `commandMoveColorTemp` command.<br>I.e., make it colder. |
 
 ### Battery Replacement
 All devices in the Opple line share the same internal design. First, you will need to remove the wireless switch part from its mount.


### PR DESCRIPTION
This PR clears up, fixes and spellchecks Opple dimmer descriptions. It also adds battery replacement instruction, because it's very complicated and absolutely not intuitive. 