### PR TITLE
Update PTM_215Z.md

### DIFF
--- a/docs/devices/PTM_215Z.md
+++ b/docs/devices/PTM_215Z.md
@@ -20,7 +20,7 @@ pageClass: device-page
 | Description | Pushbutton transmitter module |
 | Exposes | action |
 | Picture | ![EnOcean PTM 215Z](https://www.zigbee2mqtt.io/images/devices/PTM-215Z.png) |
-| White-label | Niko 91004, NodOn CWS-4-1-01_HUE, Vimar 03906, Sunricher SR-ZGP2801K4-FOH-E, LED-Trading 9125, Feller 4120.2.S.FMI.61, Namron 4512727 |
+| White-label | Niko 91004, NodOn CWS-4-1-01_HUE, Vimar 03906, Sunricher SR-ZGP2801K4-FOH-E, LED-Trading 9125, Feller 4120.2.S.FMI.61, Namron 4512727, GIRA + Senic Friends of Hue Smart Switch 100119 |
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->


### PR DESCRIPTION
Add GIra + Senic switch to white-label. It took me a while yesterday to find the correct documentation for my EnOcean Device that is used in the Gira + Senic Switch.