### PR TITLE
Update SAGE206612.md - pairing instructions

### DIFF
--- a/docs/devices/SAGE206612.md
+++ b/docs/devices/SAGE206612.md
@@ -24,6 +24,8 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Pairing
+Press and hold the reset button while inserting the battery. Hold until the LED starts blinking, this will force a reset/join. The LED will continue blinking to indicate its pairing.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
Add pairing instructions.

Press and hold the reset button while inserting the battery. Hold until the LED starts blinking, this will force a reset/join. The LED will continue blinking to indicate its pairing.