### PR TITLE
Update A1Z.md reintroduce Reset energy chapter

### DIFF
--- a/docs/devices/A1Z.md
+++ b/docs/devices/A1Z.md
@@ -23,7 +23,20 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+### Pairing
+If the indicator light does not flash rapidly, press the button for 5 to 7 seconds to reset the smart plug parameters to factory settings.
+
+
+### Reset energy
+To reset `Sum of consumed energy`, use the Dev console and execute:
+`Endpoint`: `1`
+`Cluster`: `0x00`
+`Command`: `0`
+`Payload`: (don't change this)
+
+Next time the plug gets polled, `Sum of consumed energy` will start from zero again.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
Reset energy chapter was removed with commit "c9e8b4810dbf3458a48946739049a8082328292a". But resetting the A1Z plug still works. So this is valuable input for users.