### PR TITLE
Update switch-to-dev-branch.md

### DIFF
--- a/docs/advanced/more/switch-to-dev-branch.md
+++ b/docs/advanced/more/switch-to-dev-branch.md
@@ -24,7 +24,7 @@ cp -R data data-backup
 # Update
 git fetch origin dev
 # If you get an `error: pathspec 'dev' did not match any file(s) known to git` execute: `git fetch origin --unshallow`
-git checkout dev # Change 'dev' to 'master' to switch back to the release version
+git checkout dev:dev # Change 'dev' to 'master' to switch back to the release version
 git pull
 npm ci
 


### PR DESCRIPTION
checkout did not work if you did not already have a "dev" branch locally. "git fetch origin dev:dev" fetches and creates local "dev" branch, which can now be switched to. So if you use this script on a new installation, it fails.

Test:
```
mkdir zigbee2mqtt
git clone --depth 1 https://github.com/Koenkk/zigbee2mqtt.git zigbee2mqtt
cd zigbee2mqtt
git fetch origin dev
git checkout dev # Change 'dev' to 'master' to switch back to the release version
```

result:
```
zigbee2mqtt $ git checkout dev
error: pathspec 'dev' did not match any file(s) known to git
```

"git fetch origin dev:dev" fixes this edge case