### PR TITLE
Reflect external_converters directory change

### DIFF
--- a/docs/guide/configuration/more-config-options.md
+++ b/docs/guide/configuration/more-config-options.md
@@ -30,8 +30,7 @@ map_options:
 You can define external converters to e.g. add support for a DiY device. The extension can be a file with `.js`
 extension in the `data/external_converters/` directory or a NPM package. Ensure that default export from your external converter exports an
 array or device object (refer to the definition in the `devices` folder of zigbee-herdsman-converters). Some examples
-can be found [here](https://github.com/Koenkk/zigbee2mqtt.io/tree/master/docs/externalConvertersExample). For this
-example put the files in the `data` folder and add the following to `configuration.yaml`:
+can be found [here](https://github.com/Koenkk/zigbee2mqtt.io/tree/master/docs/externalConvertersExample).
 
 Note that external converters take precedence of standard converters
 

--- a/docs/guide/configuration/more-config-options.md
+++ b/docs/guide/configuration/more-config-options.md
@@ -28,17 +28,11 @@ map_options:
 ## External converters
 
 You can define external converters to e.g. add support for a DiY device. The extension can be a file with `.js`
-extension in the `data` directory or a NPM package. Ensure that default export from your external converter exports an
+extension in the `data/external_converters/` directory or a NPM package. Ensure that default export from your external converter exports an
 array or device object (refer to the definition in the `devices` folder of zigbee-herdsman-converters). Some examples
 can be found [here](https://github.com/Koenkk/zigbee2mqtt.io/tree/master/docs/externalConvertersExample). For this
 example put the files in the `data` folder and add the following to `configuration.yaml`:
 
 Note that external converters take precedence of standard converters
-
-```yaml
-external_converters:
-    - freepad_ext.js
-    - one-more-converter.js
-```
 
 See also [How to support new devices](../../advanced/support-new-devices/01_support_new_devices.md).


### PR DESCRIPTION
Now the external_converters are loaded from a directory inside data folder. Updating this documentation to reflect that.