### PR TITLE
clarify Sonoff ZBDongle-E only supports software flow control.

### DIFF
--- a/docs/guide/adapters/emberznet.md
+++ b/docs/guide/adapters/emberznet.md
@@ -53,7 +53,7 @@ The use of `adapter: ezsp` is now deprecated. See [https://github.com/Koenkk/zig
 <details>
 <summary>Sonoff ZBDongle-E (V2 model, EFR32MG21)</summary>
 
-With external antenna.
+With external antenna. Only supports software flow control (make sure not to set `rtscts: true`).
 
 **This section is about the "ZBDongle-E", for "ZBDongle-P" see [zStack](./zstack.md).**
 


### PR DESCRIPTION
Despite the firmware filenames for the Sonoff ZBDongle-E from darkxst/silabs-firmware-builder containing the string hw, which [commonly stands for](https://github.com/itead/Sonoff_Zigbee_Dongle_Firmware/blob/master/Dongle-E/NCP/README.md#abbreviations-diction-legend) hardware flow control support, the device/firmware apparently does not support hardware flow control, as it is stated [here](https://github.com/darkxst/silabs-firmware-builder#pre-compiled-firmware).

I erroneously set `rtscts` to `true`  for this device as the firmware name suggested it and wasted quite some time on it. So I think it can't hurt to make this clear in the documentation for beginners like me.