### PR TITLE
Update E2134.md with illuminance behavior

### DIFF
--- a/docs/devices/E2134.md
+++ b/docs/devices/E2134.md
@@ -32,7 +32,12 @@ The red light on the front side should flash a few times and then turn off.
 After a few seconds it turns back on and pulsate. When connected, the light turns off.
 
 ### Common problems
+
+#### Use of alkaline batteries
 Many has experienced using 1.2v AAA batteries (instead of the common 1.5v) makes the device behave correctly. Using 1.5v might result in unexpected behavior like unable to connect and false-positive motion detection.
+
+#### Illuminance Sensor Saturation Limit
+The VALLHORN's built-in lux sensor saturates at 1364 lx. Any incident light above this level - common in direct sunlight or bright overcast conditions - will still be reported as 1364 lx. When deploying the device outdoors, treat 1364 lx as a ">=" indicator and design your logic accordingly (e.g. by treating repeated 1364 lx readingas as "full daylight" rather than a precise value)
 
 ### Mods
 As an alternative to the use of 1.2V batteries as mentioned above, the battery voltage of normal batteries can also be reduced by using a diode. Experienced user can insert a diode in series in the battery circuit at the point marked in red. An MBR0520, for example, with a Vf of 0.45V worked well here. Other types will probably work well too. At the point shown in the photo, the conductor track must be scratched/split open and the diode inserted as a bridge between the battery plate and the soldering point of the polyfuse (FR1). Please note the direction! Alternatively, the polyfuse (FR1) can be removed and the diode inserted instead, then you don't have to sratch the conductor. 


### PR DESCRIPTION
Add description that the VALLHORN illuminance sensor saturates at 1364lx (low overcast daylight)