### PR TITLE
Adding Gledopto Multi-mode controller information to docs

### DIFF
--- a/docs/devices/GL-C-003P.md
+++ b/docs/devices/GL-C-003P.md
@@ -25,15 +25,41 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
 
-
 ### Pairing
 1. Switch on your device.
 2. Now switch off and on within 2 seconds.
 3. Repeat off/on four times.
 4. Reset is done when the device is switched on in the fifth time and the light stays on after blinking 4 times
 
-### GL-C-001P
-See [GL-C-008P](./GL-C-008P.md#GL-C-001P).
+## Multi-mode 5-in-1 and 3-in-1 devices
+Gledopto produces devices that allow you to select one of up to 5 different LED Controller types with each mode displaying a different [Indicator Light] **color**.
+
+* `RGB+CCT` [GL-C-008P](./GL-C-008P.md) [White]
+* `RGBW` [GL-C-007P](./GL-C-007P.md) [Yellow]
+* `RGB` [GL-C-003P](./GL-C-003P.md) [Blue]
+* `CCT` [GL-C-006P](./GL-C-006P.md) [Green]
+* `Dimmer` [GL-C-009P](./GL-C-009P.md) [Red]
+
+
+This `GL-C-003P` mode is available as a `modelId` in the following models:
+
+* **GL-C-001P** - Zigbee Pro 5 in 1 Smart LED Controller
+* **GL-C-002P** - Zigbee Pro 5 in 1 LED Controller Mini Ultra Thin
+* **GL-C-011P** - Zigbee Pro 5 in 1 Smart LED Controller DIN Rail
+* **GL-C-201P** - Zigbee Pro+ 5 in 1 Smart LED Controller
+* **GL-C-202P** - Zigbee Pro+ 3 in 1 Smart LED Controller
+* **GL-C-301P** - Zigbee Pro+ 5 in 1 Smart LED Controller Ultra-Mini
+
+You can switch to this `GL-C-003P` mode by short pressing the `Opt` button on the device until the Indicator Light is `Blue`.
+
+To pair with, or change modes on, Zigbee2MQTT, press the `Reset` button 4 times
+
+## Model: GL-C-003P 
+
+**Important Note:** Gledopto never actually released a dedicated/single-mode `RGB` Controller with the Model No. GL-C-003P.  The `GL-C-003P` signal is only able to be communicated to Zigbee2MQTT by White-label devices, and the Multi-mode devices listed above when `RGB` mode is selected.
+
+There is a **GL-C-003P Zigbee Pro 3-wire/2-wire 2 in 1 CCT/DIM LED Controller** but this cannot control the RGB devices that use this `RGB` mode or or send the `GL-C-003P` ModelID. For the use of this device, see `CCT` [GL-C-006P](./GL-C-006P.md) and `Dimmer` [GL-C-009P](./GL-C-009P.md).
+
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/GL-C-006P.md
+++ b/docs/devices/GL-C-006P.md
@@ -25,15 +25,49 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
 
-
 ### Pairing
 1. Switch on your device.
 2. Now switch off and on within 2 seconds.
 3. Repeat off/on four times.
 4. Reset is done when the device is switched on in the fifth time and the light stays on after blinking 4 times
 
-### GL-C-001P
-See [GL-C-008P](./GL-C-008P.md#GL-C-001P).
+## Multi-mode 5-in-1 devices
+Gledopto produces devices that allow you to select one of up to 5 different LED Controller types with each mode displaying a different [Indicator Light] **color**.
+
+* `RGB+CCT` [GL-C-008P](./GL-C-008P.md) [White]
+* `RGBW` [GL-C-007P](./GL-C-007P.md) [Yellow]
+* `RGB` [GL-C-003P](./GL-C-003P.md) [Blue]
+* `CCT` [GL-C-006P](./GL-C-006P.md) [Green]
+* `Dimmer` [GL-C-009P](./GL-C-009P.md) [Red]
+
+This `GL-C-006P` mode is available as a `modelId` in the following models:
+
+* **GL-C-001P** - Zigbee Pro 5 in 1 Smart LED Controller
+* **GL-C-002P** - Zigbee Pro 5 in 1 LED Controller Mini Ultra Thin
+* **GL-C-011P** - Zigbee Pro 5 in 1 Smart LED Controller DIN Rail
+* **GL-C-201P** - Zigbee Pro+ 5 in 1 Smart LED Controller
+* **GL-C-301P** - Zigbee Pro+ 5 in 1 Smart LED Controller Ultra-Mini
+
+You can switch to this `GL-C-006P` mode by short pressing the `Opt` button on the device until the Indicator Light is `Green`.
+
+To pair with, or change modes on, Zigbee2MQTT, press the `Reset` button 4 times
+
+## Dual-mode 2-in-1 devices
+Gledopto produces devices that allow you to select one of up to 2 different LED Controller types with each mode displaying a different [Indicator Light] **status**.
+
+* `CCT` [GL-C-006P](./GL-C-006P.md) [Indicator Light Off]
+* `Dimmer` [GL-C-009P](./GL-C-009P.md) [Indicator Light On]
+
+This `GL-C-006P` mode is available as a `modelId` in the following models:
+* **GL-C-003P**† - Zigbee Pro 3-wire/2-wire 2 in 1 CCT/DIM LED Controller
+* **GL-C-203P** - Zigbee Pro+ 3-wire/2-wire 2 in 1 CCT/DIM LED Controller
+
+You can switch to this `GL-C-009P` mode by short pressing the `Reset` button on the device until the Indicator Light is `Off`.
+
+To pair with, or change modes on, Zigbee2MQTT, long press the `Reset` button for more that 2 seconds.
+
+† Note that this **GL-C-003P** Model is not an RGB Controller and not capable of being selected as an `RGB` controller or sending the `GL-C-003P` ModelId to Zigbee2MQTT. See [GL-C-003P](./GL-C-003P.md) for devices that can do this.
+
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/GL-C-007P.md
+++ b/docs/devices/GL-C-007P.md
@@ -25,15 +25,34 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
 
-
 ### Pairing
 1. Switch on your device.
 2. Now switch off and on within 2 seconds.
 3. Repeat off/on four times.
 4. Reset is done when the device is switched on in the fifth time and the light stays on after blinking 4 times
 
-### GL-C-001P
-See [GL-C-008P](./GL-C-008P.md#GL-C-001P).
+## Multi-mode 5-in-1 and 3-in-1 devices
+Gledopto produces devices that allow you to select one of up to 5 different LED Controller types with each mode displaying a different [Indicator Light] **color**.
+
+* `RGB+CCT` [GL-C-008P](./GL-C-008P.md) [White]
+* `RGBW` [GL-C-007P](./GL-C-007P.md) [Yellow]
+* `RGB` [GL-C-003P](./GL-C-003P.md) [Blue]
+* `CCT` [GL-C-006P](./GL-C-006P.md) [Green]
+* `Dimmer` [GL-C-009P](./GL-C-009P.md) [Red]
+
+This `GL-C-007P` mode is available as a `modelId` in the following models:
+
+* **GL-C-001P** - Zigbee Pro 5 in 1 Smart LED Controller
+* **GL-C-002P** - Zigbee Pro 5 in 1 LED Controller Mini Ultra Thin
+* **GL-C-011P** - Zigbee Pro 5 in 1 Smart LED Controller DIN Rail
+* **GL-C-201P** - Zigbee Pro+ 5 in 1 Smart LED Controller
+* **GL-C-202P** - Zigbee Pro+ 3 in 1 Smart LED Controller
+* **GL-C-301P** - Zigbee Pro+ 5 in 1 Smart LED Controller Ultra-Mini
+
+You can switch to this `GL-C-007P` mode by short pressing the `Opt` button on the device until the Indicator Light is `Yellow`.
+
+To pair with, or change modes on, Zigbee2MQTT, press the `Reset` button 4 times
+
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/GL-C-008P.md
+++ b/docs/devices/GL-C-008P.md
@@ -26,23 +26,34 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
 
-
 ### Pairing
 1. Switch on your device.
 2. Now switch off and on within 2 seconds.
 3. Repeat off/on four times.
 4. Reset is done when the device is switched on in the fifth time and the light stays on after blinking 4 times
 
-### GL-C-001P
-The Gledopto GL-C-001P is a 5 in 1 smart LED controller which can identify itself as one of the 5 different Gledopto controllers (the indicator light colour matches the model):
+## Multi-mode 5-in-1 and 3-in-1 devices
+Gledopto produces devices that allow you to select one of up to 5 different LED Controller types with each mode displaying a different [Indicator Light] **color**.
 
-* [White] RGB+CCT: GL-C-008P  
-* [Yellow] RGBW: GL-C-007P 
-* [Blue] RGB: GL-C-003P 
-* [Green] CCT: GL-C-006P 
-* [Red] Dimmer: GL-C-009P 
+* `RGB+CCT` [GL-C-008P](./GL-C-008P.md) [White]
+* `RGBW` [GL-C-007P](./GL-C-007P.md) [Yellow]
+* `RGB` [GL-C-003P](./GL-C-003P.md) [Blue]
+* `CCT` [GL-C-006P](./GL-C-006P.md) [Green]
+* `Dimmer` [GL-C-009P](./GL-C-009P.md) [Red]
 
-You can switch between the modes using the `Opt` button on the device. After switching modes Zigbee2MQTT will automatically detect the new mode. Note that during the pairing process the log message `identified as: Gledopto Zigbee LED Controller XXX`  might state  model that differs from currently selected one. You should wait for the log message `Detected Gledopto device mode change` that should follow shortly afterwards meaning that Zigbee2MQTT has recognized the currently selected mode.
+This `GL-C-008P` mode is available as a `modelId` in the following models:
+
+* **GL-C-001P** - Zigbee Pro 5 in 1 Smart LED Controller
+* **GL-C-002P** - Zigbee Pro 5 in 1 LED Controller Mini Ultra Thin
+* **GL-C-011P** - Zigbee Pro 5 in 1 Smart LED Controller DIN Rail
+* **GL-C-201P** - Zigbee Pro+ 5 in 1 Smart LED Controller
+* **GL-C-202P** - Zigbee Pro+ 3 in 1 Smart LED Controller
+* **GL-C-301P** - Zigbee Pro+ 5 in 1 Smart LED Controller Ultra-Mini
+
+You can switch to this `GL-C-008P` mode by short pressing the `Opt` button on the device until the Indicator Light is `White`.
+
+To pair with, or change modes on, Zigbee2MQTT, press the `Reset` button 4 times
+
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/GL-C-009P.md
+++ b/docs/devices/GL-C-009P.md
@@ -25,15 +25,49 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
 
-
 ### Pairing
 1. Switch on your device.
 2. Now switch off and on within 2 seconds.
 3. Repeat off/on four times.
 4. Reset is done when the device is switched on in the fifth time and the light stays on after blinking 4 times
 
-### GL-C-001P
-See [GL-C-008P](./GL-C-008P.md#GL-C-001P).
+## Multi-mode 5-in-1 devices
+Gledopto produces devices that allow you to select one of up to 5 different LED Controller types with each mode displaying a different [Indicator Light] **color**.
+
+* `RGB+CCT` [GL-C-008P](./GL-C-008P.md) [White]
+* `RGBW` [GL-C-007P](./GL-C-007P.md) [Yellow]
+* `RGB` [GL-C-003P](./GL-C-003P.md) [Blue]
+* `CCT` [GL-C-006P](./GL-C-006P.md) [Green]
+* `Dimmer` [GL-C-009P](./GL-C-009P.md) [Red]
+
+This `GL-C-009P` mode is available as a `modelId` in the following models:
+
+* **GL-C-001P** - Zigbee Pro 5 in 1 Smart LED Controller
+* **GL-C-002P** - Zigbee Pro 5 in 1 LED Controller Mini Ultra Thin
+* **GL-C-011P** - Zigbee Pro 5 in 1 Smart LED Controller DIN Rail
+* **GL-C-201P** - Zigbee Pro+ 5 in 1 Smart LED Controller
+* **GL-C-301P** - Zigbee Pro+ 5 in 1 Smart LED Controller Ultra-Mini
+
+You can switch to this `GL-C-009P` mode by short pressing the `Opt` button on the device until the Indicator Light is `Red`.
+
+To pair with, or change modes on, Zigbee2MQTT, press the `Reset` button 4 times
+
+## Dual-mode 2-in-1 devices
+Gledopto produces devices that allow you to select one of up to 2 different LED Controller types with each mode displaying a different [Indicator Light] **status**.
+
+* `CCT` [GL-C-006P](./GL-C-006P.md) [Indicator Light Off]
+* `Dimmer` [GL-C-009P](./GL-C-009P.md) [Indicator Light On]
+
+This `GL-C-009P` mode is available as a `modelId` in the following models:
+* **GL-C-003P**† - Zigbee Pro 3-wire/2-wire 2 in 1 CCT/DIM LED Controller
+* **GL-C-203P** - Zigbee Pro+ 3-wire/2-wire 2 in 1 CCT/DIM LED Controller
+
+You can switch to this `GL-C-009P` mode by short pressing the `Reset` button on the device until the Indicator Light is `On`.
+
+To pair with, or change modes on, Zigbee2MQTT, long press the `Reset` button for more that 2 seconds.
+
+† Note that this **GL-C-003P** Model is not an RGB Controller and not capable of being selected as an `RGB` controller or sending the `GL-C-003P` ModelId to Zigbee2MQTT. See [GL-C-003P](./GL-C-003P.md) for devices that can do this.
+
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
Updating documentation for the various Gledopto Multi-mode controllers that can be set to emulate a number of different existing devices.

I wanted to do this to try to avoid the confusion of https://github.com/Koenkk/zigbee2mqtt/issues/24091 in the future.

I did an audit of the Gledopto devices that report their `modelId` as GL-C-003P, GL-C-006P, GL-C-007P, GL-C-008P and GL-C-009P here:
![image](https://github.com/user-attachments/assets/3d343166-40ce-4038-b88b-1487911d3c22)

If you want to update the White-label fields, my recommendation is as follows:
[GL-C-003P](https://www.zigbee2mqtt.io/devices/GL-C-003P.html) - GL-C-103P, GL-C-001P, GL-C-002P,GL-C-011P, GL-C-201P, GL-C-202P, GL-C-301P
[GL-C-006P](https://www.zigbee2mqtt.io/devices/GL-C-006P.html) - GL-C-006P(mini), GL-C-001P, GL-C-002P, GL-C-003P, GL-C-011P, GL-C-201P, GL-C-203P, GL-C-301P
[GL-C-007P](https://www.zigbee2mqtt.io/devices/GL-C-007P.html) - GL-C-007P(mini), GL-C-001P, GL-C-002P, GL-C-011P, GL-C-201P, GL-C-202P, GL-C-301P
[GL-C-008P](https://www.zigbee2mqtt.io/devices/GL-C-008P.html) - GL-C-008P(mini), GL-C-001P, GL-C-002P, GL-C-011P, GL-C-201P, GL-C-202P, GL-C-301P
[GL-C-009P](https://www.zigbee2mqtt.io/devices/GL-C-009P.html) - GL-C-009P(mini), GL-C-001P, GL-C-002P, GL-C-003P, GL-C-011P, GL-C-201P, GL-C-203P, GL-C-301P
(I could create the pull request for these in zigbee-herdsman-converters/src/devices/gledopto.ts if you agree with the concept).