### PR TITLE
Adding Luminea (Pearl) ZX-5232-675 as white-label of TuYa/TS0203

### DIFF
--- a/docs/devices/TS0203.md
+++ b/docs/devices/TS0203.md
@@ -20,7 +20,7 @@ pageClass: device-page
 | Description | Door sensor |
 | Exposes | contact, battery_low, battery, voltage, tamper, linkquality |
 | Picture | ![TuYa TS0203](https://www.zigbee2mqtt.io/images/devices/TS0203.png) |
-| White-label | CR Smart Home TS0203, TuYa iH-F001, Tesla Smart TSL-SEN-DOOR, Cleverio SS100 |
+| White-label | CR Smart Home TS0203, TuYa iH-F001, Tesla Smart TSL-SEN-DOOR, Cleverio SS100, Luminea ZX-5232-675 |
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->


### PR DESCRIPTION
The Luminea ZX-5232-675 (sold for example by Pearl) is a white-label of the TuYa TS0203