### PR TITLE
Update example configuration location in docker setup docs

### DIFF
--- a/docs/guide/installation/02_docker.md
+++ b/docs/guide/installation/02_docker.md
@@ -18,7 +18,7 @@ Start by figuring out the location of your adapter as explained [here](./01_linu
 Navigate to the directory where you will store the Zigbee2MQTT data and execute the following command:
 
 ```bash
-wget https://raw.githubusercontent.com/Koenkk/zigbee2mqtt/master/data/configuration.yaml -P data
+mkdir data && wget https://raw.githubusercontent.com/Koenkk/zigbee2mqtt/master/data/configuration.example.yaml -O data/configuration.yaml
 ```
 
 Now configure the MQTT server and adapter location as explained [here](./01_linux.md#configuring).


### PR DESCRIPTION
Without it, keys would not be generated and result in an insecure setup.