### PR TITLE
Update Busch-Jaeger 6735/6736/6737 docs for Z2M 2.0

### DIFF
--- a/docs/devices/6735_6736_6737.md
+++ b/docs/devices/6735_6736_6737.md
@@ -83,12 +83,6 @@ For the 2-row and 4-row devices the following procedure has proven to be a good 
 
 For single-row devices re-inserting the battery in the very right moment might be required when reconfiguring the switches.
 
-#### Home Assistant: device discovered both as light and switch
-
-If you are using Home Assistant auto-discovery you'll notice that the device is discovered both as a `light` entity and as a `switch` entity.
-
-**Always use the `light` entity!** The `switch` entity is only there for historic (compatibility) reasons and can be safely ignored. The main issue with the `switch` entity is that it does not update it's state when the Busch-Jaeger device is controlled directly through it's top-row rockers.
-
 ### Action values
 
 This device sends the following `action` values in its payload:
@@ -101,7 +95,7 @@ This device sends the following `action` values in its payload:
 | `off_row_4`<br>`brightness_step_down_row_4` | `brightness_stop_row_4` | `on_row_4`<br>`brightness_step_up_row_4` |
 
 
-Briefly pressing and releasing a button triggers the `off_row_X` resp. `on_row_X` actions for the given row, long-pressing triggers the `brightness_step_down_row_X`/`brightness_step_up_row_X` state respectively (after about one second). When releasing the button after a long-press action, a `brightness_stop_row_X` will be issued with no distinction between the left or right button. Note that the action payload may be different when you have set the `legacy` flag for the device (not recommended).
+Briefly pressing and releasing a button triggers the `off_row_X` resp. `on_row_X` actions for the given row, long-pressing triggers the `brightness_step_down_row_X`/`brightness_step_up_row_X` state respectively (after about one second). When releasing the button after a long-press action, a `brightness_stop_row_X` will be issued with no distinction between the left or right button.
 
 Depending on the device configuration not all actions may be sent.
 <!-- Notes END: Do not edit below this line -->


### PR DESCRIPTION
* Don't mention legacy payload anymore
* Remove note regarding switch entity (dropped in Z2M 2.0)