### PR TITLE
Leviton DG6HD-1BW pairing notes

### DIFF
--- a/docs/devices/DG6HD-1BW.md
+++ b/docs/devices/DG6HD-1BW.md
@@ -24,6 +24,13 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Notes
+
+### Pairing
+
+1. Hold the top of the paddle for 7 seconds. Status light will turn amber.
+2. To start joining mode tap the top of the paddle 1 time. The status light will ﬂash green rapidly to indicate it is in joining mode.
+3. To stop joining mode tap the top of the paddle 1 time. The dimmer will leave joining mode.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
Adding pairing notes for Leviton DG6HD-1BW devices.

 [source](https://www.manualslib.com/manual/2594078/Leviton-Decora-Smart-Dg6hd.html?page=13#manual)