### PR TITLE
Minor SNZB-03P documentation fix

### DIFF
--- a/docs/devices/SNZB-03P.md
+++ b/docs/devices/SNZB-03P.md
@@ -48,7 +48,7 @@ It's not possible to write (`/set`) this value.
 If value equals `true` occupancy is ON, if `false` OFF.
 
 ### Motion timeout (numeric)
-Unoccupied to occupied delay.
+Occupied to unoccupied delay.
 Value can be found in the published state on the `motion_timeout` property.
 To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"motion_timeout": ""}`.
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"motion_timeout": NEW_VALUE}`.


### PR DESCRIPTION
That's actually not a delay for occupancy. When you enter the room it immediately says you enter the room. However there's a no-movement timeout before it says "unoccupied".

Tied to https://github.com/Koenkk/zigbee-herdsman-converters/pull/8467.