### PR TITLE
Add 'device_age' support for STARKVIND air purifier

### DIFF
--- a/docs/devices/E2007.md
+++ b/docs/devices/E2007.md
@@ -18,7 +18,7 @@ pageClass: device-page
 | Model | E2007  |
 | Vendor  | [IKEA](/supported-devices/#v=IKEA)  |
 | Description | STARKVIND air purifier |
-| Exposes | fan (state, mode), fan_speed, pm25, air_quality, led_enable, child_lock, replace_filter, filter_age, identify, linkquality |
+| Exposes | fan (state, mode), fan_speed, pm25, air_quality, led_enable, child_lock, replace_filter, filter_age, device_age, identify, linkquality |
 | Picture | ![IKEA E2007](https://www.zigbee2mqtt.io/images/devices/E2007.png) |
 
 
@@ -42,7 +42,7 @@ This device supports OTA updates, for more information see [OTA updates](../guid
 
 ## Exposes
 
-### Fan 
+### Fan
 The current state of this fan is in the published state under the `fan_state` property (value is `ON` or `OFF`).
 To control this fan publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"fan_state": "ON"}` or `{"fan_state": "OFF"}`.
 To read the current state of this fan publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"fan_state": ""}`.
@@ -96,6 +96,12 @@ Value can be found in the published state on the `filter_age` property.
 To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"filter_age": ""}`.
 It's not possible to write (`/set`) this value.
 
+### Device age (numeric)
+Time the device has been used in minutes.
+Value can be found in the published state on the `device_age` property.
+To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"device_age": ""}`.
+It's not possible to write (`/set`) this value.
+
 ### Identify (enum)
 Initiate device identification.
 Value will **not** be published in the state.
@@ -109,4 +115,3 @@ Value can be found in the published state on the `linkquality` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `255`.
 The unit of this value is `lqi`.
-


### PR DESCRIPTION
Doc update for https://github.com/Koenkk/zigbee-herdsman-converters/pull/7716

Edit: This is probably unnecessary if the doc is auto-generated.