### PR TITLE
Add note regarding click_mode change for WXKG16LM

### DIFF
--- a/docs/devices/WXKG16LM.md
+++ b/docs/devices/WXKG16LM.md
@@ -60,6 +60,8 @@ To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"click_mode": NEW_VALUE}`.
 The possible values are: `fast`, `multi`.
 
+Note: You may need to press button 5 times in order to change click mode.
+
 ### Action (enum)
 Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.


### PR DESCRIPTION
I'm my case I was unable to change click mode for WXKG16LM switch. Found somewhere that in order to be able to change click mode need to first press button 5 times and it worked. Therefore adding this note so other people are informed as well.