### PR TITLE
Add link to ESP32 adapter firmware

### DIFF
--- a/docs/guide/adapters/zboss.md
+++ b/docs/guide/adapters/zboss.md
@@ -38,3 +38,5 @@ Currently tested on nRF52840 Dongle.
 -   [Pre build coordinator firmware for Nordic Semiconductor with nRF52840 SoC](https://github.com/kardia-as/nrf-zboss-ncp)
 
 <img src="https://docs-be.nordicsemi.com/bundle/ncs-latest/page/nrf/_images/zigbee_ncp_sample_overview.svg" width="500" />
+
+-   [Experimental ESP32-C6 firmware](https://github.com/andryblack/esp-coordinator)


### PR DESCRIPTION
I write [basic implementation](https://github.com/andryblack/esp-coordinator) for ZBOSS NCP protocol for esp32 with coordinator role supported almost all command used by zigbee2mqtt project.
