### PR TITLE
Update SIRZB-110.md

### DIFF
--- a/docs/devices/SIRZB-110.md
+++ b/docs/devices/SIRZB-110.md
@@ -58,8 +58,8 @@ This alarm are preset to highest volume and using the mode `police_panic`
 Squawk are normally used to indicate activation and deactivation of an alarm system
 
 Examples:
-`{"squawk":{"level":"low","mode":"system_is_sarmed","strobe":false}}`
-`{"squawk":{"level":"low","mode":"system_is_disarmed","strobe":false}}`
+`{"squawk":{"level":"low","state":"system_is_armed","strobe":false}}`
+`{"squawk":{"level":"low","state":"system_is_disarmed","strobe":false}}`
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
1) typo
2) confusion between "state" (for squawk) and "mode" (for warning). State should be use, mode is not functional with squawk.