### PR TITLE
Documentation/zbm5 1 c 120/action states with state commands

### DIFF
--- a/docs/devices/ZBM5-1C-120.md
+++ b/docs/devices/ZBM5-1C-120.md
@@ -85,7 +85,7 @@ It's not possible to read (`/get`) or write (`/set`) this value.
 The possible values are: `toggle_l1`.
 
 State change (e.g., a `state` command sent).
-When changing the state via a sent command, the action will publish one of the following values: on_l1, off_l1.
+When changing the state via a sent command, the action will publish one of the following values: `on_l1`, `off_l1`.
 
 |                  | toggle_l1 | on_l1 | off_l1 |
 | ---------------- |:---------:|:-----:|:------:|

--- a/docs/devices/ZBM5-1C-120.md
+++ b/docs/devices/ZBM5-1C-120.md
@@ -84,3 +84,10 @@ Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The possible values are: `toggle_l1`.
 
+State change (e.g., a `state` command sent).
+When changing the state via a sent command, the action will publish one of the following values: on_l1, off_l1.
+
+|                  | toggle_l1 | on_l1 | off_l1 |
+| ---------------- |:---------:|:-----:|:------:|
+| Triggered action |     ●     |       |        |
+| State change     |           |   ●   |    ●   |


### PR DESCRIPTION
There are some states missing for this device that get sent out when you change the on off state by sending the state on or off commands.
When the state command turns the switch off it publishes the action off_l1 and when it turns it on, then it sends on_l1