### PR TITLE
Logging documentation: Allow configuring number of folders of old logs to keep

### DIFF
--- a/docs/guide/configuration/logging.md
+++ b/docs/guide/configuration/logging.md
@@ -19,6 +19,8 @@ advanced:
     timestamp_format: 'YYYY-MM-DD HH:mm:ss'
     # Optional: Location of log directory (default: shown below)
     log_directory: data/log/%TIMESTAMP%
+    # Optional: Number of log directories to keep before deleting the oldest one (default: shown below)
+    log_directories_to_keep: 10
     # Optional: Log file name, can also contain timestamp, e.g.: zigbee2mqtt_%TIMESTAMP%.log (default: shown below)
     log_file: log.txt
     # Optional: Rotate log every 10MB around 3 files (default: true)


### PR DESCRIPTION
Documentation part of [this change](https://github.com/Koenkk/zigbee2mqtt/pull/26398).