### PR TITLE
Workaround for "failed interview" in E1525_E1745.md

### DIFF
--- a/docs/devices/E1525_E1745.md
+++ b/docs/devices/E1525_E1745.md
@@ -30,7 +30,16 @@ pageClass: device-page
 Pair the sensor to Zigbee2MQTT by pressing the pair button 4 short times.
 The red light on the front side should flash a few times and then turn off. After a couple of seconds it will turn on again and pulsate to indicate that the pairing is in process. When connected, the light turns off.
 
-A long press of 10 seconds on the pair button will enter the Zigbee Light Link (ZLL) pairing mode. Use this if you don't want to pair the device to Zigbee2MQTT and instead to a smart light bulb directly. 
+A long press of 10 seconds on the pair button will enter the Zigbee Light Link (ZLL) pairing mode. Use this if you don't want to pair the device to Zigbee2MQTT but instead bind the sensor to a smart light bulb directly. 
+
+### Re-pairing
+
+This sensor might fail to rejoin the network after the batteries expire, and removing and re-adding it fails with the message "Error: Interview failed because can not get active endpoints". This could happen to devices that have been bound to a Zigbee group. The device can be re-added with these steps
+
+1. Remove the batteries from the device
+2. Remove the device via the zigbee2mqtt UI, with force: "yes"
+3. Turn on "Permit Join" in zigbee2mqtt
+4. Add the batteries back to the device, and do 4 short presses of the pair button if necessary
 
 ### Binding
 #### Warning! You need to activate the motion sensor and then immediately press bind in the Zigbee2MQTT interface. If the sensor is sleeping the bind will fail. credits: [issue #3831](https://github.com/Koenkk/zigbee2mqtt/issues/3831)


### PR DESCRIPTION
This describes a workaround for a "failed interview" trying to re-add a previously working sensor to Z2M after the device batteries expire and are replaced. It is possibly happening to devices that have device bindings. 

I found the work around in this github issue: https://github.com/Koenkk/zigbee2mqtt/issues/12422#issuecomment-2178391096