### PR TITLE
Update DJT11LM.md - Clarification regarding calibration behavior

### DIFF
--- a/docs/devices/DJT11LM.md
+++ b/docs/devices/DJT11LM.md
@@ -71,9 +71,19 @@ In order to improve the factory calibration or lack thereof, you can get a bette
   * Set the offset for z to the opposite of ``z_axis``
 You can fine tune the values of the offset by trying other sides and picking values that match best.
 Remember that the device sends accelerometer values a few seconds after the actual tilt event.
+
+
+**Important note on software-based calibration**  
+The calibration offsets (`x_calibration`, `y_calibration`, `z_calibration`) are only applied **inside** Zigbee2MQTT after the sensor has already sent its raw data. This means:
+
+
+**Raw values** (`x_axis`, `y_axis`, `z_axis`) in logs, MQTT messages, and the Zigbee2MQTT UI will remain the same as reported by the hardware.  
+- The offsets will *not* change what Home Assistant (or other software) sees if you are directly reading those raw properties.  
+- If you want to work with the "corrected" or "calibrated" values in another system (e.g., Home Assistant), you would need to create a [template sensor](https://www.home-assistant.io/integrations/template/) or otherwise apply the offsets yourself.  
+- Seeing the same raw numbers after setting offsets does **not** mean calibration isn't working—it's simply that the sensor output itself is never altered by the offsets.
+
+
 <!-- Notes END: Do not edit below this line -->
-
-
 
 ## Options
 *[How to use device type specific configuration](../guide/configuration/devices-groups.md#specific-device-options)*


### PR DESCRIPTION
This update adds a detailed note clarifying that x_calibration, y_calibration, and z_calibration in Zigbee2MQTT do not alter the raw sensor data reported by the Aqara DJT11LM. Instead, these offsets are applied internally for certain calculations, which can lead users to think calibration hasn't worked when they still see unmodified x_axis/y_axis/z_axis values.