### PR TITLE
docs: Update IKEA Symfonisk Sound Remote gen2 (E2123)

### DIFF
--- a/docs/devices/E2123.md
+++ b/docs/devices/E2123.md
@@ -54,7 +54,7 @@ Pair the sensor to Zigbee2MQTT by quickly pressing the pair button 4x to get it 
 |Dot 2|hold|dots_2_long_press|dots_2_long_press|dots_2_long_press
 |Dot 2|hold release||dots_2_long_release|dots_2_long_release
 
-## Notes on firmware 1.0.32 (20221219)
+### Notes on firmware 1.0.32 (20221219)
 
 * After updating the remote from `1.0.012 (20211214)` you may need to reconfigure or repair the device.
 * Dot single press triggers multiple actions:
@@ -67,11 +67,11 @@ Pair the sensor to Zigbee2MQTT by quickly pressing the pair button 4x to get it 
   * `dot_<1|2>_initial_press`
   * `dot_<1|2>_long_press`
   * `dot_<1|2>_long_release`
-<!-- Notes END: Do not edit below this line -->
 
-## Notes on firmware 1.0.35 (????????)
+### Notes on firmware 1.0.35 (????????)
 
 * Dot single press, Dot double press and Press & hold trigger multiple actions like in 1.0.35.
+<!-- Notes END: Do not edit below this line -->
 
 ## OTA updates
 This device supports OTA updates, for more information see [OTA updates](../guide/usage/ota_updates.md).

--- a/docs/devices/E2123.md
+++ b/docs/devices/E2123.md
@@ -32,27 +32,27 @@ Pair the sensor to Zigbee2MQTT by quickly pressing the pair button 4x to get it 
 
 ### Button -> `action` mapping
 
-|Icon|Action|Exposed Action (firmware 1.0.012 (20211214))|Exposed Action (firmware 1.0.32 (20221219))
-|-----|-----|-----|-----|
-|Play|press|toggle|toggle
-|Next Track|press|track_next|track_next
-|Previous Track|press|track_previous|track_previous
-|+ (Volume up)|press|volume_up|volume_up
-|+ (Volume up)|hold|volume_up_hold|volume_up_hold
-|- (Volume down)|press|volume_down|volume_down
-|- (Volume down)|hold|volume_down_hold|volume_down_hold
-|-----|-----|-----|-----|
-|Dot 1|press|dots_1_initial_press|dots_1_initial_press
-|Dot 1|press release||dots_1_short_release
-|Dot 1|double press|dots_1_double_press|dots_1_double_press
-|Dot 1|hold|dots_1_long_press|dots_1_long_press
-|Dot 1|hold release||dots_1_long_release
-|-----|-----|-----|-----|
-|Dot 2|press|dots_2_initial_press|dots_2_initial_press
-|Dot 2|press release||dots_2_short_release
-|Dot 2|double press|dots_2_double_press|dots_2_double_press
-|Dot 2|hold|dots_2_long_press|dots_2_long_press
-|Dot 2|hold release||dots_2_long_release
+|Icon|Action|Exposed Action (firmware 1.0.012 (20211214))|Exposed Action (firmware 1.0.32 (20221219))|Exposed Action (firmware 1.0.35 (????????))
+|-----|-----|-----|-----|-----|
+|Play|press|toggle|toggle|play_pause
+|Next Track|press|track_next|track_next|track_next
+|Previous Track|press|track_previous|track_previous|track_previous
+|+ (Volume up)|press|volume_up|volume_up|volume_up
+|+ (Volume up)|hold|volume_up_hold|volume_up_hold|volume_up_hold
+|- (Volume down)|press|volume_down|volume_down|volume_down
+|- (Volume down)|hold|volume_down_hold|volume_down_hold|volume_down_hold
+|-----|-----|-----|-----|-----|
+|Dot 1|press|dots_1_initial_press|dots_1_initial_press|dots_1_initial_press
+|Dot 1|press release||dots_1_short_release|dots_1_short_release
+|Dot 1|double press|dots_1_double_press|dots_1_double_press|dots_1_double_press
+|Dot 1|hold|dots_1_long_press|dots_1_long_press|dots_1_long_press
+|Dot 1|hold release||dots_1_long_release|dots_1_long_release
+|-----|-----|-----|-----|-----|
+|Dot 2|press|dots_2_initial_press|dots_2_initial_press|dots_2_initial_press
+|Dot 2|press release||dots_2_short_release|dots_2_short_release
+|Dot 2|double press|dots_2_double_press|dots_2_double_press|dots_2_double_press
+|Dot 2|hold|dots_2_long_press|dots_2_long_press|dots_2_long_press
+|Dot 2|hold release||dots_2_long_release|dots_2_long_release
 
 ## Notes on firmware 1.0.32 (20221219)
 
@@ -69,10 +69,12 @@ Pair the sensor to Zigbee2MQTT by quickly pressing the pair button 4x to get it 
   * `dot_<1|2>_long_release`
 <!-- Notes END: Do not edit below this line -->
 
+## Notes on firmware 1.0.35 (????????)
+
+* Dot single press, Dot double press and Press & hold trigger multiple actions like in 1.0.35.
 
 ## OTA updates
 This device supports OTA updates, for more information see [OTA updates](../guide/usage/ota_updates.md).
-
 
 ## Options
 *[How to use device type specific configuration](../guide/configuration/devices-groups.md#specific-device-options)*


### PR DESCRIPTION
I just got one of these today with firmware 1.0.35 installed and saw that the behavior differed from the existing documentation.

I cannot say when this firmware version was released or if the change occured in an earlier version (1.0.33 or 1.0.34)