### PR TITLE
Add pairing notes for TS0601_cover_1

### DIFF
--- a/docs/devices/TS0601_cover_1.md
+++ b/docs/devices/TS0601_cover_1.md
@@ -27,8 +27,11 @@ pageClass: device-page
 ## Notes
 
 ## Pairing
-On 2-button units; press down and set simultaneously until LED flashes blue.
-On 1-button units; press the set key 3 times in 5 seconds until the LED flashes blue.
+
+- On 2-button units: press down and set simultaneously until LED flashes blue.
+- On 1-button units: press the set key 3 times in 5 seconds until the LED flashes blue.
+- On Tuya/Zemismart bead curtain motor: Press set once shortly, then press set again for 5 seconds until LED flashes blue.
+  - If the sequence was not started with the initial short press, the 5 second press will turn the device off. In this case press set again for 5 seconds to turn it back on)
 
 ### Configuration of device attributes
 By publishing to `zigbee2mqtt/FRIENDLY_NAME/set` various device attributes can be configured:


### PR DESCRIPTION
Added notes for pairing of bead curtain motors which are detected as TS0601_cover_1 
Pairing on these works different than the already documented methods