### PR TITLE
Add more information on how to successfully pair the aqara pet feeder C1 aka ZNCWWSQ01LM

### DIFF
--- a/docs/devices/ZNCWWSQ01LM.md
+++ b/docs/devices/ZNCWWSQ01LM.md
@@ -28,6 +28,8 @@ pageClass: device-page
 ### Pairing
 
 To put the device in pairing mode, hold the reset button for 5 seconds. The LED light should blink quickly and it makes a beep sound once paired.
+
+Some users required waiting until the pet feeder performs two audible beeps before turning pairing on in z2m for the device to join the mesh.
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
I added more information on how to successfully pair the device - I was unable to get two of these to join my mesh until I waited for the beeps then started pairing. I saw a lot of reddit threads saying they cant be rejoined to a mesh blah blah.. seems this workaround works fine.