### PR TITLE
Update deconz.md

### DIFF
--- a/docs/guide/adapters/deconz.md
+++ b/docs/guide/adapters/deconz.md
@@ -1,18 +1,11 @@
 # deCONZ (Dresden Elektronik)
 
 ::: warning ATTENTION
-The implementation of this adapter is **not maintained** anymore.
-Consider buying one of the recommended adapters instead.
-:::
-
-::: warning ATTENTION
 Various features are not supported by this adapter, in case you depend on these features, consider a different adapter.
 
-- [Changing the channel](../configuration/zigbee-network.md#changing-the-zigbee-channel), changing requires re-pairing all devices.
 - Adding [install codes](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestinstall_codeadd), which is required to pair some devices.
-- [Backups](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestbackup)
 - Inter-PAN, which is required for [touchlink](../../guide/usage/touchlink.md)
-- Changing the [transmit power](../../guide/configuration/adapter-settings.md)
+- Lowering the [transmit power](../../guide/configuration/adapter-settings.md)
 
 :::
 
@@ -23,7 +16,7 @@ serial:
     adapter: deconz
 ```
 
-Other supported settings are: `adapter_concurrent` and `adapter_delay` ([docs](../configuration/adapter-settings.md)).
+Other supported settings are: `baudrate` ([docs](../configuration/adapter-settings.md)).
 
 ## Hardware
 
@@ -37,7 +30,14 @@ Add the correct baudrate to the `configuration.yaml` into the serial section.
 - For RaspBee2 it is 38400
 - For ConBee3 it is 115200
 
+<!--
+NOTE(manup) 2025-07-20: Following warning is **very** problematic advice as the old firmware doesn't handle some newer devices well and has various bugs which where ironed out by later versions.
+The 0x26780700 stable version is highly recommended to work solid with the new adapter rewrite.
+
+Reference: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Firmware-Changelog
+
 **Warning:** Conbee 2 firmware versions newer than 0x26580700 will result in an unstable network with devices dropping randomly, see [Issue 9554](https://github.com/Koenkk/zigbee2mqtt/issues/9554)
+-->
 
 - [Coordinator firmware](https://deconz.dresden-elektronik.de/deconz-firmware/)
 - [Flashing](https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Update-deCONZ-manually)


### PR DESCRIPTION
Updated Attention section removing the missing features Backup and Channel Change which are addressed in adapter rewrite.

I've also commented out the very misleading advice to use old firmware version 0x26580700 for ConBee II (see note in the HTML comment).

0x26780700 is the recommended stable version which fixes many problems and should work solid with the new adapter rewrite (https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Firmware-Changelog#conbee-ii-and-raspbee-ii-r21).