### PR TITLE
fix: soil electrical conductivity unit is µS/cm (microsiemens per centimetre)

### DIFF
--- a/docs/devices/NAS-STH02B2.md
+++ b/docs/devices/NAS-STH02B2.md
@@ -48,7 +48,7 @@ Soil electrical conductivity.
 Value can be found in the published state on the `ec` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The minimal value is `0` and the maximum value is `20000`.
-The unit of this value is `us/cm`.
+The unit of this value is `µS/cm`.
 
 ### Fertility (enum)
 Soil fertility.


### PR DESCRIPTION
Related to https://github.com/Koenkk/zigbee-herdsman-converters/pull/9061