### PR TITLE
Change to proper attention message

### DIFF
--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -63,8 +63,9 @@ If you only plan to use this and want to disable the _Via Home Assistant entity_
 
 ### Via Home Assistant entity
 
-> [!WARNING]
-> This is a legacy feature and will not be supported anymore as of [Zigbee2MQTT 2.0.0](https://github.com/Koenkk/zigbee2mqtt/discussions/24198).
+::: warning ATTENTION
+This is a legacy feature and will not be supported anymore as of [Zigbee2MQTT 2.0.0](https://github.com/Koenkk/zigbee2mqtt/discussions/24198).
+:::
 
 This method work by responding to the state change event of a sensor.
 


### PR DESCRIPTION
The warning message as part of PR #3236 doesn't show as intended on the website. This should correct that.

Currently
![image](https://github.com/user-attachments/assets/c71e4aae-4c32-4d56-b82d-b0178833fe1e)

Should be like this example (with different text)
![image](https://github.com/user-attachments/assets/ed87eda8-273e-4d9b-86b6-a76078f1a273)
