### PR TITLE
Updates pairing instructions for Moes ZS-EUB_2gang

### DIFF
--- a/docs/devices/ZS-EUB_2gang.md
+++ b/docs/devices/ZS-EUB_2gang.md
@@ -25,7 +25,8 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
 This device does not act as a Zigbee router, even when the optional neutral connection is used. In addition the vendor does not provide a firmware update to enable the router functionality.
-Pairing.
+
+### Pairing
 
 Press and hold the _left_ switch for 7 seconds, until the indicator on the switch flashes fast. After about 3 seconds pairing should be complete.
 

--- a/docs/devices/ZS-EUB_2gang.md
+++ b/docs/devices/ZS-EUB_2gang.md
@@ -24,6 +24,10 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+This device does not act as a Zigbee router, even when the optional neutral connection is used. In addition the vendor does not provide a firmware update to enable the router functionality.
+Pairing.
+
+Press and hold the _left_ switch for 7 seconds, until the indicator on the switch flashes fast. After about 3 seconds pairing should be complete.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
This pull request updates the pairing instructions for [Moes ZS-EUB_2gang](https://www.zigbee2mqtt.io/devices/ZS-EUB_2gang.html#moes-zs-eub-2gang).

I've based them on the pairing instructions of [[Moes ZS-EUB_1gang](https://www.zigbee2mqtt.io/devices/ZS-EUB_1gang.html#moes-zs-eub-1gang), with the addition that for the dual switch, the left switch should be used to enter pairing mode. The other instructions are identical, can confirm this as i own the device mysql.