### PR TITLE
Add more information to use a stable release instead of the master branch

### DIFF
--- a/docs/guide/installation/05_windows.md
+++ b/docs/guide/installation/05_windows.md
@@ -38,9 +38,12 @@ In order to be able to communicate with your USB device over a virtual COM port,
     node --version
     ```
 1. Choose a suitable directory for Zigbee2MQTT and copy all the files from the [Zigbee2MQTT repository](https://github.com/koenkk/zigbee2mqtt)
-    - if you prefer to use git (which you should), just clone the whole repository
+    - if you prefer to use git (which you should), just clone the whole repository and pick a release tag.(e.g. TAG=1.36.0)
         ```bash
         git clone --depth 1 https://github.com/Koenkk/zigbee2mqtt/
+        cd zigbee2mqtt
+        git fetch --all --tags
+        git checkout tags/TAG  #  replace TAG with your TAG identifier from https://github.com/Koenkk/zigbee2mqtt/tags
         ```
     - otherwise use the green `Clone or download` button to download the zip archive, then extract it
 1. Change to the newly created directory and install dependencies with Node.js own package manager `npm`


### PR DESCRIPTION
See [#23748](https://github.com/Koenkk/zigbee2mqtt/discussions/23748)

Edit the windows tutorial to use a stable release instead of the master branch.
I guess there is a problem with windows devices/ports on the current master branch ab0c021a8349f2d892d066396a92e01551a1ecc4 .
