### PR TITLE
[HG06104A] Correct description

### DIFF
--- a/docs/devices/HG06104A.md
+++ b/docs/devices/HG06104A.md
@@ -17,7 +17,7 @@ pageClass: device-page
 |-----|-----|
 | Model | HG06104A  |
 | Vendor  | [Lidl](/supported-devices/#v=Lidl)  |
-| Description | Livarno Lux smart LED light strip 2.5m |
+| Description | Livarno Home RGBCCT LED light strip 2m |
 | Exposes | light (state, brightness, color_temp, color_xy), effect, do_not_disturb, color_power_on_behavior, linkquality |
 | Picture | ![Lidl HG06104A](https://www.zigbee2mqtt.io/images/devices/HG06104A.png) |
 


### PR DESCRIPTION
- It's 2 meters, not 2.5 meters
- The branding is "Livarno Home", not "Livarno Lux"
- Added that it's an "RGBCCT" LED strip

Packaging:

![IMG_20241206_170157](https://github.com/user-attachments/assets/52028775-0882-449c-a04d-3b539ce56b8b)
