### PR TITLE
Update 404049D.md

### DIFF
--- a/docs/devices/404049D.md
+++ b/docs/devices/404049D.md
@@ -23,11 +23,25 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+### Pairing
+Remove the battery cover and use the cover to press the button above the batteries.
+Press and hold this button for 10-20 seconds and release the button.
+After that the remote should show up as a paired device.
+
+### Groups binding
+
+This remote is able to deal with 4 ZigBee groups:
+
+* group0 = All three leds lit
+* group1 = first led lit
+* group2 = second led lit
+* group3 = third let lit
+
+The device is bound to the default tint action groups (group0-3) with ids 16387/16388/16389/16390. This cannot be changed.
 
 <!-- Notes END: Do not edit below this line -->
-
-
 
 ## Options
 *[How to use device type specific configuration](../guide/configuration/devices-groups.md#specific-device-options)*
@@ -46,7 +60,10 @@ simulated_brightness:
 Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
-The possible values are: `on`, `off`, `brightness_step_up`, `brightness_step_down`, `brightness_move_up`, `brightness_move_down`, `brightness_stop`, `color_temperature_move`, `color_move`, `scene_1`, `scene_2`, `scene_3`, `scene_4`, `scene_5`, `scene_6`.
+
+The possible values are: `on`, `off`, `brightness_step_up`, `brightness_step_down`, `brightness_move_up`, `brightness_move_down`, `brightness_stop`, `color_temperature_move`, `color_move`, `scene_1`, `scene_2`, `scene_3`, `scene_4`, `scene_5`, `scene_6`. 
+
+Long press scene buttons: `scene_7`, `scene_8`, `scene_9`, `scene_10` .
 
 ### Linkquality (numeric)
 Link quality (signal strength).


### PR DESCRIPTION
Hi,

I've both devices MLI-404011 and 404049D from Müller Licht. Changing groups binding with 404011 is no problem, but 404049D is always bound to the default tint groups regardless my binding requests. 
In addition with 404049D it is possible to use the scene buttons with activated group0 and it has a long press feature for some scene buttons.

This information should be added to the documentation.

- Added information about groups
- Added long press scene
- Added pairing

Best regards

Achim