### PR TITLE
Schneider Electric CCT5010-0001 was also sold under the name 550B1012 in Denmark

### DIFF
--- a/docs/devices/CCT5010-0001.md
+++ b/docs/devices/CCT5010-0001.md
@@ -15,7 +15,7 @@ pageClass: device-page
 
 |     |     |
 |-----|-----|
-| Model | CCT5010-0001  |
+| Model | CCT5010-0001, 550B1012  |
 | Vendor  | [Schneider Electric](/supported-devices/#v=Schneider%20Electric)  |
 | Description | Micro module dimmer |
 | Exposes | ballast_minimum_level, ballast_maximum_level, dimmer_mode, light (state, brightness, level_config), effect, power_on_behavior, linkquality |


### PR DESCRIPTION
Not sure exactly how we usually document multiple model numbers for the same hardware when it's not quite a white label situation. It was sold with both Schneider Electric and "LK" (Lauritz Knudsen) branding on the device (see https://www.lk.dk/produkter/550B1012/wiser-tradlos-lysdaemper-for-indbygning-puck)

They exists as two different products in Schneider Electric's catalog

* https://www.se.com/dk/da/product/CCT5010-0001/connected-dimmer-wiser-micro-module/
* https://www.se.com/dk/da/product/550B1012/wiser-tr%C3%A5dl%C3%B8s-lysd%C3%A6mper-for-indbygning-puck/

\- but their ["dimmer guide"](https://www1.lk.dk/apps/dimmertool/dimmerGuide.ph7) makes it clear that they are in fact the same product with two different SKUs (or CRs whatever that means):
 
![image](https://github.com/user-attachments/assets/7ec2995c-c07c-4cdd-9334-1d73875249d9)
