### PR TITLE
Busch-Jaeger 6735/6736/6737: Add note regarding brightness

### DIFF
--- a/docs/devices/6735_6736_6737.md
+++ b/docs/devices/6735_6736_6737.md
@@ -57,6 +57,20 @@ By default all bindings should be set up so the device reports button events thr
 
 You should also use a ZigBee group even if you only want to bind to a single light! This way Zigbee2MQTT will continue to publish the button events, even without an explicit binding to the coordinator.
 
+#### Relay exposed as dimmable light
+
+When the 6735/6736/6737 devices are installed on a relay instead of a dimmer backend they are still exposed as a *dimmable* light. The reason for that is that there is no way to distinguish the relay from the dimmer at the ZigBee level. If you are using Home Assistant and don't want to expose the brightness feature, you can configure this in the configuration file:
+
+```yaml
+'0xd85devicemac':
+  filtered_attributes:
+    - brightness
+    - brightness_relay
+  homeassistant:
+    light_relay:
+      brightness: false
+```
+
 #### Duplicate events for battery-operated control panel
 
 The battery-operated wall switch might be sending duplicate `action` events. In this case you may want to set up debouncing for the device:


### PR DESCRIPTION
The devices will always expose dimming capabilities/brightness, even when installed on a relay instead of a dimmer. Add possible workaround to docs for people who want to hide the brightness feature.