### PR TITLE
add pairing tips for SJCGQ11LM

### DIFF
--- a/docs/devices/SJCGQ11LM.md
+++ b/docs/devices/SJCGQ11LM.md
@@ -31,6 +31,13 @@ Uses CR2032 battery.
 ### Pairing
 Press and hold the reset button by pressing hard on the top of the device (water drop logo) for +- 5 seconds (until the blue light inside the device, under the water drop starts blinking). After this the device will automatically join.
 In some cases, the sensor may not want to pair. Remove the battery and while you put it back in, keep the reset button pressed until the paring is complete.
+
+> [!NOTE]
+> In case you experience pairing issues:
+> - Try to press the reset button +-5 seconds until it flashes, wait 1 second, push the button short 2x times to enforce communication.
+> - If migrating the device from another network, turn off the old network before pairing with the new one.
+
+
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
Solves https://github.com/Koenkk/zigbee2mqtt/issues/27405

I tried to move the device between two different networks. Using the described pairing procedure failed more than 10 times. It was impossible to pair the device with the new Zigbee network. I also tried removing the battery, but that didn't help, too. However, rejoining the old network was easily possible.

I found that you need to completely shut down the old network in order to connect the device to the new one. I was able to reproduce this behavior with two of these devices.
