### PR TITLE
Add usability warning to E2013 / IKEA PARASOLL device page

### DIFF
--- a/docs/devices/E2013.md
+++ b/docs/devices/E2013.md
@@ -26,7 +26,7 @@ pageClass: device-page
 
 ::: warning Known Issues with This Device
 
-The IKEA PARASOLL door/window sensor is known to suffer from serious usability issues in some Zigbee networks, resulting in some adapters regularly going unavailable / draining their battery.
+The IKEA PARASOLL door/window sensor is known to suffer from serious usability issues in some Zigbee networks, resulting in some sensors regularly going unavailable / draining their battery.
 
 Whether this issue will affect you appears to depend on the other devices / routers in your Zigbee network, though the exact devices causing this issue have not been confirmed. Further discussion and investigation is available in the GitHub issue: [zigbee2mqtt#22579](https://github.com/Koenkk/zigbee2mqtt/issues/22579)
 

--- a/docs/devices/E2013.md
+++ b/docs/devices/E2013.md
@@ -24,6 +24,17 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+::: warning Known Issues with This Device
+
+The IKEA PARASOLL door/window sensor is known to suffer from serious usability issues in some Zigbee networks, resulting in some adapters regularly going unavailable / draining their battery.
+
+Whether this issue will affect you appears to depend on the other devices / routers in your Zigbee network, though the exact devices causing this issue have not been confirmed. Further discussion and investigation is available in the GitHub issue: [zigbee2mqtt#22579](https://github.com/Koenkk/zigbee2mqtt/issues/22579)
+
+In the meantime, **it is generally not recommended to buy PARASOLL sensors specifically for use with a Zigbee2MQTT network**.
+
+:::
+
+
 ## Pairing
 To pair the device, press the pairing button 4 times in 5 seconds to factory reset, it should now enter pairing mode.
 


### PR DESCRIPTION
This PR adds a warning message to the E2013 device page warning about a known issue when paired with certain routers, as discussed in https://github.com/Koenkk/zigbee2mqtt/issues/22579

As this issue seems to be affecting a large number of users with seemingly no possible fix available or on the horizon, I'm recommending that users be dissuaded from buying these sensors if they're specifically looking to use them with Zigbee2MQTT for the time being. If that's too harsh, I can remove the last sentence.

I'm presuming that `::: warning` can be used on device pages? If not, let me know and I'll refactor.