### PR TITLE
Add pairing instructions for Paulmann 500.48

### DIFF
--- a/docs/devices/500.48.md
+++ b/docs/devices/500.48.md
@@ -24,6 +24,13 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Pairing
+
+* Connect an LED strip to the controller
+* Connect the power supply (>5s): Check if the LED strip lights up
+* Repeat the following sequence **5x** by un- and replugging the power supply: Off > 3s, On < 2s
+
+If the device successfully enters pairing mode, the LED strip should show a breath pattern for 10s. If the LEDs show any other pattern, such as solid light or blink quite fast, power off the LED strip and repeat the pairing sequence.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/500.48.md
+++ b/docs/devices/500.48.md
@@ -30,7 +30,7 @@ pageClass: device-page
 * Connect the power supply (>5s): Check if the LED strip lights up
 * Repeat the following sequence **5x** by un- and replugging the power supply: Off > 3s, On < 2s
 
-If the device successfully enters pairing mode, the LED strip should show a breath pattern for 10s. If the LEDs show any other pattern, such as solid light or blink quite fast, power off the LED strip and repeat the pairing sequence.
+If the device successfully enters pairing mode, the LED strip should show a slow "breathe" blink pattern for 10s. If the LEDs show any other pattern, such as solid light or blink quite fast, power off the LED strip and repeat the pairing sequence.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
As depicted in vendor documentation:
https://content.paulmann.com/media/98/c4/7f/1600991028/50048_V01.pdf

I've added some notes on validating the device (properly) entered pairing mode properly since I had to take a couple of attempts.