### PR TITLE
Podman with SELinux needs :z option

### DIFF
--- a/docs/guide/installation/02_docker.md
+++ b/docs/guide/installation/02_docker.md
@@ -109,6 +109,9 @@ $ podman run \
    -e TZ=Europe/Amsterdam \
    koenkk/zigbee2mqtt
 ```
+::: tip
+With SELinux enabled you may need to append a `:z` suffix to the volume mount: `-v $(pwd)/data:/app/data:z`
+:::
 
 ## Updating
 

--- a/docs/guide/installation/02_docker.md
+++ b/docs/guide/installation/02_docker.md
@@ -109,6 +109,7 @@ $ podman run \
    -e TZ=Europe/Amsterdam \
    koenkk/zigbee2mqtt
 ```
+
 ::: tip
 With SELinux enabled you may need to append a `:z` suffix to the volume mount: `-v $(pwd)/data:/app/data:z`
 :::


### PR DESCRIPTION
When running on Fedora, where SELinux is enabled by default, the `:z` flag is needed on the volume mount to prevent permission errors like:
```
cp: can't stat '/app/data/configuration.yaml': Permission denied
```