### PR TITLE
"adapter" to "coordinator"

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ actions:
       type: primary
 features:
     - title: Compatible
-      details: Zigbee2MQTT supports various Zigbee adapters and a big bunch of devices.
+      details: Zigbee2MQTT supports various Zigbee coordinators and a big bunch of devices.
     - title: Integrations
       details: Zigbee2MQTT integrates well with most home automation solutions because it uses MQTT.
     - title: Open Source

--- a/docs/advanced/remote-adapter/connect_to_a_remote_adapter.md
+++ b/docs/advanced/remote-adapter/connect_to_a_remote_adapter.md
@@ -1,11 +1,11 @@
-# Connect to a remote adapter
+# Connect to a remote coordinator
 
-This how-to explains how to run Zigbee2MQTT with an adapter on a remote location.
+This how-to explains how to run Zigbee2MQTT with an coordinator on a remote location.
 We will use ser2net for this which allows to connect to a serial port over TCP.
-In this way you can e.g. setup a Raspberry Pi Zero with the adapter connected while running Zigbee2MQTT on a different system. The instructions below have to be executed on the system where the adapter is connected to.
+In this way you can e.g. setup a Raspberry Pi Zero with the coordinator connected while running Zigbee2MQTT on a different system. The instructions below have to be executed on the system where the coordinator is connected to.
 
 ::: warning
-Be aware that it is not recommended to use a Zigbee Coordinator via a Serial-Proxy-Server (also known as Serial-to-IP bridge or Ser2Net remote adapter) over a WiFi, WAN, or VPN connection.
+Be aware that it is not recommended to use a Zigbee Coordinator via a Serial-Proxy-Server (also known as Serial-to-IP bridge or Ser2Net remote coordinator) over a WiFi, WAN, or VPN connection.
 
 Serial protocols used by Zigbee Coordinator do not have enough robustness, resilience, or fault-tolerance to handle packet loss and latency delays that can occur over unstable connections.
 
@@ -26,7 +26,7 @@ sudo apt-get install ser2net
 sudo nano /etc/ser2net.conf
 ```
 
-Add the following entry, replace `/dev/ttyACM0` with the correct path to your adapter.
+Add the following entry, replace `/dev/ttyACM0` with the correct path to your coordinator.
 
 ```
 20108:raw:0:/dev/ttyACM0:115200 8DATABITS NONE 1STOPBIT
@@ -44,7 +44,7 @@ reboot
 sudo nano /etc/ser2net.yaml
 ```
 
-Add the following entry, replace `/dev/ttyACM0` with the correct path to your adapter.
+Add the following entry, replace `/dev/ttyACM0` with the correct path to your coordinator.
 
 ```
 connection: &con01
@@ -82,7 +82,7 @@ reboot
 
 ## 3. Configure
 
-Now edit the Zigbee2MQTT `configuration.yaml` accordingly, replace `192.168.2.13` with the IP or hostname of your system where the adapter is connected to.
+Now edit the Zigbee2MQTT `configuration.yaml` accordingly, replace `192.168.2.13` with the IP or hostname of your system where the coordinator is connected to.
 
 ```yaml
 serial:

--- a/docs/advanced/remote-adapter/connect_to_a_remote_sonoff_zbbridge.md
+++ b/docs/advanced/remote-adapter/connect_to_a_remote_sonoff_zbbridge.md
@@ -19,7 +19,7 @@ For flashing procedure follow [DigiBlurs guide](https://www.digiblur.com/2020/07
 
 ## 2. Configure
 
-Now edit the Zigbee2MQTT `configuration.yaml` accordingly, replace `192.168.2.13` with the IP or hostname of your system where the adapter is connected to. Also replace `20108` with the port you configured while flashing the Gateway (in step 6 from previous point).
+Now edit the Zigbee2MQTT `configuration.yaml` accordingly, replace `192.168.2.13` with the IP or hostname of your system where the coordinator is connected to. Also replace `20108` with the port you configured while flashing the Gateway (in step 6 from previous point).
 
 Keep in mind that the EZSP support is currently **experimental**.
 

--- a/docs/advanced/zigbee/02_improve_network_range_and_stability.md
+++ b/docs/advanced/zigbee/02_improve_network_range_and_stability.md
@@ -5,30 +5,30 @@
 
 In case you are experiencing an unstable or bad network range you can do the following things to improve your network.
 
-## Adapter
+## Coordinator
 
-Use a [recommended](../../guide/adapters/README.md) adapter, especially the CC2530 and CC2531 are known to perform poorly.
+Use a [recommended](../../guide/adapters/README.md) coordinator, especially the CC2530 and CC2531 are known to perform poorly.
 
 ## Avoid devices from AwoX
 
 It is known that AwoX devices cause network issues. In case you are having issues, remove them from your network.
 It [may help](https://github.com/Koenkk/zigbee2mqtt/discussions/18366) to OTA update your device via the "AwoX HomeControl" app over Bluetooth.
 
-## USB based adapter
+## USB based coordinator
 
-The range of these adapters can greatly be improved when connecting them with an USB extension
-cable instead of directly plugging it into the computer (e.g. Raspberry Pi). When plugged directly into the computer, the antenna suffers from interference of radio signals and electrical components of the computer. Also be sure not to position the adapter too close
+The range of these coordinators can greatly be improved when connecting them with an USB extension
+cable instead of directly plugging it into the computer (e.g. Raspberry Pi). When plugged directly into the computer, the antenna suffers from interference of radio signals and electrical components of the computer. Also be sure not to position the coordinator too close
 to any other radio transmitting devices (e.g. a Wi-Fi router) or an SSD.
 
 A **USB extension cable** of 50 cm is already enough to reduce the interference. Preferably get one with shielding as this may give better results ([source](https://www.reddit.com/r/homeassistant/comments/10ebkis/psareminder_about_zigbee_interference/)).
 
-**Do not underestimate this!** Placing your adapter close to an USB port can kill the radio signal entirely as demonstrated in [this article](https://www.unit3compliance.co.uk/2-4ghz-intra-system-or-self-platform-interference-demonstration/).
+**Do not underestimate this!** Placing your coordinator close to an USB port can kill the radio signal entirely as demonstrated in [this article](https://www.unit3compliance.co.uk/2-4ghz-intra-system-or-self-platform-interference-demonstration/).
 
-Additionally, it may help to plug the adapter to a USB 2 instead of USB 3 port.
+Additionally, it may help to plug the coordinator to a USB 2 instead of USB 3 port.
 
-### Try different orientations of the adapter
+### Try different orientations of the coordinator
 
-RF connection between the adapter and other devices also depends on the way it is oriented in space. You might be having very poor `linkquality` reports and intermittent ping failures but once the adapter is rotated a little it all can change greatly without re-locating the coordinator far away. Try to experiment with positioning and orienting the adapter in space while monitoring the `linkquality` values reported. You might find it useful to buy a small rotating USB connector like this:
+RF connection between the coordinator and other devices also depends on the way it is oriented in space. You might be having very poor `linkquality` reports and intermittent ping failures but once the coordinator is rotated a little it all can change greatly without re-locating the coordinator far away. Try to experiment with positioning and orienting the coordinator in space while monitoring the `linkquality` values reported. You might find it useful to buy a small rotating USB connector like this:
 
 ![rotating USB connector](https://i.imgur.com/AI41Oxz.png)
 

--- a/docs/advanced/zigbee/04_sniff_zigbee_traffic.md
+++ b/docs/advanced/zigbee/04_sniff_zigbee_traffic.md
@@ -25,7 +25,7 @@ Download and install [Npcap](https://nmap.org/npcap/) and make sure you select t
 
 ### Usage
 
-Use Adapter for loopback traffic capture. Then set the Zigbee protocol filter: `udp.port==17754` (default ZEP port) to only see Zigbee traffic.
+Use Coordinator for loopback traffic capture. Then set the Zigbee protocol filter: `udp.port==17754` (default ZEP port) to only see Zigbee traffic.
 
 Wireshark will start and log the Zigbee messages once the sniffer is started. As these messages are encrypted we need to add 2 encryption keys. The first one is the Trust Center link key, which is the same for (almost) every Zigbee network. The second one is the network encryption key (Transport Key).
 
@@ -81,9 +81,9 @@ Now Wireshark is able to decrypt the messages. When e.g. turning on a light you 
 - Computer
     - Ubuntu / Debian machine (tested with Ubuntu 18.04 / 18.10 and Debian 10)
     - Windows machine (tested with Windows 10)
-- CC2531 adapter
+- CC2531 coordinator
 
-### 1. Flashing the CC2531 adapter
+### 1. Flashing the CC2531 coordinator
 
 The CC2531 needs to be flashed with a sniffer firmware. Flash the firmware using the instructions from [Flashing the CC2531](../../guide/adapters/flashing/flashing_the_cc2531.md).
 
@@ -155,17 +155,17 @@ Run the ZBOSS executable in `gui\zboss_sniffer.exe`, enter the path to your Wire
 - If you get `couldn't run /usr/bin/dumpcap in child process: permission denied` when running whsniff, check if /usr/bin/dumpcap is executable for everyone. Or `chmod 755 /usr/bin/dumpcap`.
 - You may need to remove `modemmanager` as this has been known to cause issues. [Howto](../../guide/faq/README.md#modemmanager-is-installed)
 
-## With EmberZNet and HUSBZB-1 adapters
+## With EmberZNet and HUSBZB-1 coordinators
 
-### Prerequisites for USB adapters
+### Prerequisites for USB coordinators
 
 #### Linux
 
-The adapter should work out of the box and require no extra step.
+The coordinator should work out of the box and require no extra step.
 
 #### Windows
 
-Install drivers (whichever works for your adapter):
+Install drivers (whichever works for your coordinator):
 
 - [Silicon Labs CP210x Universal Windows Driver](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers?tab=downloads)
     - Extract drivers to a folder
@@ -181,7 +181,7 @@ Install drivers (whichever works for your adapter):
     - Linux machine (tested with Debian 12 64-bit)
     - Windows machine (tested with Windows 11)
     - MacOS machine
-- EmberZNet or HUSBZB-1 adapter
+- EmberZNet or HUSBZB-1 coordinator
 - Wireshark (optional, can write directly to a [PCAP file](https://github.com/Nerivec/ember-zli/wiki/Sniff#sending-to-pcap-file) instead)
 - NodeJS / npm (if using npm-based installation method)
 
@@ -200,7 +200,7 @@ Install drivers (whichever works for your adapter):
 - Computer
     - Linux machine (tested with Ubuntu 18.10)
     - Windows machine (tested with Windows 10)
-- EmberZNet or HUSBZB-1 adapter
+- EmberZNet or HUSBZB-1 coordinator
 - Wireshark
 - Java
 
@@ -211,24 +211,24 @@ Both Windows and Linux use the same program for sniffing. You can fetch a precom
 You can also find a PDF documentation from ZSmart Systems [here](https://www.opensmarthouse.org/files/download/ZigBeeWiresharkSniffer.pdf).
 
 ::: tip TIP
-Linux: Some EmberZNet adapters use the exact same USB identifiers as a brltty udev-registered device, so if your EmberZNet USB dongle is not recognized, just disable the rule of brltty for idVendor=1a86, idProduct=7523 (same as the CH340 serial converter used in the EmberZNet adapter). Edit /`usr/lib/udev/rules.d/85-brltty.rules` and comment `# ENV{PRODUCT}=="1a86/7523/*", ENV{BRLTTY_BRAILLE_DRIVER}="bm", GOTO="brltty_usb_run"`. Unplug and replug the EmberZNet adapter.
+Linux: Some EmberZNet coordinators use the exact same USB identifiers as a brltty udev-registered device, so if your EmberZNet USB dongle is not recognized, just disable the rule of brltty for idVendor=1a86, idProduct=7523 (same as the CH340 serial converter used in the EmberZNet coordinator). Edit /`usr/lib/udev/rules.d/85-brltty.rules` and comment `# ENV{PRODUCT}=="1a86/7523/*", ENV{BRLTTY_BRAILLE_DRIVER}="bm", GOTO="brltty_usb_run"`. Unplug and replug the EmberZNet coordinator.
 :::
 
 #### 2. Sniffing traffic
 
 In a terminal or command line, run `java -jar ZigbeeSniffer.jar -baud 115200 -flow {OPTION} -port {PORT} -c {CHANNEL}`.
 
-Depending on your adapter, `OPTION` should be replaced by `none` (Sonoff Dongle-E, SLZB-06m...) or `hardware` (HUSBZB-1, SkyConnect...).
+Depending on your coordinator, `OPTION` should be replaced by `none` (Sonoff Dongle-E, SLZB-06m...) or `hardware` (HUSBZB-1, SkyConnect...).
 
 ##### Windows
 
-Open the Device Manager (Win+X, M) and find which COM port your adapter is using in `Ports (COM & LPT)`. It should be something like COM3, COM6. `PORT` should be replaced by that value.
+Open the Device Manager (Win+X, M) and find which COM port your coordinator is using in `Ports (COM & LPT)`. It should be something like COM3, COM6. `PORT` should be replaced by that value.
 
 ##### Linux
 
 `PORT` will be something like `/dev/ttyUSB0` or wherever you plugged in your HUSBZB-1 device.
 
-## With nRF52 adapter
+## With nRF52 coordinator
 
 ### Prerequisites
 

--- a/docs/guide/adapters/README.md
+++ b/docs/guide/adapters/README.md
@@ -3,9 +3,9 @@ sidebarDepth: 1
 next: ../installation/
 ---
 
-# Supported Adapters
+# Supported Coordinators
 
-All officially supported adapters are listed on this page. Note that before an adapter can be used with Zigbee2MQTT it has to be flashed with a coordinator firmware (some adapters come preflashed).
+All officially supported coordinators are listed on this page. Note that before an coordinator can be used with Zigbee2MQTT it has to be flashed with a coordinator firmware (some coordinators come preflashed).
 
 - [zStack based (Texas Instruments)](./zstack.md)
 - [EmberZNet based (Silicon Labs)](./emberznet.md)
@@ -14,31 +14,31 @@ All officially supported adapters are listed on this page. Note that before an a
 - [ZBOSS based (Nordic Semiconductor)](./zboss.md)
 
 ::: tip TIP
-Want to migrate to a different adapter? Read [this](../faq/README.md#how-do-i-migrate-from-one-adapter-to-another)
+Want to migrate to a different coordinator? Read [this](../faq/README.md#how-do-i-migrate-from-one-adapter-to-another)
 :::
 
 ## Notes
 
-Before buying an adapter, please read the notes below!
+Before buying an coordinator, please read the notes below!
 
-- Want to migrate to a different adapter? This may require repairing all your devices in some cases, see [FAQ](../faq/README.md#what-does-and-does-not-require-repairing-of-all-devices)
-- Network adapters connected via WiFi might have reduced stability as the serial protocol does not have enough fault-tolerance to handle packet loss or latency delays that can normally occur over WiFi connections. If cannot use a locally connected USB or UART/GPIO adapter then the recommendation is to use remote adapter that connected via Ethernet (wired) to avoid issues.
+- Want to migrate to a different coordinator? This may require repairing all your devices in some cases, see [FAQ](../faq/README.md#what-does-and-does-not-require-repairing-of-all-devices)
+- Network coordinators connected via WiFi might have reduced stability as the serial protocol does not have enough fault-tolerance to handle packet loss or latency delays that can normally occur over WiFi connections. If cannot use a locally connected USB or UART/GPIO coordinator then the recommendation is to use remote coordinator that connected via Ethernet (wired) to avoid issues.
 - What are the differences between the various CC2652/CC1352 chips?
-    - Chips ending with `P` have a power amplifier which support up-to 20dBm vs 5dBm on adapters ending with `R`/`RB`.
+    - Chips ending with `P` have a power amplifier which support up-to 20dBm vs 5dBm on coordinators ending with `R`/`RB`.
     - Chips starting with `CC1352` support the sub-1 GHz frequency (which is not relevant for Zigbee since it uses 2.4 GHz), `CC2652` only supports 2.4 GHz. So for Zigbee2MQTT purposes there is no difference between `CC1352` and `CC2652`.
     - Chips ending with `RB` don't require a crystal on the PCB, this only makes a difference for the manufacturing process.
 
 ### Coordinator backups
 
-Note that only adapters based on zStack or EmberZNet currently support backing up the coordinator (`coordinator_backup.json`).
+Note that only coordinators based on zStack or EmberZNet currently support backing up the coordinator (`coordinator_backup.json`).
 
-#### Flashing an existing adapter
+#### Flashing an existing coordinator
 
-Flashing tools can be used to upgrade the firmware on an existing adapter without needing to repair devices. See the [FAQ](https://www.zigbee2mqtt.io/guide/faq/#what-does-and-does-not-require-repairing-of-all-devices) for information on what does and does not require repairing of devices.
+Flashing tools can be used to upgrade the firmware on an existing coordinator without needing to repair devices. See the [FAQ](https://www.zigbee2mqtt.io/guide/faq/#what-does-and-does-not-require-repairing-of-all-devices) for information on what does and does not require repairing of devices.
 
 #### Is your OS unable to find your device?
 
-If you're asking yourself "Why won't my dongle or adapter show up?" when you are using (for example) Flash Programmer 2, chances are that your OS can't communicate with your device over VCP (Virtual COM Port) serial port, causing your dongle not showing up as a flashable device. To fix this problem, be sure to install a USB-to-UART bridge/converter VCP driver for your operating system like the one at [Silicon Labs](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers), [FTDI Chip](https://ftdichip.com/drivers/vcp-drivers/), or [WCH (CH34x/CH91xx)](http://www.wch-ic.com/downloads/category/30.html).
+If you're asking yourself "Why won't my dongle or coordinator show up?" when you are using (for example) Flash Programmer 2, chances are that your OS can't communicate with your device over VCP (Virtual COM Port) serial port, causing your dongle not showing up as a flashable device. To fix this problem, be sure to install a USB-to-UART bridge/converter VCP driver for your operating system like the one at [Silicon Labs](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers), [FTDI Chip](https://ftdichip.com/drivers/vcp-drivers/), or [WCH (CH34x/CH91xx)](http://www.wch-ic.com/downloads/category/30.html).
 
 ### Router
 

--- a/docs/guide/adapters/deconz.md
+++ b/docs/guide/adapters/deconz.md
@@ -1,7 +1,7 @@
 # deCONZ (Dresden Elektronik)
 
 ::: warning ATTENTION
-Various features are not supported by this adapter, in case you depend on these features, consider a different adapter.
+Various features are not supported by this coordinator, in case you depend on these features, consider a different coordinator.
 
 - [Changing the channel](../configuration/zigbee-network.md#changing-the-zigbee-channel), changing requires re-pairing all devices.
 - Adding [install codes](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestinstall_codeadd), which is required to pair some devices.
@@ -24,7 +24,7 @@ Other supported settings are: `adapter_concurrent` and `adapter_delay` ([docs](.
 
 ConBee / ConBee II / ConBee III / RaspBee / RaspBee II
 
-USB connected adapters (ConBee / ConBee II / ConBee III) and Raspberry Pi GPIO modules (RaspBee and RaspBee II).
+USB connected coordinators (ConBee / ConBee II / ConBee III) and Raspberry Pi GPIO modules (RaspBee and RaspBee II).
 
 Add the correct baudrate to the `configuration.yaml` into the serial section.
 

--- a/docs/guide/adapters/emberznet.md
+++ b/docs/guide/adapters/emberznet.md
@@ -1,4 +1,4 @@
-# EmberZNet adapters (Silicon Labs)
+# EmberZNet coordinators (Silicon Labs)
 
 Currently supported firmware version: 7.4.x, 8.0.x
 
@@ -8,7 +8,7 @@ Use of 8.0.0 and 8.0.1 is not recommended due to firmware issues that have been 
 
 Firmware release notes: [https://www.silabs.com/developers/zigbee-emberznet?tab=documentation](https://www.silabs.com/developers/zigbee-emberznet?tab=documentation)
 
-_Multiprotocol firmware is not supported. The recommended alternative to establish multiple networks is to use one adapter per protocol._
+_Multiprotocol firmware is not supported. The recommended alternative to establish multiple networks is to use one coordinator per protocol._
 
 ### Configuration
 
@@ -20,7 +20,7 @@ serial:
 Other supported settings are: `adapter_concurrent` and `transmit_power` ([docs](../configuration/adapter-settings.md)).
 
 ::: tip TIP
-If you are experiencing issues with your adapter and it has hardware flow control support (check list below), try to flash a [firmware with hardware flow control disabled](https://github.com/darkxst/silabs-firmware-builder/tree/ember-nohw/firmware_builds/) and use the following setting instead:
+If you are experiencing issues with your coordinator and it has hardware flow control support (check list below), try to flash a [firmware with hardware flow control disabled](https://github.com/darkxst/silabs-firmware-builder/tree/ember-nohw/firmware_builds/) and use the following setting instead:
 
 ```yaml
 serial:
@@ -50,7 +50,7 @@ The use of `adapter: ezsp` is now deprecated. See [https://github.com/Koenkk/zig
     - Multi-devices by [@Nerivec](https://github.com/Nerivec/) using NodeJS: [Ember ZLI](https://github.com/Nerivec/ember-zli)
 - Other:
     - Standalone J-Link Flash Tool (also included in [Simplicity Studio](https://www.silabs.com/developers/simplicity-studio)): [Simplicity Commander](https://www.silabs.com/developers/simplicity-studio/simplicity-commander)
-- Some Ethernet adapters support flashing Zigbee firmware over their own web-interface. In this case you do not need any external software and hardware. Just go to the webinterface and press "Update Zigbee firmware". Please refer to the manual of your particular Zigbee adapter for this functionality.
+- Some Ethernet coordinators support flashing Zigbee firmware over their own web-interface. In this case you do not need any external software and hardware. Just go to the webinterface and press "Update Zigbee firmware". Please refer to the manual of your particular Zigbee coordinator for this functionality.
 
 ## Recommended
 
@@ -288,7 +288,7 @@ _NOT READY - Signaling NCP_: `ember` driver is temporarily overloaded. The coord
 
 ### `error` level
 
-_NCP EZSP protocol version of XX does not match Host version 13_: `ember` currently requires a firmware with EZSP v13 (EmberZNet firmware 7.4.x). You will need to upgrade your adapter's firmware. [Check the first two posts here](https://github.com/Koenkk/zigbee2mqtt/discussions/21462).
+_NCP EZSP protocol version of XX does not match Host version 13_: `ember` currently requires a firmware with EZSP v13 (EmberZNet firmware 7.4.x). You will need to upgrade your coordinator's firmware. [Check the first two posts here](https://github.com/Koenkk/zigbee2mqtt/discussions/21462).
 
 _[BACKUP] Current backup file is from an unsupported EZSP version_: `ember` currently only supports EZSP v12 and above backups (can be identified by opening the `coordinator_backup.json` file). The file has been renamed automatically. A new one will be created by `ember` upon successful start.
 
@@ -304,13 +304,13 @@ NCP Fatal Error. The coordinator failed (the reason should be given in the messa
 
 [https://github.com/Nerivec/ember-zli/](https://github.com/Nerivec/ember-zli/)
 
-NodeJS command line tool that allows firmware flashing, interacting with the adapter's stack, sniffing, etc. using [zigbee-herdsman](https://github.com/Koenkk/zigbee-herdsman/). Check out the [Wiki](https://github.com/Nerivec/ember-zli/wiki) for more details.
+NodeJS command line tool that allows firmware flashing, interacting with the coordinator's stack, sniffing, etc. using [zigbee-herdsman](https://github.com/Koenkk/zigbee-herdsman/). Check out the [Wiki](https://github.com/Nerivec/ember-zli/wiki) for more details.
 
 ### Bellows CLI
 
 [https://github.com/zigpy/bellows](https://github.com/zigpy/bellows)
 
-Python command line tool that allows interacting with the adapter's stack.
+Python command line tool that allows interacting with the coordinator's stack.
 
 ### Zigbee2MQTT Ember Helper
 
@@ -321,7 +321,7 @@ Analyze log files in your browser and get an automated review of your network.
 ## [EXPERT] Customizing stack configuration
 
 ::: warning ATTENTION
-This feature modifies the behavior of your adapter, and the network. Using improper values for your network can completely break it. Only modify any of these values if you are absolutely sure your network will benefit from it. Most networks will be just fine with the defaults.
+This feature modifies the behavior of your coordinator, and the network. Using improper values for your network can completely break it. Only modify any of these values if you are absolutely sure your network will benefit from it. Most networks will be just fine with the defaults.
 :::
 
 ::: warning ATTENTION
@@ -371,4 +371,4 @@ The driver further restricts values to the below:
     - "SIGNAL_AND_RSSI": RSSI and signal identifier-based CCA. CCA reports a busy medium only on detecting any energy above -75 (default) of a signal compliant with this standard with the same modulation and spreading characteristics of the PHY that is currently in use.
     - "ALWAYS_TRANSMIT": ALOHA. Always transmit CCA=1. CCA always reports an idle medium.
 
-**Note that some values are not only restricted by these ranges, but also by the memory available in your adapter. If any value (or combination) is too great for your adapter to handle, it will default to the firmware value(s) instead.**
+**Note that some values are not only restricted by these ranges, but also by the memory available in your coordinator. If any value (or combination) is too great for your coordinator to handle, it will default to the firmware value(s) instead.**

--- a/docs/guide/adapters/flashing/copy_ieeaddr.md
+++ b/docs/guide/adapters/flashing/copy_ieeaddr.md
@@ -1,7 +1,7 @@
 ---
 ---
 
-# Copying the ieee address of an adapter
+# Copying the ieee address of an coordinator
 
 When migrating from one stick to another it is important that the new stick uses the same ieee address as the old stick. Some devices lookup the coordinator by its ieee address, this fails when the ieee address of the coordinator changes. There are various tools which can do this.
 
@@ -21,8 +21,8 @@ Note that the _primary_ ieee address will remain the same and these instructions
 Supports: CC2652, CC1352, CC2538
 
 1. [Download](https://github.com/xyzroe/ZigStarGW-MT/releases) and run the tool
-1. Plug in your adapter and put it in BSL mode, consult your adapters manual on how to put it in BSL mode
-1. Click refresh icon and select your adapter
+1. Plug in your coordinator and put it in BSL mode, consult your coordinators manual on how to put it in BSL mode
+1. Click refresh icon and select your coordinator
 1. Fill in the old coordinators ieee address under "IEEE" (first `0x` can be skipped)
 1. Check "Write IEEE" and click "Write IEEE"
 1. Reflash the firmware on your stick (this is important, otherwise the coordinator will not use the new ieee address)
@@ -32,19 +32,19 @@ Supports: CC2652, CC1352, CC2538
 Supports: CC2652, CC1352, CC2538
 
 1. [Download](https://github.com/JelmerT/cc2538-bsl) the tool
-1. Plug in your adapter and put it in BSL mode, consult your adapters manual on how to put it in BSL mode (if necessary, some adapters have an autobootloader, e.g. [this one](https://slae.sh/projects/cc2652/#flash-it))
+1. Plug in your coordinator and put it in BSL mode, consult your coordinators manual on how to put it in BSL mode (if necessary, some coordinators have an autobootloader, e.g. [this one](https://slae.sh/projects/cc2652/#flash-it))
 1. Run `./cc2538-bsl.py -evw --ieee-address 00:12:4b:aa:bb:cc:dd:ee -p /dev/tty.usbserial-10 ./fw.hex`, replace:
     - `00:12:4b:aa:bb:cc:dd:ee` with your coordinator ieee address (first `0x` can be skipped)
-    - `/dev/tty.usbserial-10` with the path to your adapter (for Sonoff Zigbee USB Dongle Plus `--bootloader-sonoff-usb` is needed as well)
-    - `./fw.hex` with the path to your adapters firmware.
+    - `/dev/tty.usbserial-10` with the path to your coordinator (for Sonoff Zigbee USB Dongle Plus `--bootloader-sonoff-usb` is needed as well)
+    - `./fw.hex` with the path to your coordinators firmware.
 
 ## FLASH-PROGRAMMER-2
 
 Supports: CC2652, CC1352, CC2538
 
 1. [Download](https://www.ti.com/tool/FLASH-PROGRAMMER) the tool
-1. Plug in your adapter and put it in BSL mode, consult your adapters manual on how to put it in BSL mode
-1. Select your adapter, go to "MAC address"
+1. Plug in your coordinator and put it in BSL mode, consult your coordinators manual on how to put it in BSL mode
+1. Select your coordinator, go to "MAC address"
 1. Fill the old coordinator ieee address into "Secondary Address" -> "IEEE 802.15.4 MAC address" (first `0x` can be skipped)
 1. Press "Write"
 1. Reflash the firmware on your stick - in the right corner under Secondary MAC check "Retain secondary IEEE" (this is important, otherwise the coordinator will not use the new ieee address)

--- a/docs/guide/adapters/flashing/flashing_via_cc2538-bsl.md
+++ b/docs/guide/adapters/flashing/flashing_via_cc2538-bsl.md
@@ -50,7 +50,7 @@ The sonoff feature is in the master since 20.01.2022.
 
 ### Download the Firmware
 
-Download the firmware for your adapter from the [Supported adapter page](../README.md) and unzip it in the `c2538-bsl` directory. So everything needed is in one folder.
+Download the firmware for your coordinator from the [Supported coordinator page](../README.md) and unzip it in the `c2538-bsl` directory. So everything needed is in one folder.
 
 4. In this case we will flash `CC1352P2_CC2652P_launchpad_coordinator_***.zip`.
 

--- a/docs/guide/adapters/zboss.md
+++ b/docs/guide/adapters/zboss.md
@@ -1,21 +1,21 @@
-# ZBOSS adapters
+# ZBOSS coordinators
 
 ::: warning ATTENTION
 
-Support for this adapter is **experimental**, not recommended yet for production setups
+Support for this coordinator is **experimental**, not recommended yet for production setups
 
 :::
 
-The adapter for the ZBOSS protocol is based on the example of ZBOSS NCP Host [Zigbee NCP (Network Co-Processor)](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/zigbee/ncp/README.html) for Nordic Semiconductor chips, such as nRF5340, nRF52840, nRF52833, nRF21540.
+The coordinator for the ZBOSS protocol is based on the example of ZBOSS NCP Host [Zigbee NCP (Network Co-Processor)](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/zigbee/ncp/README.html) for Nordic Semiconductor chips, such as nRF5340, nRF52840, nRF52833, nRF21540.
 
 Also, thanks to the special firmware https://github.com/andryblack/esp-coordinator, ZBOSS protocol can be used to interact with the Espressif ESP32-C6/H2 chips.
 
 The interaction between the chip and the host occurs according to [ZBOSS NCP Serial Protocol](https://cloud.dsr-corporation.com/index.php/s/BAn4LtRWbJjFiAm).
 
-The adapter code is based on the [zigpy-zboss library](https://github.com/kardia-as/zigpy-zboss).
+The coordinator code is based on the [zigpy-zboss library](https://github.com/kardia-as/zigpy-zboss).
 
 ::: warning ATTENTION
-Currently, this adapter does not support various functions, so if you depend on these functions, consider using a different adapter.
+Currently, this coordinator does not support various functions, so if you depend on these functions, consider using a different coordinator.
 
 - [Changing the channel](../configuration/zigbee-network.md#changing-the-zigbee-channel), changing requires re-pairing all devices.
 - Adding [install codes](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestinstall_codeadd), which is required to pair some devices.

--- a/docs/guide/adapters/zigate.md
+++ b/docs/guide/adapters/zigate.md
@@ -1,15 +1,15 @@
-# ZiGate adapters
+# ZiGate coordinators
 
 ::: warning ATTENTION
 
-Support for this adapter is **experimental**, not recommended yet for production setups
+Support for this coordinator is **experimental**, not recommended yet for production setups
 
 :::
 
-Initial development started on experimental (alpha stage) support for various ZigGate adapters. This includes all ZiGate compatible hardware adapters which are currently based on NXP Zigbee MCU chips like JN5168 and JN5169 with ZigGate 3.1d firmware or later.
+Initial development started on experimental (alpha stage) support for various ZigGate coordinators. This includes all ZiGate compatible hardware coordinators which are currently based on NXP Zigbee MCU chips like JN5168 and JN5169 with ZigGate 3.1d firmware or later.
 
 ::: warning ATTENTION
-Various features are not supported by this adapter, in case you depend on these features, consider a different adapter.
+Various features are not supported by this coordinator, in case you depend on these features, consider a different coordinator.
 
 - [Changing the channel](../configuration/zigbee-network.md#changing-the-zigbee-channel), changing requires re-pairing all devices.
 - Adding [install codes](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestinstall_codeadd), which is required to pair some devices.
@@ -19,7 +19,7 @@ Various features are not supported by this adapter, in case you depend on these 
 :::
 
 ::: warning ATTENTION
-zigbee-herdsman is looking for maintainers for the ZiGate adapter. See [https://github.com/Koenkk/zigbee-herdsman/issues/1037](https://github.com/Koenkk/zigbee-herdsman/issues/1037)
+zigbee-herdsman is looking for maintainers for the ZiGate coordinator. See [https://github.com/Koenkk/zigbee-herdsman/issues/1037](https://github.com/Koenkk/zigbee-herdsman/issues/1037)
 :::
 
 ### Configuration

--- a/docs/guide/adapters/zstack.md
+++ b/docs/guide/adapters/zstack.md
@@ -1,4 +1,4 @@
-# zStack adapters (Texas Instruments)
+# zStack coordinators (Texas Instruments)
 
 ### Configuration
 
@@ -11,13 +11,13 @@ Other supported settings are: `disable_led`, `adapter_concurrent` and `transmit_
 
 ### Firmware flashing (CC2652/CC1352)
 
-Adapters based on CC1352 or CC2652 chips can be flashed by putting them in the BSL (bootloader) mode.
-See the "Vendor flashing instructions" of your adapter below on how to do this.
-Once you've successfully put your adapter into BSL mode, use any of the tools below to flash it.
+Coordinators based on CC1352 or CC2652 chips can be flashed by putting them in the BSL (bootloader) mode.
+See the "Vendor flashing instructions" of your coordinator below on how to do this.
+Once you've successfully put your coordinator into BSL mode, use any of the tools below to flash it.
 
 - UI tools
     - [SMLIGHT firmware updater](https://smlight.tech/flasher/#other_cc) (**recommended**)
-        - Allows for flashing your adapter from the browser, eliminating the need for any software installation.
+        - Allows for flashing your coordinator from the browser, eliminating the need for any software installation.
     - Texas Instruments [FLASH PROGRAMMER 2](https://www.ti.com/tool/FLASH-PROGRAMMER) (Windows only) (can't find your device? read below!)
     - [ZigStar GW Multi tool](https://github.com/xyzroe/ZigStarGW-MT) (multi platform GUI tool)
 - CLI tools (multi platform Python based command line tools)
@@ -28,7 +28,7 @@ Once you've successfully put your adapter into BSL mode, use any of the tools be
     - [TubesZB TI CC2652 FW Flasher](https://github.com/tube0013/tubeszb_addons)
     - [ZigStar TI CC2652 FW Flasher](https://github.com/mercenaruss/zigstar_addons) (fork of TubesZB with added features)
 
-- Some Ethernet adapters support flashing Zigbee firmware over their own web-interface. In this case you do not need any external software and hardware. Just go to the webinterface and press "Update Zigbee firmware". Please refer to the manual of your particular Zigbee adapter for this functionality. For example the universal [XZG Firmware](https://github.com/xyzroe/XZG) that fits any CC1352/CC2652 based gateway ([video](https://github.com/Koenkk/zigbee2mqtt.io/assets/6440415/c2ca1d4c-166a-4bd9-b642-86595da1dcdb))
+- Some Ethernet coordinators support flashing Zigbee firmware over their own web-interface. In this case you do not need any external software and hardware. Just go to the webinterface and press "Update Zigbee firmware". Please refer to the manual of your particular Zigbee coordinator for this functionality. For example the universal [XZG Firmware](https://github.com/xyzroe/XZG) that fits any CC1352/CC2652 based gateway ([video](https://github.com/Koenkk/zigbee2mqtt.io/assets/6440415/c2ca1d4c-166a-4bd9-b642-86595da1dcdb))
 
 <img src="../../images/flashing/web-interface-ota-flashing.jpg" title="SLZB-06 WEB OTA Zigbee Flashing" height=300 />
 
@@ -38,7 +38,7 @@ Once you've successfully put your adapter into BSL mode, use any of the tools be
 
 ::: details Electrolama zig-a-zig-ah! (zzh!)
 
-USB connected adapter with external antenna based on CC2652R chip
+USB connected coordinator with external antenna based on CC2652R chip
 
 - [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/releases/download/Z-Stack_3.x.0_coordinator_20240710/CC2652R_coordinator_20240710.zip)
 - [Router firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/Z-Stack_3.x.0_router_20221102/router/Z-Stack_3.x.0/bin/CC2652R_router_20221102.zip)
@@ -50,7 +50,7 @@ USB connected adapter with external antenna based on CC2652R chip
 
 ::: details Slaesh's CC2652RB stick
 
-USB connected adapter with external antenna based on CC2652RB chip
+USB connected coordinator with external antenna based on CC2652RB chip
 
 - [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/releases/download/Z-Stack_3.x.0_coordinator_20240710/CC2652RB_coordinator_20240710.zip)
 - [Router firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/Z-Stack_3.x.0_router_20221102/router/Z-Stack_3.x.0/bin/CC2652RB_router_20221102.zip)
@@ -62,7 +62,7 @@ USB connected adapter with external antenna based on CC2652RB chip
 
 ::: details Tube's CC2652P2 USB Coordinator
 
-Open source hardware CC2652P based USB connected adapter with external antenna and USB extension cable
+Open source hardware CC2652P based USB connected coordinator with external antenna and USB extension cable
 
 - [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/releases/download/Z-Stack_3.x.0_coordinator_20240710/CC1352P2_CC2652P_launchpad_coordinator_20240710.zip)
 - [Router firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/Z-Stack_3.x.0_router_20221102/router/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_launchpad_router_20221102.zip)
@@ -101,7 +101,7 @@ Powerful Open source dongle with external antenna based on CC2652P
 
 ::: details CircuitSetup's CC2652P2 USB Coordinator
 
-CC2652P based USB connected adapter pre-programmed with Z-Stack
+CC2652P based USB connected coordinator pre-programmed with Z-Stack
 
 - [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/releases/download/Z-Stack_3.x.0_coordinator_20240710/CC1352P2_CC2652P_launchpad_coordinator_20240710.zip)
 - [Router firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/Z-Stack_3.x.0_router_20221102/router/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_launchpad_router_20221102.zip)
@@ -111,7 +111,7 @@ CC2652P based USB connected adapter pre-programmed with Z-Stack
 <img src="../../images/circset_cc2652.jpg" width="200" />
 :::
 
-::: details SMLIGHT CC2652P Zigbee USB Adapter SLZB-02
+::: details SMLIGHT CC2652P Zigbee USB Coordinator SLZB-02
 
 CC2652P factory-made Zigbee USB coordinator with external 6dB antenna and worldwide delivery
 
@@ -126,7 +126,7 @@ CC2652P factory-made Zigbee USB coordinator with external 6dB antenna and worldw
 
 ::: details SONOFF Zigbee 3.0 USB Dongle Plus ZBDongle-P
 
-CC2652P based USB connected adapter pre-programmed and with enclosure.
+CC2652P based USB connected coordinator pre-programmed and with enclosure.
 
 Note before buying that ITead slightly confusingly now sells both the Dongle Plus "ZBDongle-P" (based on CC2652P), and the Dongle Plus V2 "ZBDongle-E" (based on EFR32MG21).
 
@@ -142,7 +142,7 @@ Note before buying that ITead slightly confusingly now sells both the Dongle Plu
 
 ::: details Vision CC2652 dongle
 
-Adapter or small development board based on CC2652R (VS201) or CC2652P (VS202)  
+Coordinator or small development board based on CC2652R (VS201) or CC2652P (VS202)  
 Coordinator firmware: [VS201](https://github.com/Koenkk/Z-Stack-firmware/releases/download/Z-Stack_3.x.0_coordinator_20240710/CC2652R_coordinator_20240710.zip) [VS202](https://github.com/Koenkk/Z-Stack-firmware/releases/download/Z-Stack_3.x.0_coordinator_20240710/CC1352P2_CC2652P_launchpad_coordinator_20240710.zip)  
 Router firmware: [VS201](https://github.com/Koenkk/Z-Stack-firmware/raw/Z-Stack_3.x.0_router_20221102/router/Z-Stack_3.x.0/bin/CC2652R_router_20221102.zip) [VS202](https://github.com/Koenkk/Z-Stack-firmware/raw/Z-Stack_3.x.0_router_20221102/router/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_launchpad_router_20221102.zip)
 
@@ -164,9 +164,9 @@ Powerful CC2652P1 factory-made Zigbee USB dongle with external antenna.
 <img src="../../images/jetstick_z2.png" width="200" />
 :::
 
-::: details SMLIGHT SLZB-07p7 Zigbee USB CC2652P7 adapter
+::: details SMLIGHT SLZB-07p7 Zigbee USB CC2652P7 coordinator
 
-Powerful, tiny modern design, developed for Zigbee2MQTT, pre-flashed and ready to use Zigbee adapter. Autodiscovery in Home Assistant. AutoBSL (remote update) enabled.  
+Powerful, tiny modern design, developed for Zigbee2MQTT, pre-flashed and ready to use Zigbee coordinator. Autodiscovery in Home Assistant. AutoBSL (remote update) enabled.  
 Rich packing that includes:
 | Package includes | SLZB-07p7 adapter | +3dB antenna 360° | QR-manual |
 |:-|:-:|:-:|:-:|
@@ -226,9 +226,9 @@ An open source Zstack3 gateway powered by ESP8266 and CC2652P modules. One costs
 <img src="../../images/CC2652P-Z2M.jpg" width="200" />
 :::
 
-::: details SMLIGHT Zigbee LAN Adapter CC2652P Model SLZB-05
+::: details SMLIGHT Zigbee LAN Coordinator CC2652P Model SLZB-05
 
-Pre-flashed ready-to-use Zigbee LAN CC2652P Adapter, factory made, metal case, 6dB antenna, worldwide delivery, Zigbee firmware can be manually updated via USB in 5 easy steps, customer/tech support, fast order processing.
+Pre-flashed ready-to-use Zigbee LAN CC2652P Coordinator, factory made, metal case, 6dB antenna, worldwide delivery, Zigbee firmware can be manually updated via USB in 5 easy steps, customer/tech support, fast order processing.
 
 - [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/releases/download/Z-Stack_3.x.0_coordinator_20240710/CC1352P2_CC2652P_other_coordinator_20240710.zip)
 - [Router firmware](https://github.com/Koenkk/Z-Stack-firmware/raw/Z-Stack_3.x.0_router_20221102/router/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_other_router_20221102.zip)
@@ -242,7 +242,7 @@ Pre-flashed ready-to-use Zigbee LAN CC2652P Adapter, factory made, metal case, 6
 
 ::: details Gio-dot Z-Bee Duo with CC2652P
 
-4 in 1 zigbee adapter: USB Stick, WiFi, LAN, PI Zero Hat, with external antenna and 3D printed case.
+4 in 1 zigbee coordinator: USB Stick, WiFi, LAN, PI Zero Hat, with external antenna and 3D printed case.
 
 - [Description](https://gio-dot.github.io/Z-Bee-Duo/)
 - [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/releases/download/Z-Stack_3.x.0_coordinator_20240710/CC1352P2_CC2652P_other_coordinator_20240710.zip)
@@ -279,11 +279,11 @@ Open source PoE af Coordinator with external antenna on CC2652P
 <img src="../../images/ZigStar-PoE.png" width="200" />
 :::
 
-::: details SMLIGHT SLZB-06 Zigbee+Matter/Thread+Bluetooth Ethernet USB POE WiFi LAN adapter
+::: details SMLIGHT SLZB-06 Zigbee+Matter/Thread+Bluetooth Ethernet USB POE WiFi LAN coordinator
 
-Powerful, tiny modern design, developed for Zigbee2MQTT, PoE supported, pre-flashed and ready to use Zigbee adapter.  
+Powerful, tiny modern design, developed for Zigbee2MQTT, PoE supported, pre-flashed and ready to use Zigbee coordinator.  
 It supports **Zigbee 3.0**, experimental **Matter-over-Thread** and **Bluetooth**. Connections: Ethernet (+PoE), LAN, USB, and WiFi. Rich packing that includes:
-| Package includes | SLZB-06 adapter | +5dB antenna 360° | Adhesive tape | Screws | Screwdriver | MicroUSB-Type-C | Screw-fix helper |
+| Package includes | SLZB-06 coordinator | +5dB antenna 360° | Adhesive tape | Screws | Screwdriver | MicroUSB-Type-C | Screw-fix helper |
 |:-|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 |Quantity: |1 pcs|1 pcs|2 pcs|2 pcs|1 pcs|1 pcs|1 pcs|  
 |Image| <img src="https://smlight.tech/external-content/images/zigbee2mqtt-io/slzb-06-adapter.jpg" width="200" /> | <img src="https://smlight.tech/external-content/images/zigbee2mqtt-io/slzb-06-antenna.jpg" width="200" /> | <img src="https://smlight.tech/external-content/images/zigbee2mqtt-io/slzb-06-adhesive.jpg" width="200" /> | <img src="https://smlight.tech/external-content/images/zigbee2mqtt-io/slzb-06-screws.jpg" width="200" /> | <img src="https://smlight.tech/external-content/images/zigbee2mqtt-io/slzb-06-screwdriver.jpg" width="200" /> | <img src="https://smlight.tech/external-content/images/zigbee2mqtt-io/slzb-06-microusb.jpg" width="200" /> | <img src="https://smlight.tech/external-content/images/zigbee2mqtt-io/slzb-06-qr.jpg" width="200" /> |
@@ -324,11 +324,11 @@ Open source PoE af Coordinator with external antenna on CC2652P
 
 :::
 
-::: details SMLIGHT SLZB-06p7 Zigbee Ethernet USB POE WiFi LAN adapter
+::: details SMLIGHT SLZB-06p7 Zigbee Ethernet USB POE WiFi LAN coordinator
 
-Powerful, tiny modern design, developed for Zigbee2MQTT, PoE supported, pre-flashed and ready to use Zigbee adapter.  
+Powerful, tiny modern design, developed for Zigbee2MQTT, PoE supported, pre-flashed and ready to use Zigbee coordinator.  
 It supports Zigbee 3.0, Ethernet, LAN, USB, and WiFi connections. Rich packing that includes:
-| Package includes | SLZB-06p7 adapter | +5dB antenna 360° | Adhesive tape | Screws | Screwdriver | MicroUSB-Type-C | Screw-fix helper |
+| Package includes | SLZB-06p7 coordinator | +5dB antenna 360° | Adhesive tape | Screws | Screwdriver | MicroUSB-Type-C | Screw-fix helper |
 |:-|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 |Quantity: |1 pcs|1 pcs|2 pcs|2 pcs|1 pcs|1 pcs|1 pcs|  
 |Image| <img src="https://smlight.tech/external-content/images/zigbee2mqtt-io/slzb-06p7-adapter.jpg" width="200" /> | <img src="https://smlight.tech/external-content/images/zigbee2mqtt-io/slzb-06-antenna.jpg" width="200" /> | <img src="https://smlight.tech/external-content/images/zigbee2mqtt-io/slzb-06-adhesive.jpg" width="200" /> | <img src="https://smlight.tech/external-content/images/zigbee2mqtt-io/slzb-06-screws.jpg" width="200" /> | <img src="https://smlight.tech/external-content/images/zigbee2mqtt-io/slzb-06-screwdriver.jpg" width="200" /> | <img src="https://smlight.tech/external-content/images/zigbee2mqtt-io/slzb-06-microusb.jpg" width="200" /> | <img src="https://smlight.tech/external-content/images/zigbee2mqtt-io/slzb-06-qr.jpg" width="200" /> |
@@ -479,10 +479,10 @@ These devices have two serial devices built in. Make sure you put the right seri
 
 ::: details Texas Instruments CC2531
 
-USB connected Zigbee adapter with PCB antenna  
+USB connected Zigbee coordinator with PCB antenna  
 **Warning 1:** requires additional hardware to flash (CC debugger + download cable)  
 **Warning 2:** might not be powerful enough to handle networks of 20+ devices  
-**Warning 3:** this adapter has bad range
+**Warning 3:** this coordinator has bad range
 
 - [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_Home_1.2/bin)
 - [Router firmware](https://github.com/Koenkk/Z-Stack-firmware/tree/master/router/Z-Stack_Home_1.2/bin)
@@ -496,7 +496,7 @@ USB connected Zigbee adapter with PCB antenna
 
 ::: details Vision CC2538+CC2592 Dongle(VS203)
 
-Adapter or small development board based on CC2538 and CC2592 chip
+Coordinator or small development board based on CC2538 and CC2592 chip
 
 - [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.0.x/bin)
 - [Flashing instructions](https://www.aliexpress.com/item/1005002809329614.html?spm=a2g0o.store_pc_allProduct.8148356.2.4d7f1012TTc3uX)
@@ -507,7 +507,7 @@ Adapter or small development board based on CC2538 and CC2592 chip
 
 ::: details Texas Instruments CC2530
 
-Serial connected adapter with external antenna optionally with CC2591 or CC2592 RF frontend  
+Serial connected coordinator with external antenna optionally with CC2591 or CC2592 RF frontend  
 **Warning 1:** requires additional hardware to flash (CC debugger + download cable)  
 **Warning 2:** might not be powerful enough to handle networks of 20+ devices
 
@@ -522,7 +522,7 @@ Serial connected adapter with external antenna optionally with CC2591 or CC2592 
 
 ::: details Texas Instruments CC2538
 
-Serial connected adapter with CC2592 RF Amplifier
+Serial connected coordinator with CC2592 RF Amplifier
 
 - [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.0.x/bin)
 - [Flashing instructions](./flashing/flashing_the_cc2538.md)

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -1,5 +1,5 @@
 ---
-next: adapter-settings.md
+next: coordinator-settings.md
 ---
 
 # Configuration
@@ -17,7 +17,7 @@ permit_join: true
 mqtt:
     server: mqtt://localhost:1883
 serial:
-    # Could be either USB port (/dev/ttyUSB0), network Zigbee adapters (tcp://192.168.1.1:6638) or mDNS adapter (mdns://my-adapter).
+    # Could be either USB port (/dev/ttyUSB0), network Zigbee coordinators (tcp://192.168.1.1:6638) or mDNS coordinator (mdns://my-coordinator).
     port: /dev/ttyUSB0
 # Will run frontend on port 8080
 frontend:

--- a/docs/guide/configuration/adapter-settings.md
+++ b/docs/guide/configuration/adapter-settings.md
@@ -2,19 +2,19 @@
 sidebarDepth: 1
 ---
 
-# Adapter settings
+# Coordinator settings
 
 ::: warning ATTENTION
-Not all features are supported for every adapter, to see what's supported, go to your [adapter page](../../guide/adapters/README.md).
+Not all features are supported for every coordinator, to see what's supported, go to your [coordinator page](../../guide/adapters/README.md).
 :::
 
 ## Basic configuration
 
-In case Zigbee2MQTT cannot automatically detect your adapter (fails to start with: `USB adapter discovery error (No valid USB adapter found). Specify valid 'adapter' and 'port' in your configuration.`) we need to configure the `serial` section in the `configuration.yaml`.
+In case Zigbee2MQTT cannot automatically detect your coordinator (fails to start with: `USB coordinator discovery error (No valid USB coordinator found). Specify valid 'coordinator' and 'port' in your configuration.`) we need to configure the `serial` section in the `configuration.yaml`.
 
-First determine the port of your adapter:
+First determine the port of your coordinator:
 
-- For USB adapters: when running on Windows see [these instructions](../installation/05_windows.md#starting-zigbee2mqtt), for Linux execute `ls -l /dev/serial/by-id`:
+- For USB coordinators: when running on Windows see [these instructions](../installation/05_windows.md#starting-zigbee2mqtt), for Linux execute `ls -l /dev/serial/by-id`:
 
     ```bash
     pi@raspberry:/ $ ls -l /dev/serial/by-id
@@ -22,21 +22,21 @@ First determine the port of your adapter:
     lrwxrwxrwx. 1 root root 13 Oct 19 19:26 usb-Texas_Instruments_TI_CC2531_USB_CDC___0X00124B0018ED3DDF-if00 -> ../../ttyACM0
     ```
 
-- For network adapters you need to find the IP address of your adapter through router/switch web-interface. Make sure that the adapter has been assigned a static IP address!
-    - Alternatively, in case your adapter supports mDNS, see the mDNS docs below.
+- For network coordinators you need to find the IP address of your coordinator through router/switch web-interface. Make sure that the coordinator has been assigned a static IP address!
+    - Alternatively, in case your coordinator supports mDNS, see the mDNS docs below.
 
-Next determine what `adapter` you are using by going to your [adapter page](../adapters/README.md).
-Possible adapters are `zstack`, `ember`, `deconz`, `zigate` or `zboss`.
+Next determine what `adapter` you are using by going to your [coordinator page](../adapters/README.md).
+Possible coordinators are `zstack`, `ember`, `deconz`, `zigate` or `zboss`.
 
-Given the example of the USB adapter above in combination with a `zstack` adapter, we would add the following to the `configuration.yaml`:
+Given the example of the USB coordinator above in combination with a `zstack` coordinator, we would add the following to the `configuration.yaml`:
 
 ```yaml
 serial:
-    # Location of the adapter
-    # USB adapters - use format "port: /dev/serial/by-id/XXX"
-    # Ethernet adapters - use format "port: tcp://192.168.1.12:6638"
+    # Location of the coordinator
+    # USB coordinators - use format "port: /dev/serial/by-id/XXX"
+    # Ethernet coordinators - use format "port: tcp://192.168.1.12:6638"
     port: /dev/serial/by-id/usb-Texas_Instruments_TI_CC2531_USB_CDC___0X00124B0018ED3DDF-if00
-    # Adapter type, allowed values: `zstack`, `ember`, `deconz`, `zigate` or `zboss`
+    # Coordinator type, allowed values: `zstack`, `ember`, `deconz`, `zigate` or `zboss`
     adapter: zstack
 ```
 
@@ -44,9 +44,9 @@ This serial configuration should be enough to make Zigbee2MQTT start.
 
 ## mDNS Zeroconf discovery.
 
-Zigbee2MQTT supports automatic discovery of Zigbee network Adapters. In order to use this feature, your adapter must support discovery via mDNS Zeroconf.
+Zigbee2MQTT supports automatic discovery of Zigbee network Coordinators. In order to use this feature, your coordinator must support discovery via mDNS Zeroconf.
 
-If you have a more than 1 device with the same mDNS service type (name), Zigbee2MQTT with autodiscover option will connect to the random one. So for proper use we recommend to have only one physically connected network adapter with the same mDNS service type (name). Otherwise, please set-up a settings over IP address and port, as described on the passage above.
+If you have a more than 1 device with the same mDNS service type (name), Zigbee2MQTT with autodiscover option will connect to the random one. So for proper use we recommend to have only one physically connected network coordinator with the same mDNS service type (name). Otherwise, please set-up a settings over IP address and port, as described on the passage above.
 
 ::: warning ATTENTION
 When using this autodetection, the following parameters in `configuration.yaml` will be ignored: `adapter`, `baudrate`
@@ -64,7 +64,7 @@ serial:
     port: mdns://slzb-06
     # port: mdns://uzg-01
     # port: mdns://czc
-    # Optional: disable LED of the adapter if supported (default: false)
+    # Optional: disable LED of the coordinator if supported (default: false)
     disable_led: false
     # Optional: Baud rate speed for serial port, this can be anything firmware support but default is 115200 for Z-Stack and EZSP, 38400 for Deconz, however note that some EZSP firmware need 57600.
     baudrate: 115200
@@ -76,7 +76,7 @@ serial:
 
 ```yaml
 advanced:
-    # Optional: configure adapter concurrency (e.g. 2 for CC2531 or 16 for CC26X2R1) (default: null, uses recommended value)
+    # Optional: configure coordinator concurrency (e.g. 2 for CC2531 or 16 for CC26X2R1) (default: null, uses recommended value)
     adapter_concurrent: null
     # Optional: Transmit power setting in dBm (default: 5).
     # This will set the transmit power for devices that bring an inbuilt amplifier.
@@ -84,14 +84,14 @@ advanced:
     # by firmware (for example to migrate heat, or by using an unsupported firmware).
     # For the CC2652R(B) this is 5 dBm, CC2652P/CC1352P-2 20 dBm.
     transmit_power: 5
-    # Optional: Set the adapter delay, only used for Conbee/Raspbee adapters (default 0).
+    # Optional: Set the coordinator delay, only used for Conbee/Raspbee coordinators (default 0).
     # In case you are having issues try `200`.
     # For more information see https://github.com/Koenkk/zigbee2mqtt/issues/4884
     adapter_delay: 0
 ```
 
-<!-- TODO: some notes about rtscts? Is it useful, which adapter supports it? -->
+<!-- TODO: some notes about rtscts? Is it useful, which coordinator supports it? -->
 
 ::: tip
-It's also possible to connect USB Adapters over TCP. See how to connect a [remote adapter](../../advanced/remote-adapter/connect_to_a_remote_adapter.md).
+It's also possible to connect USB Coordinators over TCP. See how to connect a [remote coordinator](../../advanced/remote-adapter/connect_to_a_remote_adapter.md).
 :::

--- a/docs/guide/configuration/device-availability.md
+++ b/docs/guide/configuration/device-availability.md
@@ -70,7 +70,7 @@ following attributes will be read: `state`, `brightness`, `color_temp` and `colo
 
 ## Performance considerations
 
-- The pinging can be heavy on the coordinator, especially if you are using a CC2530 or CC2531 adapter.
+- The pinging can be heavy on the coordinator, especially if you are using a CC2530 or CC2531 coordinator.
 - Higher `timeout` for active devices results in less pinging so less stress on the coordinator.
 
 ## Groups

--- a/docs/guide/configuration/zigbee-network.md
+++ b/docs/guide/configuration/zigbee-network.md
@@ -43,7 +43,7 @@ Some Zigbee devices do not support changing channels. In case a device remains u
 :::
 
 ::: warning
-Changing channels is only supported for the `zstack` and `ember` adapter.
+Changing channels is only supported for the `zstack` and `ember` coordinator.
 :::
 
 Zigbee2MQTT will send this broadcast during startup if the channel in the configuration has been changed. The following logging will be produced:

--- a/docs/guide/faq/README.md
+++ b/docs/guide/faq/README.md
@@ -8,15 +8,15 @@ sidebarDepth: 0
 
 ## General limitations that apply to all Zigbee implementations
 
-Note that each Zigbee2MQTT installation instance only supports connecting a single dedicated Zigbee Coordinator radio adapter or module with a single Zigbee network and that the Zigbee Coordinator cannot already be connected or used by any other application. Any devices that are or have previously been connected to another Zigbee implementation will also need to first be reset to their factory default settings before they can be paired/joined to Zigbee2MQTT, please see each device manufacturer's documentation.
+Note that each Zigbee2MQTT installation instance only supports connecting a single dedicated Zigbee Coordinator radio coordinator or module with a single Zigbee network and that the Zigbee Coordinator cannot already be connected or used by any other application. Any devices that are or have previously been connected to another Zigbee implementation will also need to first be reset to their factory default settings before they can be paired/joined to Zigbee2MQTT, please see each device manufacturer's documentation.
 
 Any Zigbee device is limited to only be paired/joined to one Zigbee Coordinator and only be part of one Zigbee network, meaning that Zigbee devices can only be connected to a single Zigbee gateway. If you want to move a Zigbee device to a different Zigbee network then you need to factory reset that Zigbee device and re-pair/re-join it to the other Zigbee Gateway. This is a limitation in the current (as well as previous) Zigbee protocol specifications, governed by the [CSA (Connectivity Standards Alliance)](https://csa-iot.org/all-solutions/zigbee/), and as such, that limitation applies to all Zigbee implementations, not just the Zigbee2MQTT implementation.
 
-Another limitation that applies to all Zigbee implementations is that there is no such thing as "Zigbee over IP" or "Zigbee over LAN/WAN" in the Zigbee protocol specifications. It is therefore not possible to extend the same Zigbee network to two separate locations or sites that can not be reached directly via Zigbee radio signals within the Zigbee network mesh. That means that there is no way to use a so-called "Zigbee network adapter" or similar solutions to convert and bridge a single Zigbee network communication over a different medium such as Ethernet or VPN. As such there are no network-attached remote Zigbee adapters that can span a Zigbee network to remote sites, regardless if the marketing material of such products makes it sound like they can do in "Zigbee Router" mode. The fact is that the "Zigbee Router" feature of such "Zigbee network adapter" products puts their Zigbee radio chip into stand-alone mode so it works like any Zigbee Router device, disconnected from the Ethernet network part in those products.
+Another limitation that applies to all Zigbee implementations is that there is no such thing as "Zigbee over IP" or "Zigbee over LAN/WAN" in the Zigbee protocol specifications. It is therefore not possible to extend the same Zigbee network to two separate locations or sites that can not be reached directly via Zigbee radio signals within the Zigbee network mesh. That means that there is no way to use a so-called "Zigbee network coordinator" or similar solutions to convert and bridge a single Zigbee network communication over a different medium such as Ethernet or VPN. As such there are no network-attached remote Zigbee coordinators that can span a Zigbee network to remote sites, regardless if the marketing material of such products makes it sound like they can do in "Zigbee Router" mode. The fact is that the "Zigbee Router" feature of such "Zigbee network coordinator" products puts their Zigbee radio chip into stand-alone mode so it works like any Zigbee Router device, disconnected from the Ethernet network part in those products.
 
-Support for commissioning Zigbee 3.0 devices via "Install Code" or "QR Code" has so far only been implemented for 'zstack' (Texas Instruments ZNP) and 'ember' (Silicon Labs EmberZNet) adapter type radios in Zigbee2MQTT. Other radio adapter types are either missing support in their respective adapter/driver for [zigbee-herdsman](https://github.com/Koenkk/zigbee-herdsman) or more likely missing in the manufacturer's firmware commands/APIs and documentation.
+Support for commissioning Zigbee 3.0 devices via "Install Code" or "QR Code" has so far only been implemented for 'zstack' (Texas Instruments ZNP) and 'ember' (Silicon Labs EmberZNet) coordinator type radios in Zigbee2MQTT. Other radio coordinator types are either missing support in their respective coordinator/driver for [zigbee-herdsman](https://github.com/Koenkk/zigbee-herdsman) or more likely missing in the manufacturer's firmware commands/APIs and documentation.
 
-Zigbee2MQTT does not currently support devices that can only use the ZSE ("Zigbee Smart Energy") profile, that is however due to the "Zigbee SE" specification not being part of the standard Zigbee 3.0 specification that includes the more common Zigbee Home Automation + Zigbee lighting and thus not implemented in most of the Zigbee Coordinator firmware that is commonly available for Zigbee Coordinator radio adapters and modules, usually because the manufacturer offers separate Zigbee protocol stack SDK for Zigbee Smart Energy.
+Zigbee2MQTT does not currently support devices that can only use the ZSE ("Zigbee Smart Energy") profile, that is however due to the "Zigbee SE" specification not being part of the standard Zigbee 3.0 specification that includes the more common Zigbee Home Automation + Zigbee lighting and thus not implemented in most of the Zigbee Coordinator firmware that is commonly available for Zigbee Coordinator radio coordinators and modules, usually because the manufacturer offers separate Zigbee protocol stack SDK for Zigbee Smart Energy.
 
 ## My network is unstable and/or performs poorly, what can I do?
 
@@ -31,7 +31,7 @@ This problem can be divided in 2 categories; no logging is shown at all OR inter
 
 - Make sure [joining is enabled](../usage/pairing_devices.md).
 - There can be too much interference, try connecting the coordinator USB through an USB extension cable. This problem occurs a lot when used in combination with a Raspberry Pi 3 and 4.
-- If you are using a Texas Instruments CC2652 or CC1352 based adapter, routers might be missing from the coordinator memory. Do a [coordinator check](../usage/mqtt_topics_and_messages.md#zigbee2mqtt-bridge-request-coordinator-check) and re-pair the missing routers.
+- If you are using a Texas Instruments CC2652 or CC1352 based coordinator, routers might be missing from the coordinator memory. Do a [coordinator check](../usage/mqtt_topics_and_messages.md#zigbee2mqtt-bridge-request-coordinator-check) and re-pair the missing routers.
 - If you are using a Raspberry Pi, try disconnecting any other USB devices. If after that pairing works, try connecting the USB devices via a powered USB hub.
 - Make sure that any other Zigbee networks/hubs are powered down. When you e.g. want to pair an IKEA bulb which was first paired to the IKEA gateway make sure to power down the IKEA gateway. If that doesn't help also try powering down all devices that are connected to the IKEA hub.
 - If it's a battery powered device, try replacing the battery.
@@ -52,12 +52,12 @@ This problem can be divided in 2 categories; no logging is shown at all OR inter
 - In case the device is a bulb, try resetting it through [Touchlink](../usage/touchlink.md)
 - Try pairing close to a bulb (light) router instead of the coordinator.
 
-## How do I migrate from one adapter to another?
+## How do I migrate from one coordinator to another?
 
-Want to migrate from e.g. a CC2530/CC2531 to a more powerful adapter (e.g. CC2652/CC1352)? Then follow these instructions below:
+Want to migrate from e.g. a CC2530/CC2531 to a more powerful coordinator (e.g. CC2652/CC1352)? Then follow these instructions below:
 
 ::: warning
-Migration from one adapter to another requires backup and restore support which is so far only implemented for the `zstack` (Texas Instrument) and `ember` adapters. Backup and restore is **not supported** for any other adapters (`conbee`, `ezsp`, `zboss` and `zigate`).
+Migration from one coordinator to another requires backup and restore support which is so far only implemented for the `zstack` (Texas Instrument) and `ember` coordinators. Backup and restore is **not supported** for any other coordinators (`conbee`, `ezsp`, `zboss` and `zigate`).
 
 Note that when switching from `zstack` -> `ember` or `ember` -> `zstack` re-pairing **might not** be required, however results might vary as this is not officially supported. After switching, check if all devices are working and re-pair the ones that are not. In case pairing new devices is not working, re-pair some routers close to the coordinator while only permitting joining via the coordinator. Pairing should then work via routers that have been re-paired.
 :::
@@ -66,7 +66,7 @@ Note that when switching from `zstack` -> `ember` or `ember` -> `zstack` re-pair
 1. Stop Zigbee2MQTT
 1. Determine whether migrating [requires re-pairing of your devices](#what-does-and-does-not-require-re-pairing-of-all-devices)
     - If re-pairing is required: remove `data/coordinator_backup.json` (if it exists) and `data/database.db`
-    - If re-pairing is **not** required: [copy the ieee address of the old adapter into the new one](../adapters/flashing/copy_ieeaddr.html)
+    - If re-pairing is **not** required: [copy the ieee address of the old coordinator into the new one](../adapters/flashing/copy_ieeaddr.html)
 1. Update the `serial` -> `port` in your `configuration.yaml`
 1. Start Zigbee2MQTT
 
@@ -87,7 +87,7 @@ You need to re-pair all you devices when:
 
 - Changing the network key (`network_key`) or panID (`pan_id`) in `configuration.yaml`.
 - Changing the Zigbee channel (`channel`) in the `configuration.yaml` might require re-pairing **some** devices, read the [documentation for more info](../configuration/zigbee-network.md#changing-the-zigbee-channel).
-- Switching between adapters requires re-pairing, **except when**:
+- Switching between coordinators requires re-pairing, **except when**:
     - When the `serial.adapter` in the `configuration.yaml` is `zstack` or `ember` and the `serial.adapter` stays the same; e.g. `zstack` -> `zstack` re-pairing is **not** required.
         - There is one exception, when switching from a CC2531 or CC2530 (Z-Stack 1.2) to a CC2652/CC1352 (Z-Stack 3) re-pairing **is** required.
     - When switching from `zstack` -> `ember` or `ember` -> `zstack` re-pairing **might not** be required, however results might vary as this is not officially supported.
@@ -132,7 +132,7 @@ LQI (Link Quality Index) values can be hard to interpret for Zigbee. This is bec
 
 When the Home Assistant legacy action sensor is enabled (`homeassistant.legacy_action_sensor: true` in your `configuration.yaml`) the `action` property of your e.g. buttons will almost always be empty. Whenever an `action` is published e.g. `{"action": "single"}` it will be immediately followed up by a `{"action": ""}`. This is to trigger a state change in the Home Assistant action sensor (so that it can be used in e.g. automations).
 
-## I read that Zigbee2MQTT has a limit of 20 devices (when using a CC2530/CC2531 adapter), is this true?
+## I read that Zigbee2MQTT has a limit of 20 devices (when using a CC2530/CC2531 coordinator), is this true?
 
 Definitely not! Example given: the default Zigbee2MQTT CC2531 firmware indeed supports 20 devices connected **directly** to the coordinator. However, by having routers in your network the network size can be extended. Probably all AC powered devices e.g. bulbs serve as a router, you can even use another [CC2530/CC2531 as a router](../../advanced/zigbee/05_create_a_cc2530_router.md) (which has a limit of 21 devices).
 
@@ -158,11 +158,11 @@ In case you setup multiple instances of Zigbee2MQTT it's important to use a diff
 
 ## Zigbee2MQTT crashes after some time
 
-If after some uptime Zigbee2MQTT crashes with errors like: `SRSP - AF - dataRequest after 6000ms` or `SRSP - ZDO - mgmtPermitJoinReq after 6000ms` it means the adapter has crashed.
+If after some uptime Zigbee2MQTT crashes with errors like: `SRSP - AF - dataRequest after 6000ms` or `SRSP - ZDO - mgmtPermitJoinReq after 6000ms` it means the coordinator has crashed.
 
-- Normally this can be fixed by replugging the adapter and restarting Zigbee2MQTT
-- If you are using a CC2530 or CC2531 adapter consider upgrading to one of the [recommended adapters](../adapters/README.md). The CC2530/CC2531 is considered legacy hardware and runs into memory corruption easily.
-- Make sure you are using the latest firmware on your adapter, see the [adapter page](../adapters/README.md) for a link to the latest firmware.
+- Normally this can be fixed by replugging the coordinator and restarting Zigbee2MQTT
+- If you are using a CC2530 or CC2531 coordinator consider upgrading to one of the [recommended coordinators](../adapters/README.md). The CC2530/CC2531 is considered legacy hardware and runs into memory corruption easily.
+- Make sure you are using the latest firmware on your coordinator, see the [coordinator page](../adapters/README.md) for a link to the latest firmware.
 - If using a Raspberry Pi; this problem can occur if you are using a bad power supply or when other USB devices are connected directly to the Pi (especially occurs with external SSD), try connecting other USB devices through a powered USB hub.
 - Disable the USB autosuspend feature, if `cat /sys/module/usbcore/parameters/autosuspend` returns `1` or `2` it is enabled; to disable execute:
     ```bash

--- a/docs/guide/getting-started/README.md
+++ b/docs/guide/getting-started/README.md
@@ -9,9 +9,9 @@ next: ../usage/
 
 In order to use Zigbee2MQTT we need the following hardware:
 
-1. <img src="../../images/zzh.jpg" title="ZZH" class="float-left" /> **A Zigbee Adapter** which is the interface between the Computer (or Server) where you run Zigbee2MQTT and the Zigbee radio
-   communication. Zigbee2MQTT supports a variety of adapters with different kind of connections like USB, GPIO or remote via WIFI or Ethernet.
-   Recommended adapters have a chip starting with CC2652 or CC1352. See [supported Adapters](../adapters/README.md). It's recommended to check out your adapter's recommendation details before the installation process, to find out whether it needs any additional configuration parameters. <br class="clear" />
+1. <img src="../../images/zzh.jpg" title="ZZH" class="float-left" /> **A Zigbee Coordinator** which is the interface between the Computer (or Server) where you run Zigbee2MQTT and the Zigbee radio
+   communication. Zigbee2MQTT supports a variety of coordinators with different kind of connections like USB, GPIO or remote via WIFI or Ethernet.
+   Recommended coordinators have a chip starting with CC2652 or CC1352. See [supported Coordinators](../adapters/README.md). It's recommended to check out your coordinator's recommendation details before the installation process, to find out whether it needs any additional configuration parameters. <br class="clear" />
 
 2. <img src="../../images/pi.jpg" title="Raspberry Pi" class="float-left" /> **A Server** where you would run Zigbee2MQTT. Most Raspberry-Pi models are known to work but you can run it on many computers and platforms including Linux, Windows and MacOS. It should have an MQTT broker installed. [Mosquitto](https://www.mosquitto.org/download/) ([Tutorial for Raspberry-Pi](https://randomnerdtutorials.com/how-to-install-mosquitto-broker-on-raspberry-pi/)) is the recommended MQTT broker but [others](https://mqtt.org/software/) should also work fine. <br class="clear" />
 
@@ -28,11 +28,11 @@ You can run Zigbee2MQTT in different ways, see [Installation](../installation/).
 [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) is used to
 set up and run Zigbee2MQTT.
 
-### 1.) Find the Zigbee-Adapter
+### 1.) Find the Zigbee-Coordinator
 
-#### 1.1) USB Zigbee adapter
+#### 1.1) USB Zigbee coordinator
 
-After you plug the adapter in see the `dmesg` output to find the device location:
+After you plug the coordinator in see the `dmesg` output to find the device location:
 
 ```bash
 $ sudo dmesg
@@ -44,23 +44,23 @@ ch341 3-1:1.0: ch341-uart converter detected
 usb 3-1: ch341-uart converter now attached to ttyUSB0
 ```
 
-As we can see the adapter was identified and mounted on `ttyUSB0`.
+As we can see the coordinator was identified and mounted on `ttyUSB0`.
 
 ```bash
 $ ls -l /dev/ttyUSB0
 crw-rw---- 1 root dialout 188, May 16 19:15 /dev/ttyUSB0
 ```
 
-Here we can see that the adapter is owned by `root` and accessible from all users in the `dialout` group.
+Here we can see that the coordinator is owned by `root` and accessible from all users in the `dialout` group.
 
-#### 1.2) Network Zigbee adapter
+#### 1.2) Network Zigbee coordinator
 
-Zigbee2MQTT supports mDNS autodiscovery feature for network Zigbee adapters. If your network Zigbee adapter supports mDNS, you do not need to know the IP address of your network Zigbee adapter, Zigbee2MQTT will detect it and configure. Otherwise, you need to know the network Zigbee adapter's IP address:
+Zigbee2MQTT supports mDNS autodiscovery feature for network Zigbee coordinators. If your network Zigbee coordinator supports mDNS, you do not need to know the IP address of your network Zigbee coordinator, Zigbee2MQTT will detect it and configure. Otherwise, you need to know the network Zigbee coordinator's IP address:
 
-- Connect your adapter to your LAN network either over Ethernet or Wi-Fi, depending on your adapter.
+- Connect your coordinator to your LAN network either over Ethernet or Wi-Fi, depending on your coordinator.
 - Go to your router/switch setting and find the list of connected device.
-- Find the IP address and of your Ethernet Zigbee adapter.
-- You also need to know the communication port of your Ethernet Zigbee-Adapter. In most cases (TubeZB, SLZB-06) the default port is `6638`. You can check the port at your Adapter's user manual.
+- Find the IP address and of your Ethernet Zigbee coordinator.
+- You also need to know the communication port of your Ethernet Zigbee-Coordinator. In most cases (TubeZB, SLZB-06) the default port is `6638`. You can check the port at your Coordinator's user manual.
 
 ### 2.) Setup and start Zigbee2MQTT
 
@@ -68,7 +68,7 @@ Zigbee2MQTT supports mDNS autodiscovery feature for network Zigbee adapters. If 
 
 It's assumed, that you have a recent version of Docker and Docker Compose installed.
 
-First, we create a folder where we want the project to reside `mkdir folder-name`. In the folder, we create we save the `docker-compose.yml` file which defines how Docker would run our containers. The following file consists of two services, one for the MQTT-Server and one for Zigbee2MQTT itself. Be sure to adjust the file to your needs and match the devices-mount in the case your adapter was not mounted on `/dev/ttyUSB0` or in case you use a network adapter.
+First, we create a folder where we want the project to reside `mkdir folder-name`. In the folder, we create we save the `docker-compose.yml` file which defines how Docker would run our containers. The following file consists of two services, one for the MQTT-Server and one for Zigbee2MQTT itself. Be sure to adjust the file to your needs and match the devices-mount in the case your coordinator was not mounted on `/dev/ttyUSB0` or in case you use a network coordinator.
 
 ```yaml
 version: '3.8'
@@ -106,23 +106,23 @@ NOTE: Docker Compose makes the MQTT-Server available using "mqtt" hostname.
 
 <Configurator mqtt="mqtt://mqtt" serial="/dev/ttyUSB0" portType="Serial" adapter="zstack" />
 
-For network adapters, `serial` > `port` settings should look like this:
+For network coordinators, `serial` > `port` settings should look like this:
 
 ```yaml
 serial:
     port: tcp://192.168.1.12:6638
 ```
 
-Where `192.168.1.112` is the IP address of your network Zigbee adapter, and `6638` is the port.
+Where `192.168.1.112` is the IP address of your network Zigbee coordinator, and `6638` is the port.
 
-In case you adapter supports mDNS, you can omit the IP address and use a configuration like:
+In case you coordinator supports mDNS, you can omit the IP address and use a configuration like:
 
 ```yaml
 serial:
     port: mdns://slzb-06
 ```
 
-Where `slzb-06` is the mDNS name of your network Zigbee adapter.
+Where `slzb-06` is the mDNS name of your network Zigbee coordinator.
 
 #### 2.3) Start Zigbee2MQTT
 

--- a/docs/guide/installation/01_linux.md
+++ b/docs/guide/installation/01_linux.md
@@ -123,7 +123,7 @@ Zigbee2MQTT can be stopped by pressing `CTRL + C`.
 
 ::: warning ATTENTION
 
-In case Zigbee2MQTT fails to start with `USB adapter discovery error (No valid USB adapter found). Specify valid 'adapter' and 'port' in your configuration.` see the [serial configuration docs](../configuration/adapter-settings.md)
+In case Zigbee2MQTT fails to start with `USB coordinator discovery error (No valid USB coordinator found). Specify valid 'adapter' and 'port' in your configuration.` see the [serial configuration docs](../configuration/adapter-settings.md)
 
 :::
 

--- a/docs/guide/installation/02_docker.md
+++ b/docs/guide/installation/02_docker.md
@@ -9,7 +9,7 @@ It is possible to run Zigbee2MQTT in a Docker container using the official [Zigb
 This image support the following architectures: `linux/386`, `linux/amd64`, `linux/arm/v6`, `linux/arm/v7`, `linux/arm64` and `linux/riscv64`.
 Since Zigbee2MQTT images are manifest listed, Docker will auto-detect the architecture and pull the right image.
 
-Start by figuring out the location of your adapter as explained [here](../configuration/adapter-settings.md#determine-location-of-the-adapter).
+Start by figuring out the location of your coordinator as explained [here](../configuration/adapter-settings.md#determine-location-of-the-adapter).
 
 **IMPORTANT**: Using a Raspberry Pi? Make sure to check [Notes for Raspberry Pi users](#notes-for-raspberry-pi-users).
 
@@ -21,11 +21,11 @@ Navigate to the directory where you will store the Zigbee2MQTT data and execute 
 mkdir data && wget https://raw.githubusercontent.com/Koenkk/zigbee2mqtt/master/data/configuration.example.yaml -O data/configuration.yaml
 ```
 
-Now configure the MQTT server and adapter location as explained [here](./01_linux.md#configuring).
+Now configure the MQTT server and coordinator location as explained [here](./01_linux.md#configuring).
 
 ## Running the container
 
-Execute the following command, update the `--device` parameter to match the location of your adapter.
+Execute the following command, update the `--device` parameter to match the location of your coordinator.
 
 ```bash
 $ docker run \
@@ -43,9 +43,9 @@ $ docker run \
 
 - `--name zigbee2mqtt`: Name of container
 - `--restart=unless-stopped`: Automatically start on boot and restart after a crash
-- `--device=/dev/serial/by-id/usb-Texas_Instruments_TI_CC2531_USB_CDC___0X00124B0018ED3DDF-if00:/dev/ttyACM0`: Location of adapter (e.g. CC2531). The path before the `:` is the path on the host, the path after it is the path that is mapped to inside the container. You should always use the `/dev/serial/by-id/` path on the host.
+- `--device=/dev/serial/by-id/usb-Texas_Instruments_TI_CC2531_USB_CDC___0X00124B0018ED3DDF-if00:/dev/ttyACM0`: Location of coordinator (e.g. CC2531). The path before the `:` is the path on the host, the path after it is the path that is mapped to inside the container. You should always use the `/dev/serial/by-id/` path on the host.
 - `-v $(pwd)/data:/app/data`: Directory where Zigbee2MQTT stores it configuration (pwd maps to the current working directory)
-- `-v /run/udev:/run/udev:ro`: required for auto-detecting the adapter
+- `-v /run/udev:/run/udev:ro`: required for auto-detecting the coordinator
 - `-e TZ=Europe/Amsterdam`: configure the timezone
 - `-p 8080:8080`: port forwarding from inside Docker container to host (for the frontend)
 
@@ -58,7 +58,7 @@ of the `docker0` bridge to establish the connection: `server: mqtt://172.17.0.1`
 
 To improve the security of the deployment you may want to run Zigbee2MQTT as a _non-root_ user.
 
-1. Identify the group that has access to the adapter (in Ubuntu, e.g. it might be assigned to `dialout`). Update `ttyACM0` to match your adapter location.
+1. Identify the group that has access to the coordinator (in Ubuntu, e.g. it might be assigned to `dialout`). Update `ttyACM0` to match your coordinator location.
 
 ```
 $ ls -l /dev/ttyACM0
@@ -152,7 +152,7 @@ services:
         environment:
             - TZ=Europe/Berlin
         devices:
-            # Make sure this matched your adapter location
+            # Make sure this matched your coordinator location
             - /dev/serial/by-id/usb-Texas_Instruments_TI_CC2531_USB_CDC___0X00124B0018ED3DDF-if00:/dev/ttyACM0
 ```
 
@@ -256,8 +256,8 @@ A workaround is to manually set the right permissions. The workaround is based o
 
 This workaround only works with cgroup v1, which is not enabled on many newer distro releases.
 
-1. Identify serial adapter
-   Identify the serial adapter using the following command:
+1. Identify serial coordinator
+   Identify the serial coordinator using the following command:
 
     ```shell
     sudo lsusb -v
@@ -357,7 +357,7 @@ This workaround only works with cgroup v1, which is not enabled on many newer di
 
 2. UDEV Rules
 
-    Create a new udev rule for serial adapter, `idVendor` and `idProduct` must be equal to values from `lsusb` command. The rule below creates device `/dev/zigbee-serial`:
+    Create a new udev rule for serial coordinator, `idVendor` and `idProduct` must be equal to values from `lsusb` command. The rule below creates device `/dev/zigbee-serial`:
 
     ```shell
     echo "SUBSYSTEM==\"tty\", ATTRS{idVendor}==\"0451\", ATTRS{idProduct}==\"16a8\", SYMLINK+=\"zigbee-serial\",  RUN+=\"/usr/local/bin/docker-setup-zigbee-serial.sh\"" | sudo tee /etc/udev/rules.d/99-zigbee-serial.rules
@@ -434,7 +434,7 @@ This workaround only works with cgroup v1, which is not enabled on many newer di
 
     ```shell
     [Unit]
-    Description=Docker Event Listener for Zigbee serial adapter
+    Description=Docker Event Listener for Zigbee serial coordinator
     After=network.target
     StartLimitIntervalSec=0
     [Service]
@@ -480,7 +480,7 @@ This workaround only works with cgroup v1, which is not enabled on many newer di
 
 6. Verify and deploy Zigbee2MQTT stack
 
-    Now reconnect the serial adapter. Verify using the following command:
+    Now reconnect the serial coordinator. Verify using the following command:
 
     ```shell
     ls -al /dev/zigbee-serial
@@ -514,7 +514,7 @@ This workaround only works with cgroup v1, which is not enabled on many newer di
     	external: true
     ```
 
-    In the above example, `proxy_traefik-net` is the network to connect to the mqtt broker. The constraint makes sure Docker deploys only to this (`rpi-3`) node, where the serial adapter is connected to. The volume binding `/mnt/docker-cluster/zigbee2mqtt/data` is the zigbee2mqtt persistent directory, where `configuration.yaml` is saved.
+    In the above example, `proxy_traefik-net` is the network to connect to the mqtt broker. The constraint makes sure Docker deploys only to this (`rpi-3`) node, where the serial coordinator is connected to. The volume binding `/mnt/docker-cluster/zigbee2mqtt/data` is the zigbee2mqtt persistent directory, where `configuration.yaml` is saved.
 
     The Zigbee2MQTT `configuration.yaml` should point to `/dev/zigbee-serial`:
 

--- a/docs/guide/installation/04_openhabian.md
+++ b/docs/guide/installation/04_openhabian.md
@@ -12,7 +12,7 @@ If you are using openHABian on a Raspberry Pi then the installation is pretty ea
 1. Under "Select Branch" choose option "main".
 1. Go to "optional components".
 1. If you don't have a MQTT-server yet, then first choose Mosquitto and follow the instructions. After installation of Mosquitto come back to the "optional components" and select "Zigbee2MQTT".
-1. After selecting your Zigbee USB adapter, or specifying the ip:port of your ethernet adapter, you have to enter your MQTT username and if necessary a password.
+1. After selecting your Zigbee USB coordinator, or specifying the ip:port of your ethernet coordinator, you have to enter your MQTT username and if necessary a password.
 1. After about 3 to 4 minutes Zigbee2MQTT should be up and running. You can test if the configuration page is available on port 8081.
 
 ## Update

--- a/docs/guide/installation/05_windows.md
+++ b/docs/guide/installation/05_windows.md
@@ -80,7 +80,7 @@ Zigbee2MQTT can be stopped anytime by pressing `CTRL + C` and then confirming wi
 
 ::: warning ATTENTION
 
-In case Zigbee2MQTT fails to start with `USB adapter discovery error (No valid USB adapter found). Specify valid 'adapter' and 'port' in your configuration.`, we need to configure the `serial` section in the `configuration.yaml`.
+In case Zigbee2MQTT fails to start with `USB coordinator discovery error (No valid USB coordinator found). Specify valid 'adapter' and 'port' in your configuration.`, we need to configure the `serial` section in the `configuration.yaml`.
 
 First determine which COM port is assigned to your device:
 

--- a/docs/guide/installation/08_kubernetes.md
+++ b/docs/guide/installation/08_kubernetes.md
@@ -13,7 +13,7 @@ configuration required for you.
 The Zigbee2MQTT config section in the values.yaml is a 1:1 mapping of the usual config file, it simply is created on a configmap
 during the helm release creation. If you don't provide any additional values, sensible defaults are used in the deployment.
 
-If you are planning to use an usb adapter directly plugged into a node of the cluster, most likely you need to
+If you are planning to use an usb coordinator directly plugged into a node of the cluster, most likely you need to
 specify a `.values.statefulset.nodeSelector` so the pods are scheduled in the right node.
 
 By default, storage is not enabled, which is great for testing.

--- a/docs/guide/installation/20_zigbee2mqtt-fails-to-start_crashes-runtime.md
+++ b/docs/guide/installation/20_zigbee2mqtt-fails-to-start_crashes-runtime.md
@@ -4,11 +4,11 @@ sidebarDepth: 0
 
 # Zigbee2MQTT fails to start/crashes runtime
 
-Most of the time this is caused by Zigbee2MQTT not being able to communicate with your Zigbee adapter.
+Most of the time this is caused by Zigbee2MQTT not being able to communicate with your Zigbee coordinator.
 
 [[toc]]
 
-## Error: `USB adapter discovery error (No valid USB adapter found). Specify valid 'adapter' and 'port' in your configuration.`
+## Error: `USB coordinator discovery error (No valid USB coordinator found). Specify valid 'coordinator' and 'port' in your configuration.`
 
 Configure the `serial` section as described [here](../configuration/adapter-settings.md).
 
@@ -16,14 +16,14 @@ Configure the `serial` section as described [here](../configuration/adapter-sett
 
 Common reasons for this error:
 
-1. The port of your serial adapter changed.
-   Check [this](../configuration/adapter-settings.md) to find out the port of your adapter.
-2. If you are using a CC2530 or CC2531; it is a common issue for this adapter to crash (due to its outdated hardware).
-   Reflashing the firmware should fix the problem. If it happens often consider flashing the [source routing firmware](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_Home_1.2/bin/source_routing) or upgrade to a [more powerful adapter](../adapters/README.md).
-3. Your adapter requires additional configuration parameters. Check [supported Adapters](../adapters/README.md) section to find out if your adapter requires extra parameters (eg. ConBee II / RaspBee II).
+1. The port of your serial coordinator changed.
+   Check [this](../configuration/adapter-settings.md) to find out the port of your coordinator.
+2. If you are using a CC2530 or CC2531; it is a common issue for this coordinator to crash (due to its outdated hardware).
+   Reflashing the firmware should fix the problem. If it happens often consider flashing the [source routing firmware](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_Home_1.2/bin/source_routing) or upgrade to a [more powerful coordinator](../adapters/README.md).
+3. Your coordinator requires additional configuration parameters. Check [supported Coordinators](../adapters/README.md) section to find out if your coordinator requires extra parameters (eg. ConBee II / RaspBee II).
 4. Home Assistant's "Zigbee Home Automation" (ZHA) integration is enabled. Try to disable the ZHA integration and restart the Zigbee2MQTT add-on.
-5. Your hardware adapter is flashed with the router firmware and not with the coordinator firmware.
-6. Your network Zigbee adapter is not accessible over the LAN network.
+5. Your hardware coordinator is flashed with the router firmware and not with the coordinator firmware.
+6. Your network Zigbee coordinator is not accessible over the LAN network.
 7. Another software on your machine (including Home Assistant integration) is interfering with USB devices (example: [HA EDL21 integration](https://www.home-assistant.io/integrations/edl21) trying to find a USB device).
 
 ## Verify that you put the correct port in configuration.yaml
@@ -103,16 +103,16 @@ Reboot your device and now your user should have access to the device.
 ## Error: `Coordinator failed to start, probably the panID is already in use, try a different panID or channel`
 
 - If you still get this error after increasing the panID (as explained [here](../configuration/zigbee-network.md#network-config))
-  and you are using a Raspberry Pi with other USB devices attached (e.g. SSD) try connecting the SSD or adapter through a powered USB hub.
+  and you are using a Raspberry Pi with other USB devices attached (e.g. SSD) try connecting the SSD or coordinator through a powered USB hub.
 - In case you are getting this after first starting successfully and pairing a device it might be that the firmware has
   been flashed incorrectly. Try flashing the stick on a different
   computer ([detailed info](https://github.com/Koenkk/zigbee2mqtt/issues/6302)). This issue mainly occurs in combination with a Slaesh's CC2652RB stick.
-- If you had your Zigbee network before and such an error appears with the new Zigbee adapter, try to switch off the Zigbee routers that were connected to your previous Zigbee network and restart Zigbee2MQTT.
+- If you had your Zigbee network before and such an error appears with the new Zigbee coordinator, try to switch off the Zigbee routers that were connected to your previous Zigbee network and restart Zigbee2MQTT.
 
 ## Error: `Resource temporarily unavailable Cannot lock port`
 
-This error occurs when another program is already using (and thus locking) the adapter. You can find out which via the
-following command: `ls -l /proc/[0-9]/fd/ |grep /dev/ttyACM0` (replace `/dev/ttyACM0` with your adapter port).
+This error occurs when another program is already using (and thus locking) the coordinator. You can find out which via the
+following command: `ls -l /proc/[0-9]/fd/ |grep /dev/ttyACM0` (replace `/dev/ttyACM0` with your coordinator port).
 
 ## Raspberry Pi users: use a good power supply
 
@@ -127,11 +127,11 @@ In case you see message like below when running `dmesg -w` you are using a bad p
 [44889.075627] Voltage normalised (0x00000000)
 ```
 
-Also try connecting the adapter via a powered USB hub (especially if you have an SSD connected to the Pi).
+Also try connecting the coordinator via a powered USB hub (especially if you have an SSD connected to the Pi).
 
 ## Make sure the extension cable works
 
-A bad extension cable can lead to connection issues between the system and the adapter. Symptoms of this are
+A bad extension cable can lead to connection issues between the system and the coordinator. Symptoms of this are
 disconnection messages in the `dmesg -w` log like below.
 
 ```
@@ -149,7 +149,7 @@ The Openhab zwave binding interferes with Zigbee2MQTT,
 click [here](https://community.openhab.org/t/apparently-the-zwave-binding-blocks-the-dev-ttyusb0-port-in-combination-with-a-cc2652rb-zigbee2mqtt-dongle/103245)
 for more information.
 
-## In case of a CC2530 or CC2531 adapter, verify that don't have a CC2540
+## In case of a CC2530 or CC2531 coordinator, verify that don't have a CC2540
 
 The CC2540 can be confused easily with the CC2531 as it looks (almost) exactly the same. However, this device does not
 support zigbee but bluetooth. This can be verified by looking at the chip.
@@ -174,7 +174,7 @@ hciuart can be disabled by executing: `sudo systemctl disable hciuart`.
 If Zigbee2MQTT fails to start with a Texas Instruments LAUNCHXL-CC1352P-2/CC26X2R1 with `Error: SRSP - SYS - version after 6000ms`, you most probably have connected your device to a system that requires pressing the reset button (the one next to the USB connector)
 momentarily/shortly after connecting the USB cable. This issue has primarily been observed on x86 architectures only (
 e.g., Intel NUC, HPE Microserver, i7 laptop), see also [#2162](https://github.com/Koenkk/zigbee2mqtt/issues/2162). The
-procedure has to be repeated every time the adapter is re-connected and it's not clear yet, whether this can be fixed
+procedure has to be repeated every time the coordinator is re-connected and it's not clear yet, whether this can be fixed
 at all. It does not seem to occur on ARM based boards (Raspberry Pi, ODROID XU4).
 
 Something that can also solve the issue is to replug the USB cable.
@@ -223,18 +223,18 @@ This happens when you edit one or more of the `pan_id`, `network_key` or `ext_pa
 [2024-12-14 20:25:39] error: 	zh:adapter:zstack:manager: - Channel List: configured=**, adapter=**
 ```
 
-(In this example the actual values are replaced with `*`s) You can used the values that are listed for the adapter and put them back in the configuration file. Note that you can't just paste them back: in the logs the keys are printed as hexadecimal strings, but in the config file, `ext_pan_id` and `ext_pan_id` should be entered as arrays. Suppose your network key shows as `39af4d83h2dcb389` in the logs, then you should put the following in your config file:
+(In this example the actual values are replaced with `*`s) You can used the values that are listed for the coordinator and put them back in the configuration file. Note that you can't just paste them back: in the logs the keys are printed as hexadecimal strings, but in the config file, `ext_pan_id` and `ext_pan_id` should be entered as arrays. Suppose your network key shows as `39af4d83h2dcb389` in the logs, then you should put the following in your config file:
 
 ```
 ext_pan_id: [0x39,0xaf,0x4d,0x83,0xh2,0xdc,0xb3,0x89]
 ```
 
-## Zigbee adapters over the network: use robust and reliable network adapters on Zigbee2MQTT server
+## Zigbee coordinators over the network: use robust and reliable network coordinators on Zigbee2MQTT server
 
-If you have a WiFi or ethernet-connected Zigbee adapter, Zigbee2MQTT is communicating with the Zigbee adapter over the LAN through serial-over-IP protocol.
+If you have a WiFi or ethernet-connected Zigbee coordinator, Zigbee2MQTT is communicating with the Zigbee coordinator over the LAN through serial-over-IP protocol.
 
-The use of USB-WiFi or USB-ethernet adapters on the Zigbee2MQTT server is discouraged because despite the apparent equivalence to the onboard adapters in terms of specifications, they are designed in small enclosures, often not well ventilated and tend to overheat.  
-These adapters are known to stall or stop working in case of high loads or overheating, causing errors like:
+The use of USB-WiFi or USB-ethernet coordinators on the Zigbee2MQTT server is discouraged because despite the apparent equivalence to the onboard coordinators in terms of specifications, they are designed in small enclosures, often not well ventilated and tend to overheat.  
+These coordinators are known to stall or stop working in case of high loads or overheating, causing errors like:
 
 ```
 [2024-06-24 03:37:22] error: zh:ember:uart:ash: Received ERROR from NCP while connecting, with code=ERROR_EXCEEDED_MAXIMUM_ACK_TIMEOUT_COUNT.
@@ -263,8 +263,8 @@ which shows a communication out of sync between host and NCP but also, and this 
 where Zigbee2MQTT could not connect to the MQTT server over the LAN.
 
 The best setup for this situation is to use the ethernet port embedded into the Zigbee2MQTT server motherboard which guarantees reliability of communications in all load conditions.  
-As a second choice you can use the onboard WiFi adapter which should as well be designed for reliability, but also consider the stability of your WiFi network.  
-If all the onboard adapters are in use and you need to add another network adapter, the best choice is to install an internal network card on the PCIe bus, with proper cooling design.
+As a second choice you can use the onboard WiFi coordinator which should as well be designed for reliability, but also consider the stability of your WiFi network.  
+If all the onboard coordinators are in use and you need to add another network coordinator, the best choice is to install an internal network card on the PCIe bus, with proper cooling design.
 
 ## Error: regular crashes with timeout errors or failure to start after the serial port is opened
 

--- a/docs/guide/supported-hardware.md
+++ b/docs/guide/supported-hardware.md
@@ -4,11 +4,11 @@ next: ./adapters/
 
 # Supported Hardware
 
-## Zigbee Adapters
+## Zigbee Coordinators
 
-Zigbee2MQTT supports a range of Adapters which enable communication with the Zigbee radio network.
-Most adapters are connected on a USB port but there are options to use GPIO-Pins or [connect it remotely](../advanced/remote-adapter/connect_to_a_remote_adapter.md)
-over TCP using a WIFI or Ethernet network. See the [list of supported Zigbee Adapters](./adapters/)
+Zigbee2MQTT supports a range of Coordinators which enable communication with the Zigbee radio network.
+Most coordinators are connected on a USB port but there are options to use GPIO-Pins or [connect it remotely](../advanced/remote-adapter/connect_to_a_remote_adapter.md)
+over TCP using a WIFI or Ethernet network. See the [list of supported Zigbee Coordinators](./adapters/)
 
 ## Zigbee Devices
 

--- a/docs/guide/usage/integrations.md
+++ b/docs/guide/usage/integrations.md
@@ -5,7 +5,7 @@
 - [node-red-contrib-zigbee2mqtt](https://flows.nodered.org/node/node-red-contrib-zigbee2mqtt)
 - [Domoticz](https://github.com/stas-demydiuk/domoticz-zigbee2mqtt-plugin)
 - [Majordomo](https://github.com/directman66/majordomo-zigbee2mqtt/) (Russian)
-- [Mozilla IoT WebThings Gateway via Zigbee2MQTT adapter](https://github.com/kabbi/zigbee2mqtt-adapter)
+- [Mozilla IoT WebThings Gateway via Zigbee2MQTT coordinator](https://github.com/kabbi/zigbee2mqtt-adapter)
 - [openHAB](./integrations/openhab.md)
 - [Homebridge plugin](https://github.com/itavero/homebridge-z2m/#readme) (Apple HomeKit)
 - [Symcon Automation Solutions](https://github.com/Schnittcher/IPS-Zigbee2MQTT)

--- a/docs/guide/usage/mqtt_topics_and_messages.md
+++ b/docs/guide/usage/mqtt_topics_and_messages.md
@@ -390,7 +390,7 @@ Allows to check whether Zigbee2MQTT is healthy. Payload has to be empty, example
 
 Allows to check to execute a coordinator check. Payload has to be empty, example response: `{"data":{"missing_routers":[{"friendly_name":"bulb","ieee_address":"0x000b57fffec6a5b2"}]},"status":"ok"}`.
 
-This check is only supported for Texas Instruments based adapters (e.g. CC2652/CC1352). It checks whether any routers are missing from the coordinator memory. In case routers are missing, you may experience one of the following problems:
+This check is only supported for Texas Instruments based coordinators (e.g. CC2652/CC1352). It checks whether any routers are missing from the coordinator memory. In case routers are missing, you may experience one of the following problems:
 
 - Unable to pair devices to your network, pairing might fail for any device that tries to joins the network via this missing router.
 - Devices falling of the network. Sometimes devices that are in the network re-join it, if they try to re-join via this missing router, re-joining will fail.
@@ -441,7 +441,7 @@ See [External converters](../../advanced/more/external_converters.md).
 
 #### zigbee2mqtt/bridge/request/backup
 
-Creates a backup of the `data` folder (without the `data/log` directory). Payload has to be empty, example response: `{"data":{"zip":"WklHQkVFMk1RVFQuUk9DS1M="},"status":"ok"}`. The `zip` property represents a zip file encoded via Base64. Note that not all adapters support backup (`coordinator_backup.json`), see [adapters](../adapters/README.md) for more details.
+Creates a backup of the `data` folder (without the `data/log` directory). Payload has to be empty, example response: `{"data":{"zip":"WklHQkVFMk1RVFQuUk9DS1M="},"status":"ok"}`. The `zip` property represents a zip file encoded via Base64. Note that not all coordinators support backup (`coordinator_backup.json`), see [coordinators](../adapters/README.md) for more details.
 
 #### zigbee2mqtt/bridge/request/install_code/add
 

--- a/docs/guide/usage/touchlink.md
+++ b/docs/guide/usage/touchlink.md
@@ -1,6 +1,6 @@
 # Touchlink
 
-**Important:** The touchlinking function **only** works with Zigbee Coordinator adapters based on a Texas Instruments ZNP adapters (TI chips starting with "CC", e.g. CC2652) and Silicon Labs EZSP adapters (Silabs chips starting with "EFR32", e.g. EFR32MG21) with touchlink enabled in the Zigbee Coordinator firmware.
+**Important:** The touchlinking function **only** works with Zigbee Coordinator coordinators based on a Texas Instruments ZNP coordinators (TI chips starting with "CC", e.g. CC2652) and Silicon Labs EZSP coordinators (Silabs chips starting with "EFR32", e.g. EFR32MG21) with touchlink enabled in the Zigbee Coordinator firmware.
 
 Touchlink is a feature of Zigbee which allows devices physically close to each other to communicate with each other **without** being in the same network.
 

--- a/navbar.ts
+++ b/navbar.ts
@@ -16,7 +16,7 @@ export const navbar: NavbarConfig = [
             '/guide/getting-started/',
             {
                 link: '/guide/adapters/',
-                text: 'Supported Adapters',
+                text: 'Supported Coordinators',
                 activeMatch: '(/guide/adapters/|/guide/supported-hardware)',
             },
             {
@@ -43,7 +43,7 @@ export const navbar: NavbarConfig = [
         children: [
             {text: 'Zigbee', children: getFiles('advanced/zigbee')},
             {text: 'Support new devices', children: getFiles('advanced/support-new-devices')},
-            {text: 'Remote Adapter', children: getFiles('advanced/remote-adapter')},
+            {text: 'Remote Coordinator', children: getFiles('advanced/remote-adapter')},
             {text: 'More', children: getFiles('advanced/more')},
         ],
     },

--- a/sidebar.ts
+++ b/sidebar.ts
@@ -8,7 +8,7 @@ export const sidebar: SidebarOptions = {
             text: 'Supported Hardware',
             link: '/guide/supported-hardware.md',
             children: [
-                {text: 'Adapters', link: '/guide/adapters/'},
+                {text: 'Coordinators', link: '/guide/adapters/'},
                 {text: 'Devices', link: '/supported-devices/'},
             ],
         },


### PR DESCRIPTION
Zigbee implies 3 types of devices:

- **Zigbee Coordinator (ZC)**
-- There is exactly one coordinator in each Zigbee network.
-- Responsible for initiating and configuring the network (choosing channel, PAN ID, etc.).
-- Can route packets and also act as a parent for end devices.
-- Typically has more memory and power resources compared to the other devices.

- **Zigbee Router (ZR)**
-- Optional device type; can exist in a network to help relay data.
-- Can route packets on behalf of other devices.
-- Can act as a parent to End Devices, allowing them to join the network and forward their messages.

- **Zigbee End Device (ZED)**
-- Optional device type; can exist in a network.
-- Has the most limited functionality: cannot route packets for others; only communicates with its parent (Coordinator or Router).
-- Typically optimized for low power, can “sleep” to conserve energy.
-- Suitable for simple sensor nodes or actuators.

The “adapter” can operate in multiple modes (ZC, ZR, and even ZED (for example, to control its onboard LED)). Therefore, it makes more sense to use the term “Coordinator” instead of “Adapter.”

I propose changing only the frontend and leaving the backend (e.g., page names, etc.) as is, so as not to affect search engine rankings.