### PR TITLE
add note to PJ-1203A

### DIFF
--- a/docs/devices/PJ-1203A.md
+++ b/docs/devices/PJ-1203A.md
@@ -24,10 +24,17 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Notes
+
+### Late Energy Flow Bug
+
+Some or all PJ-1203A suffer from a bug that causes the energy flow direction to be reported during the next cycle update. In parctice, that means that an incorrect direction is published during `update_frequency`frequency seconds after any transition between `producing` and `consuming`.
+
+For each channel `x`, the option `late_energy_flow_x` attempts to solve that problem by delaying the publication of `power_x`, `current_x`, `power_factor_x` and `energy_flow_x` until the next update of `energy_flow_x`.
+
+The attribute `timestamp_x` indicates when the power value was actually received from the device. This is typically `update_frequency` seconds before the publication time when the option `late_energy_flow_x` is enabled. It should be noted that this delay des not occur when the power value is zero because the energy flow datapoint is neither emited nor needed.
 
 <!-- Notes END: Do not edit below this line -->
-
-
 
 ## Options
 *[How to use device type specific configuration](../guide/configuration/devices-groups.md#specific-device-options)*

--- a/docs/devices/PJ-1203A.md
+++ b/docs/devices/PJ-1203A.md
@@ -32,7 +32,7 @@ Some or all PJ-1203A suffer from a bug that causes the energy flow direction to 
 
 For each channel `x`, the option `late_energy_flow_x` attempts to solve that problem by delaying the publication of `power_x`, `current_x`, `power_factor_x` and `energy_flow_x` until the next update of `energy_flow_x`.
 
-The attribute `timestamp_x` indicates when the power value was actually received from the device. This is typically `update_frequency` seconds before the publication time when the option `late_energy_flow_x` is enabled. It should be noted that this delay des not occur when the power value is zero because the energy flow datapoint is neither emited nor needed.
+The attribute `timestamp_x` indicates when the power value was actually received from the device. This is typically `update_frequency` seconds before the publication time when the option `late_energy_flow_x` is enabled. It should be noted that this delay does not occur when the power value is zero because the energy flow datapoint is neither produced by the device nor needed to compute the sign.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
Add a note to explain the purpose of the new `late_energy_flow_a|b` options
