### PR TITLE
Update 33943_33944_33946.md add pairing instructions

### DIFF
--- a/docs/devices/33943_33944_33946.md
+++ b/docs/devices/33943_33944_33946.md
@@ -111,7 +111,7 @@ The possible values are: `off`, `on`, `toggle`, `previous`.
 
 ### Pairing
 
-To pair or reset this device for Zigbee pairing mode, at least for :
+To pair or reset this device for Zigbee pairing mode:
 
 1. Turn the device **off** for at least 30 seconds.
 2. Perform the following power cycle sequence using the wall switch:

--- a/docs/devices/33943_33944_33946.md
+++ b/docs/devices/33943_33944_33946.md
@@ -108,3 +108,22 @@ To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"power_on_behavior": NEW_VALUE}`.
 The possible values are: `off`, `on`, `toggle`, `previous`.
 
+
+### Pairing
+
+To pair or reset this device for Zigbee pairing mode, at least for :
+
+1. Turn the device **off** for at least 30 seconds.
+2. Perform the following power cycle sequence using the wall switch:
+   - **On** for 1 second
+   - **Off** for 6 seconds
+   - **On** for 1 second
+   - **Off** for 6 seconds
+   - **On** for 1 second
+   - **Off** for 6 seconds
+   - **On** for 12 seconds
+   - **Off** for 6 seconds
+   - Finally turn **on** and leave it on
+3. The device will blink to indicate it is in pairing mode.
+
+Repeat the sequence if it does not enter pairing mode the first time.

--- a/docs/devices/33943_33944_33946.md
+++ b/docs/devices/33943_33944_33946.md
@@ -123,6 +123,8 @@ To pair or reset this device for Zigbee pairing mode:
    - **Off** for 6 seconds
    - **On** for 12 seconds
    - **Off** for 6 seconds
+   - **On** for 12 seconds
+   - **Off** for 6 seconds
    - Finally turn **on** and leave it on
 3. The device will blink to indicate it is in pairing mode.
 

--- a/docs/devices/33943_33944_33946.md
+++ b/docs/devices/33943_33944_33946.md
@@ -23,8 +23,28 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+### Pairing
 
+To pair or reset this device for Zigbee pairing mode:
+
+1. Turn the device **off** for at least 30 seconds.
+2. Perform the following power cycle sequence using the wall switch:
+   - **On** for 1 second
+   - **Off** for 6 seconds
+   - **On** for 1 second
+   - **Off** for 6 seconds
+   - **On** for 1 second
+   - **Off** for 6 seconds
+   - **On** for 12 seconds
+   - **Off** for 6 seconds
+   - **On** for 12 seconds
+   - **Off** for 6 seconds
+   - Finally turn **on** and leave it on
+3. The device will blink to indicate it is in pairing mode.
+
+Repeat the sequence if it does not enter pairing mode the first time.
 <!-- Notes END: Do not edit below this line -->
 
 ## Warning: degrades network performance
@@ -108,24 +128,3 @@ To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"power_on_behavior": NEW_VALUE}`.
 The possible values are: `off`, `on`, `toggle`, `previous`.
 
-
-### Pairing
-
-To pair or reset this device for Zigbee pairing mode:
-
-1. Turn the device **off** for at least 30 seconds.
-2. Perform the following power cycle sequence using the wall switch:
-   - **On** for 1 second
-   - **Off** for 6 seconds
-   - **On** for 1 second
-   - **Off** for 6 seconds
-   - **On** for 1 second
-   - **Off** for 6 seconds
-   - **On** for 12 seconds
-   - **Off** for 6 seconds
-   - **On** for 12 seconds
-   - **Off** for 6 seconds
-   - Finally turn **on** and leave it on
-3. The device will blink to indicate it is in pairing mode.
-
-Repeat the sequence if it does not enter pairing mode the first time.


### PR DESCRIPTION
I had a hard time finding my pairing instructions for my EGLO branded product, hopefully others will find it helpful.

Source: https://www.eglo.com/en/connect-z-general-q2

I hope someone with an AwoX branded product can confirm that these instructions also work for them before this gets merged, as i have the suspicious its just rebranding/re-using off the same controller hence my EGLO light strip shows up at this one. 
This is my specific device: https://www.eglo.com/media/catalog/product/dam/BDA/99686_BDA.pdf that shows as this model in zigbee2mqtt

First PR here, if i missed anything let me know, couldn't find an issue template to fill out or anything so I hope this covers everything.