### PR TITLE
Update Secure your Zigbee network page for the now automatically random encryption key

### DIFF
--- a/docs/advanced/zigbee/03_secure_network.md
+++ b/docs/advanced/zigbee/03_secure_network.md
@@ -10,7 +10,9 @@ To disable joining it's important that `permit_join: false` is set in your `conf
 ## Change Zigbee network encryption key
 **Changing the network key requires re-pairing of all devices!**
 
-Zigbee2MQTT uses a known default encryption key (Zigbee Transport Key). Therefore it is recommended to use a different one. To use a different encryption key add the following to your `configuration.yaml`:
+Zigbee2MQTT releases prior to 1.33.0 use a known default encryption key (Zigbee Transport Key). Therefore it is recommended to change the network encryption key on those versions. Release 1.33.0 and later will generate a random encryption key on startup.
+
+To use a different encryption key add the following to your `configuration.yaml`:
 
 **Do not use this exact key.**
 ```yaml


### PR DESCRIPTION
Updated network encryption key guidance for updates in https://github.com/Koenkk/zigbee2mqtt/pull/18357

https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.33.0

Release 1.33.0 implements https://github.com/Koenkk/zigbee2mqtt/issues/14868 which automatically generates random key generation on startup.  Guidance that Zigbee2MQTT uses an insecure default key is no longer accurate.  