### PR TITLE
Update home_assistant.md

### DIFF
--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -72,11 +72,12 @@ automation:
       triggers:
           - trigger: state
             entity_id: event.my_switch_click
-            attribute: event_type
-            to: 'single'
+            to: ~
       conditions:
           - condition: template
             value_template: "{{trigger.from_state.state != 'unavailable'}}"
+          - condition: template
+            value_template: "{{trigger.to_state.attributes.event_type == 'single'}}"
       actions:
           - action: light.toggle
             target:


### PR DESCRIPTION
The problem is that the event trigger as written won't work if the button is pushed a second time. This is because the attribute won't change, so HA won't trigger.

By using the fact that events have a timestamp of the last event, you can trigger when the state changes, and then check the event type attribute.

[This HA forum thread](https://community.home-assistant.io/t/wth-are-event-entities-not-triggered-a-second-time-when-using-the-attribute-event-type-in-a-state-trigger/804428) explains this problem in more detail.