### PR TITLE
Note that Enbrighten devices sometimes need to be power cycled

### DIFF
--- a/docs/devices/43076.md
+++ b/docs/devices/43076.md
@@ -23,7 +23,11 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+# Device Not Responding
+
+Some Enbrighten devices will not respond to route update requests after a while. This can cause them to eventually not respond to commands, even though "last seen" will be recent. The only way to fix this is to reset the device by unplugging it or flipping power at the breaker.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/43078.md
+++ b/docs/devices/43078.md
@@ -23,7 +23,11 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+# Device Not Responding
+
+Some Enbrighten devices will not respond to route update requests after a while. This can cause them to eventually not respond to commands, even though "last seen" will be recent. The only way to fix this is to reset the device by unplugging it or flipping power at the breaker.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/43080.md
+++ b/docs/devices/43080.md
@@ -34,6 +34,11 @@ To change the LED status indicator press the top of rocker 3 times and then the 
 
 ### Pairing
 Factory reset the dimmer by pressing the top of the rocker 10 times quickly.
+
+# Device Not Responding
+
+Some Enbrighten devices will not respond to route update requests after a while. This can cause them to eventually not respond to commands, even though "last seen" will be recent. The only way to fix this is to reset the device by unplugging it or flipping power at the breaker.
+
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/43082.md
+++ b/docs/devices/43082.md
@@ -37,6 +37,11 @@ Factory reset the dimmer by pressing the top of the rocker 10 times quickly.
 
 ### Binding
 This device does not support [binding](../guide/usage/binding.md) to groups. It does support binding to devices.
+
+# Device Not Responding
+
+Some Enbrighten devices will not respond to route update requests after a while. This can cause them to eventually not respond to commands, even though "last seen" will be recent. The only way to fix this is to reset the device by unplugging it or flipping power at the breaker.
+
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/43084.md
+++ b/docs/devices/43084.md
@@ -23,7 +23,11 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+# Device Not Responding
+
+Some Enbrighten devices will not respond to route update requests after a while. This can cause them to eventually not respond to commands, even though "last seen" will be recent. The only way to fix this is to reset the device by unplugging it or flipping power at the breaker.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/43090.md
+++ b/docs/devices/43090.md
@@ -23,7 +23,11 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+# Device Not Responding
+
+Some Enbrighten devices will not respond to route update requests after a while. This can cause them to eventually not respond to commands, even though "last seen" will be recent. The only way to fix this is to reset the device by unplugging it or flipping power at the breaker.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/43094.md
+++ b/docs/devices/43094.md
@@ -23,7 +23,11 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+# Device Not Responding
+
+Some Enbrighten devices will not respond to route update requests after a while. This can cause them to eventually not respond to commands, even though "last seen" will be recent. The only way to fix this is to reset the device by unplugging it or flipping power at the breaker.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/43095.md
+++ b/docs/devices/43095.md
@@ -23,7 +23,11 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+# Device Not Responding
+
+Some Enbrighten devices will not respond to route update requests after a while. This can cause them to eventually not respond to commands, even though "last seen" will be recent. The only way to fix this is to reset the device by unplugging it or flipping power at the breaker.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/43096.md
+++ b/docs/devices/43096.md
@@ -23,7 +23,11 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+# Device Not Responding
+
+Some Enbrighten devices will not respond to route update requests after a while. This can cause them to eventually not respond to commands, even though "last seen" will be recent. The only way to fix this is to reset the device by unplugging it or flipping power at the breaker.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/43100.md
+++ b/docs/devices/43100.md
@@ -33,6 +33,11 @@ pageClass: device-page
 3. Plug the smart switch back into the outlet while holding down the push button.
 4. Release button after the smart switch is plugged in. You must release button within four seconds of
 plugging in the switch.
+
+# Device Not Responding
+
+Some Enbrighten devices will not respond to route update requests after a while. This can cause them to eventually not respond to commands, even though "last seen" will be recent. The only way to fix this is to reset the device by unplugging it or flipping power at the breaker.
+
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/43102.md
+++ b/docs/devices/43102.md
@@ -23,7 +23,11 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+# Device Not Responding
+
+Some Enbrighten devices will not respond to route update requests after a while. This can cause them to eventually not respond to commands, even though "last seen" will be recent. The only way to fix this is to reset the device by unplugging it or flipping power at the breaker.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/43109.md
+++ b/docs/devices/43109.md
@@ -25,6 +25,11 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
 A bulk order version of the Enbrighten 43076.
+
+# Device Not Responding
+
+Some Enbrighten devices will not respond to route update requests after a while. This can cause them to eventually not respond to commands, even though "last seen" will be recent. The only way to fix this is to reset the device by unplugging it or flipping power at the breaker.
+
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/43113.md
+++ b/docs/devices/43113.md
@@ -34,6 +34,11 @@ To change the LED status indicator press the top of rocker 3 times and then the 
 
 ### Pairing
 Factory reset the dimmer by pressing the top of the rocker 10 times quickly.
+
+# Device Not Responding
+
+Some Enbrighten devices will not respond to route update requests after a while. This can cause them to eventually not respond to commands, even though "last seen" will be recent. The only way to fix this is to reset the device by unplugging it or flipping power at the breaker.
+
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/43132.md
+++ b/docs/devices/43132.md
@@ -23,7 +23,11 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+# Device Not Responding
+
+Some Enbrighten devices will not respond to route update requests after a while. This can cause them to eventually not respond to commands, even though "last seen" will be recent. The only way to fix this is to reset the device by unplugging it or flipping power at the breaker.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/ZB3102.md
+++ b/docs/devices/ZB3102.md
@@ -23,7 +23,11 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+# Device Not Responding
+
+Some Enbrighten devices will not respond to route update requests after a while. This can cause them to eventually not respond to commands, even though "last seen" will be recent. The only way to fix this is to reset the device by unplugging it or flipping power at the breaker.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
I had two different Enbrighten devices stop responding over the past two days. In the past, I've just power cycled them but not figured out why they were not working.

Today, I sniffed the traffic, and discovered that the coordinator had no route to the device such as:

```
debug: 	zh:zstack: Discovering route to 7418
```

While I could see `Route Request` commands being sent, there were no `Route Record` responses coming from the devices. This was even though I could see occasional link status broadcasts coming from those devices.

As soon as I power cycled the devices, I saw them sending `Route Record` responses and all was good again.

I don't see any bug in herdsman for this and think its' an issue with the Enbrighten devices. I've seen this behaviour across a few different models, so I wouldn't be surprised if they all had this issue. Enbrighten has never issued a firmware update for Zigbee devices, so I think we should put this warning in the docs. I know between this and https://github.com/jascoproducts/firmware/issues/127, I wish I had used a different vendor!