### PR TITLE
Update 501.40.md

### DIFF
--- a/docs/devices/501.40.md
+++ b/docs/devices/501.40.md
@@ -47,7 +47,7 @@ If the remote has already been paired once, you first need to do a factory reset
 The remote might become unresponsive after ~10 minutes and refuses to send out commands. In this case a full factory reset (see section **Factory Reset** above) and re-pairing (see section **Pairing** above) should fix this issue.
 
 #### Only the first selected group receives commands
-This seems to be a firmware quirk of the Gent 2, when multiple groups are enabled at the bottom (e.g., 1 and 3) only the first active group (in this example 1) will receive commands. There is currently no fix for this issue unless a firmware update by Paulmann is released.
+This seems to be a firmware quirk of the Gent 2, when multiple groups are enabled at the bottom (e.g., 1 and 3) only the first active group (in this example 1) will receive commands. There is currently no fix for this issue unless a firmware update by Paulmann is released. Note: this seems to be fixed at least in devices with firmware 2.7.6_r22 and z2m 2.1 which issues individual actions for each active button.
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
Put clarification on using multiple lights simultaneously (works for all of my 3 remote bought on Amazon.de in Jan/Feb 2025). Unsure if there are other firmware versions?

I see something like:
``` 
MQTT publish: topic 'zigbee2mqtt/LR-RGB-Remote-1', payload '{"action":"on_1","battery":100,"linkquality":172}'
MQTT publish: topic 'zigbee2mqtt/LR-RGB-Remote-1/action', payload 'on_1'
MQTT publish: topic 'zigbee2mqtt/LR-RGB-Remote-1', payload '{"action":"on_2","battery":100,"linkquality":172}'
MQTT publish: topic 'zigbee2mqtt/LR-RGB-Remote-1/action', payload 'on_2'
```