### PR TITLE
Fix some formatting in IKEA E1525_E1745.md

### DIFF
--- a/docs/devices/E1525_E1745.md
+++ b/docs/devices/E1525_E1745.md
@@ -32,17 +32,18 @@ The red light on the front side should flash a few times and then turn off. If t
 After a few seconds it turns back on and pulsate. When connected, the light turns off.
 
 ### Binding
-#### Warning! You need to activate the motion sensor and then immediately press bind in the Zigbee2MQTT interface. If the sensor is sleeping the bind will fail. credits: https://github.com/Koenkk/zigbee2mqtt/issues/3831
+#### Warning! You need to activate the motion sensor and then immediately press bind in the Zigbee2MQTT interface. If the sensor is sleeping the bind will fail. credits: [issue #3831](https://github.com/Koenkk/zigbee2mqtt/issues/3831)
 The E1745 can be bound to groups. Although it is not possible to set the groupID at which the E1745 sends messages. But you can watch out in the log files for following debug messages:
-
-### occupancy_timeout option
-Setting occupancy_timeout option to a value of fewer than 90 seconds will clear the occupancy flag, but will leave the sensor unresponsive till 90 seconds elapse. credits: https://github.com/Koenkk/zigbee2mqtt/issues/13259
 
 ```
 debug Received Zigbee message from 'device', type 'commandOnWithTimedOff', cluster 'genOnOff', data '{"ctrlbits":0,"offwaittime":0,"ontime":600}' from endpoint 1 with groupID 123
 ```
 
 Now you can create a group with a groupID of 123 and add your devices that should receive the message.
+
+### occupancy_timeout option
+Setting occupancy_timeout option to a value of fewer than 90 seconds will clear the occupancy flag, but will leave the sensor unresponsive till 90 seconds elapse. credits: [issue #13259](https://github.com/Koenkk/zigbee2mqtt/issues/13259)
+
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
* The occupancy_timeout text was in the middle of the previous section
* Use links that can render on the website