### PR TITLE
Update `E2001_E2002.md` to suggest needed setting

### DIFF
--- a/docs/devices/E2001_E2002.md
+++ b/docs/devices/E2001_E2002.md
@@ -72,6 +72,7 @@ simulated_brightness:
   delta: 20 # delta per interval, default = 20
   interval: 200 # interval in milliseconds, default = 200
 ```
+**Note:** If the `action` entry does not report all the attributes (brightness, action_brightness_delta, ...) you may need to activate the `Home Assistant legacy entity attributes` setting in `Zigbee2Mqtt Settings` > `Home Assistant integration`.
 
 * `legacy`: Set to false to disable the legacy integration (highly recommended), will change structure of the published payload (default true). The value must be `true` or `false`
 


### PR DESCRIPTION
Add a note that `legacy entity attributes` *must* (I'm not entirely sure if it is always the case but for me and a friend it was the case [Devices from 2022 and 2024]) be active for some attributes.

Because I'm not entirely sure I worded it as a suggestion.


Note: Of course we tried to set the device specific setting `Legacy` to false but we also needed to change the setting in Z2M.