### PR TITLE
Update ZG-204ZM.md

### DIFF
--- a/docs/devices/ZG-204ZM.md
+++ b/docs/devices/ZG-204ZM.md
@@ -97,8 +97,8 @@ If value equals `ON` indicator is ON, if `OFF` OFF.
 Motion detection mode (Firmware version>=0122052017).
 Value can be found in the published state on the `motion_detection_mode` property.
 It's not possible to read (`/get`) this value.
-To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"motion_detection_mode": NEW_VALUE}`.
-The possible values are: `Only PIR`, `PIR+Dadar`, `Only Dadar`.
+To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"motion_detection_mode": "NEW_VALUE"}`.
+The possible values are: `only_pir`, `pir_and_dadar`, `only_dadar`.
 
 ### Motion detection sensitivity (numeric)
 Motion detection sensitivity (Firmware version>=0122052017).


### PR DESCRIPTION
### Motion detection mode (enum)
To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"motion_detection_mode": "NEW_VALUE"}`. The possible values are: `only_pir`, `pir_and_dadar`, `only_dadar`.

zigbee2mqtt/FRIENDLY_NAME/set
`{"motion_detection_mode": PIR+Dadar}`

 does not work. 

>>

zigbee2mqtt/FRIENDLY_NAME/set
`{"motion_detection_mode": "pir_and_dadar"}`

does work.


----------------------------------------------------------------------------------------------------------------------------------

![image](https://github.com/Koenkk/zigbee2mqtt.io/assets/9786634/46a0ed9c-a15d-4023-90c9-1d72eba255fa)

ERROR: Value: 'PIR+Dadar' not found in: [only_pir, pir_and_dadar, only_dadar]'

----------------------------------------------------------------------------------------------------------------------------------

![image](https://github.com/Koenkk/zigbee2mqtt.io/assets/9786634/94a711ad-f66b-4778-8875-3bce635852f9)


ERROR Invalid message 'null', skipping...

----------------------------------------------------------------------------------------------------------------------------------

![image](https://github.com/Koenkk/zigbee2mqtt.io/assets/9786634/8cb2208a-ee85-4fa9-8884-1f3d217a121e)

NO ERROR
INFO MQTT publish: topic 'zigbee2mqtt/1-TuYa-ZG-204ZM-0xa4c138e5a2f6b559', payload '{"battery":100,"fading_time":60,"illuminance_lux":50,"indicator":"ON","linkquality":172,"motion_detection_mode":"pir_and_dadar","motion_detection_sensitivity":10,"motion_state":"static","presence":true,"static_detection_distance":5,"static_detection_sensitivity":5}'


----------------------------------------------------------------------------------------------------------------------------------

>> I **only** tested to change **Motion detection mode (enum)** 