### PR TITLE
Add "off" system mode to Vimar 02973.B

### DIFF
--- a/docs/devices/02973.B.md
+++ b/docs/devices/02973.B.md
@@ -42,7 +42,7 @@ This climate device supports the following features: `occupied_heating_setpoint`
 - `occupied_heating_setpoint`: Temperature setpoint. To control publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"occupied_heating_setpoint": VALUE}` where `VALUE` is the °C between `4` and `40`. To read send a message to `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"occupied_heating_setpoint": ""}`.
 - `occupied_cooling_setpoint`: Temperature setpoint. To control publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"occupied_cooling_setpoint": VALUE}` where `VALUE` is the °C between `4` and `40`. To read send a message to `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"occupied_cooling_setpoint": ""}`.
 - `local_temperature`: Current temperature measured on the device (in °C). To read send a message to `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"local_temperature": ""}`.
-- `system_mode`: Mode of this device. To control publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"system_mode": VALUE}` where `VALUE` is one of: `heat`, `cool`. To read send a message to `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"system_mode": ""}`.
+- `system_mode`: Mode of this device. To control publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"system_mode": VALUE}` where `VALUE` is one of: `off`, `heat`, `cool`. To read send a message to `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"system_mode": ""}`.
 
 ### Linkquality (numeric)
 Link quality (signal strength).


### PR DESCRIPTION
Add "off" system mode to Vimar 02973.B.

The Vimar 02973.B reports and accepts "off" as system mode:

2024-08-19 14:08:49z2m:mqtt: MQTT publish: topic 'zigbee2mqtt/Termostato camera', payload '{"linkquality":168,"local_temperature":27.5,"occupied_cooling_setpoint":23,"occupied_heating_setpoint":17,"running_state":"idle","system_mode":"off"}'

Without "off" as system mode, home assistants logs this error:

`Logger: homeassistant.components.mqtt.climate
Source: components/mqtt/climate.py:703
integration: MQTT ([documentation](https://www.home-assistant.io/integrations/mqtt), [issues](https://github.com/home-assistant/core/issues?q=is%3Aissue+is%3Aopen+label%3A%22integration%3A+mqtt%22))
First occurred: 13:05:30 (15 occurrences)
Last logged: 13:15:10

Invalid modes mode: off`

Change linked to https://github.com/Koenkk/zigbee-herdsman-converters/pull/7875