### PR TITLE
Update TS0601_dimmer_4.md

### DIFF
--- a/docs/devices/TS0601_dimmer_4.md
+++ b/docs/devices/TS0601_dimmer_4.md
@@ -20,7 +20,7 @@ pageClass: device-page
 | Description | 2 gang smart dimmer module |
 | Exposes | light (state, brightness, min_brightness, max_brightness), countdown, light_type, power_on_behavior, linkquality |
 | Picture | ![Moes Moes ZM-105B-M](https://www.zigbee2mqtt.io/images/devices/ZM-105B-M.png) |
-| White-label | Moes MS-105B-M | Moes ZM-105B-M |
+| White-label | Moes ZM-105B-M |
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->


### PR DESCRIPTION
Whitelabel MS-105B-M removed because it is not a Zigbee device. Ref: https://github.com/Koenkk/zigbee-herdsman-converters/pull/7835#discussion_r1709140620