### PR TITLE
Add hint to required firmware for auto close switch

### DIFF
--- a/docs/devices/SWV.md
+++ b/docs/devices/SWV.md
@@ -73,7 +73,8 @@ It's not possible to write (`/set`) this value.
 The possible values are: `normal_state`, `water_shortage`, `water_leakage`, `water_shortage & water_leakage`.
 
 ### Auto close when water shortage (binary)
-Automatically shut down the water valve after the water shortage exceeds 30 minutes..
+This feature requires firmware version 1.0.4 or later!
+Automatically shut down the water valve after the water shortage exceeds 30 minutes.
 Value can be found in the published state on the `auto_close_when_water_shortage` property.
 To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"auto_close_when_water_shortage": ""}`.
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"auto_close_when_water_shortage": NEW_VALUE}`.


### PR DESCRIPTION
It was not mentioned in the PR https://github.com/Koenkk/zigbee-herdsman-converters/pull/7891 and already caused some confusion on different channels.
This hint should help...