### PR TITLE
Update home_assistant.md

### DIFF
--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -291,7 +291,7 @@ automation:
                     {%- set find_integration = 'mqtt' %} 
                      {%- set devices = states | map(attribute='entity_id') | map('device_id') | unique | reject('eq',None) | list %}
                      {%- set ns = namespace(entities = []) %}
-                     {%- for device in devices %}
+                     {%- for device in devices if device_attr(device, 'identifiers') %}
                        {%- set ids = device_attr(device, 'identifiers') | list | first %}
                        {%- if ids and ids | length == 2 and ids[0] == find_integration %}
                          {% set names = device_attr(device, 'name').split('\n') | list %}


### PR DESCRIPTION
Add condition to only loop over devices containing the requested attribute.
This avoids the error "No first item, sequence was empty."