### PR TITLE
Adjust vendor name from TuYa to Tuya

### DIFF
--- a/docs/devices/TS0105.md
+++ b/docs/devices/TS0105.md
@@ -1,6 +1,6 @@
 ---
-title: "TuYa TS0105 control via MQTT"
-description: "Integrate your TuYa TS0105 via Zigbee2MQTT with whatever smart home infrastructure you are using without the vendor's bridge or gateway."
+title: "Tuya TS0105 control via MQTT"
+description: "Integrate your Tuya TS0105 via Zigbee2MQTT with whatever smart home infrastructure you are using without the vendor's bridge or gateway."
 addedAt: 2024-11-30T20:27:20
 pageClass: device-page
 ---
@@ -11,15 +11,15 @@ pageClass: device-page
 <!-- Do not use h1 or h2 heading within "## Notes"-Section. -->
 <!-- !!!! -->
 
-# TuYa TS0105
+# Tuya TS0105
 
 |     |     |
 |-----|-----|
 | Model | TS0105  |
-| Vendor  | [TuYa](/supported-devices/#v=TuYa)  |
+| Vendor  | [Tuya](/supported-devices/#v=Tuya)  |
 | Description | 3 gang switch |
 | Exposes | switch (state), linkquality |
-| Picture | ![TuYa TS0105](https://www.zigbee2mqtt.io/images/devices/TS0105.png) |
+| Picture | ![Tuya TS0105](https://www.zigbee2mqtt.io/images/devices/TS0105.png) |
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->


### PR DESCRIPTION
Adjust vendor name from "TuYa" to "Tuya" to ensure consistent device clustering under the "Tuya" vendor group.