### PR TITLE
Update TH1123ZB-G2 to include thermostat_time instruction

### DIFF
--- a/docs/devices/TH1123ZB-G2.md
+++ b/docs/devices/TH1123ZB-G2.md
@@ -48,6 +48,33 @@ If you want to automate the publishing of the outdoor temperature using Home Ass
     service: mqtt.publish
 ```
 
+### Setting the clock
+To set thermostat display clock, you need to send an epoch value to the following MQTT topic:
+```
+zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_time
+```
+
+On pairing of the device, the time will be set to the network time. Afterwards, the thermostat does not update with network time change, like DST.
+
+An empty payload will set time to current network time. 
+
+If you want to automate setting the clock using Home Assistant, you may create an automation like this:
+
+``` yaml
+- id: 'Auto_Set_Thermostat_Time'
+  alias: Auto_Set_Thermostat_Time
+  description: Automatically set time thermostat time
+  trigger:
+    - platform: time
+      at: "00:00:00"
+  condition: []
+  action:
+    - service: mqtt.publish
+      data:
+        topic: zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_time
+        payload: ""
+```
+
 ### Activate eco mode
 To set the eco_mode, you need to send the value to the following MQTT topic:
 ```


### PR DESCRIPTION
It's good to know because the thermostat seem to synchronize itself with the network clock on pairing but never update afterwards.

After last weeks DST change, all my thermostat became out of sync with local time.

It was not too hard to figure out from reading the [`sinope.ts`](https://github.com/Koenkk/zigbee-herdsman-converters/blob/6b3911a45601e5b01e916c74bcf51b9848d2e757/src/devices/sinope.ts#L343) implementation but assuming everyone will want their thermostat to display correct time, it would be easier to have it directly in the documentation.

I've open the PR for `TH1123ZB-G2` devices because it's what I have but its safe to assume it would be the same for all Sinope thermostat (`TH1123ZB`, `TH1124ZB`, etc).

For anyone running into issues keeping Sinope thermostat display updated, I have a [gist](https://gist.github.com/unixcharles/e68197da4e3bd5485d5ec5d0bd25be71) with all the the shenanigan I'm doing to keep up to date.