### PR TITLE
Update SLR2.md

### DIFF
--- a/docs/devices/SLR2.md
+++ b/docs/devices/SLR2.md
@@ -17,7 +17,7 @@ pageClass: device-page
 |-----|-----|
 | Model | SLR2  |
 | Vendor  | [Hive](/supported-devices/#v=Hive)  |
-| Description | Dual channel heating and hot water thermostat |
+| Description | Dual channel heating and hot water receiver |
 | Exposes | climate (occupied_heating_setpoint, local_temperature, system_mode, running_state), temperature_setpoint_hold, temperature_setpoint_hold_duration, linkquality |
 | Picture | ![Hive SLR2](https://www.zigbee2mqtt.io/images/devices/SLR2.png) |
 
@@ -28,13 +28,13 @@ pageClass: device-page
 
 ### Pairing
 
-To pair the thermostat with Zigbee2MQTT, follow these steps:
+To pair the receiver with Zigbee2MQTT, follow these steps:
 
-1. Temporarily disconnect any thermostat controllers connected to the thermostat by remove a battery from them.
-2. Turn the thermostat and boiler off, then on again to ensure it is not trying to connect to any thermostat controllers.
-3. Once the thermostat and boiler are on, hold down the Central heating button on the device until the Central heating'light turns white/ pink, then release the button. This will enable stand-alone mode on the thermostat.
+1. Temporarily disconnect any thermostat controllers connected to the receiver by removing a battery from them.
+2. Turn the receiver and boiler off, then on again to ensure it is not trying to connect to any thermostat controllers.
+3. Once the receiver and boiler are on, hold down the Central heating button on the device until the Central heating'light turns white/ pink, then release the button. This will enable stand-alone mode on the receiver.
 4. Hold down the central heating button again until the Central heating light begins to flash amber. The device is now in pairing mode and should be found by Zigbee2MQTT.
-5. You can now re-insert the battery back into any thermostat controllers disconnected in step 1 and pair them to the boiler (and optionally Zigbee2MQTT). For information on pairing the thermostat controllers see the pairing instructions for the [Hive SLT3B](./SLT3.md). Note that the thermostat's Central heating light will remain amber until a controller is paired with the thermostat, however the thermostat will still function correctly.
+5. You can now re-insert the battery back into any thermostat controllers disconnected in step 1 and pair them to the receiver (and optionally Zigbee2MQTT). For information on pairing the thermostat controllers see the pairing instructions for the [Hive SLT3B](./SLT3.md). Note that the receiver's Central heating light will remain amber until a thermostat controller is paired with the receiver, however the receiver will still function correctly.
 
 
 ### Sending payloads on dual channel receivers


### PR DESCRIPTION
Clarified the pairing instructions by replacing the word 'thermostat' with 'receiver' to differentiate the two devices better.