### PR TITLE
Update Rodret documentation

### DIFF
--- a/docs/devices/E2201.md
+++ b/docs/devices/E2201.md
@@ -37,7 +37,7 @@ To resolve the `Device didn't respond to OTA request` error, you can try to push
 If your main ZigBee coordinator is a SONOFF Zigbee 3.0 USB Dongle Plus, you may experience issues updating the firmware. To work around this, unpair the switch (hit delete, then quickly follow the pairing instructions), re-pair through a router, then re-attempt the OTA update. See [this issue](https://github.com/Koenkk/zigbee2mqtt/issues/11473) for more details.
 
 ### Binding
-Supports [binding](../guide/usage/binding.md) to devices only. This can be done by sending to `zigbee2mqtt/bridge/request/device/unbind` payload `{"from": "DEVICE_FRIENDLY_NAME", "to": "default_bind_group"}`. Wake up the device right before sending the commands by pressing a button on it.
+Supports [binding](../guide/usage/binding.md) to both devices and groups. Wake up the device right before sending the commands by pressing a button on it.
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
Contrary to what the documentation states, I was able to bind my Rodret to a Zigbee group without problems. I also removed the superfluous sentence how to bind (if you add it back, please fix the `unbind` -> `bind` typo in the mqtt topic).

I suspect it is a firmware issue that hindered @lorenzspenger from binding it to groups in the past? I did not have to do a firmware update though, mine came with 1.0.47 out-of-the-box.