### PR TITLE
Update binding instructions for Phillips Dimmer 929002398602

### DIFF
--- a/docs/devices/929002398602.md
+++ b/docs/devices/929002398602.md
@@ -55,7 +55,22 @@ When endpoint `1` is bound to a light or a group of lights, the behavior is as f
 | Brightness up | Long | Smoothly increase the brightness | In steps of 63 points (around 25%), using the `commandStep` command with `{"stepmode":0,"stepsize":63,"transtime":9}` payload.<br>Sends the `commandStop` command, on button release. |
 | Brightness down | Single | Step down the brightness | In steps of 30 points (around 12%), using the `commandStep` command with `{"stepmode":1,"stepsize":30,"transtime":9}` payload. |
 | Brightness down | Long | Smoothly decrease the brightness | In steps of 63 points (around 25%), using the `commandStep` command with `{"stepmode":1,"stepsize":63,"transtime":9}` payload.<br>Sends the `commandStop` command, on button release. |
-| Hue | Single | Switch between scenes | The device keeps track of each press, alternating between two scenes (`"sceneid":1` and `"sceneid":2`) in a predetermined group with `"groupid":43632`, using the `commandRecall` command. |
+| Hue | Single | Switch between scenes | The device keeps track of each press, alternating between two scenes (`"sceneid":1` and `"sceneid":2`) in a predetermined group with a groupID specific to the particular device¹ using the `commandRecall` command. |
+
+¹ To obtain the groupID and set up the binding, you need to follow these steps:
+
+- turn on debug level logging in Zigbee2MQTT
+- make sure dimmer is paired
+- in Bind settings for the dimmer, unbind everything not `Scenes` and bind `Scenes` cluster between dimmer and coordinator
+- in logs filter for `scene` as the amount of debug messages is very high
+- press the `Hue` button on the remote
+- you will see a debug level message looking like `debug 2025-03-11 11:00:52z2m: Received Zigbee message from 'Dimmer - Bathroom', type 'commandRecall', cluster 'genScenes', data '{"groupid":14719,"sceneid":0}' from endpoint 1 with groupID 14719`
+- this will be slightly different for your device, read your `groupID`
+- create a group with this `groupID` and add the lights you want to bind to the dimmer to this group
+- save two scenes in this group with sceneIDs `0` and `1`
+- bind the dimmer to the newly created group with matching `groupID` making sure `Scenes` cluster is also bound
+- the `Hue` button should now alternate between the two stored scenes on repeat presses, and also recall one of the predetermined scenes even when the group is turned off
+
 
 ### Troubleshooting
 


### PR DESCRIPTION
This PR attempts to add detailed binding steps to enable the scene functionality of the Hue button also known as button 4.

The instructions were collected from the comments on https://github.com/Koenkk/zigbee-herdsman-converters/pull/3815 and extended upon. I verified their correctness myself while encountering the situation described in https://github.com/Koenkk/zigbee2mqtt/issues/25363 and successfully resolving it.