### PR TITLE
Update OSRAM AC0251100NJ page with known problem workaround

### DIFF
--- a/docs/devices/AC0251100NJ_AC0251600NJ_AC0251700NJ.md
+++ b/docs/devices/AC0251100NJ_AC0251600NJ_AC0251700NJ.md
@@ -31,6 +31,12 @@ For the OSRAM Smart+ Switch Mini (AC0251100NJ/AC0251600NJ/AC0251700NJ) hold the 
 to Reset the Device. Hold the Middle and Arrow Up Buttons for 3 Seconds to connect.
 If the Switch is connected hold Middle and Arrow Up Buttons for 3 Seconds to disconnect.
 
+### Known issue - pressing a button unexpectedly switches other Zigbee devices
+This is referenced in [this issue](https://github.com/Koenkk/zigbee2mqtt/issues/962). Problem occurs because of default bindings to group 0.
+
+Known workaround is to create an empty group in Z2M with different ID (example: 1111), bind all three buttons to this group and remove default bindings to group 0.  
+Read more on a simmilar issue and workarounds in [this issue](https://github.com/Koenkk/zigbee2mqtt/issues/12397) related to other device.
+
 ### Actions
 #### Arrow up 
 causes 'on' at short pressure; 'brightness_move_up' at long pressure (>1 sec); 'brightness_stop' at long pressure release


### PR DESCRIPTION
Adds references to a known binding problem, issues related to this problem and a proposed tested workaround in OSRAM AC0251100NJ_AC0251600NJ_AC0251700NJ.md docs.

This is in relation to [this issue](https://github.com/Koenkk/zigbee2mqtt/issues/962)