### PR TITLE
Fix Helm chart URL.

### DIFF
--- a/docs/guide/installation/08_kubernetes.md
+++ b/docs/guide/installation/08_kubernetes.md
@@ -56,7 +56,7 @@ metadata:
     namespace: flux-system
 spec:
     interval: 10m
-    url: https://charts.zigbee2mqtt.io/index
+    url: https://charts.zigbee2mqtt.io
 ```
 
 Then create a Helm release:


### PR DESCRIPTION
Delete /index at the end of the URL, as it is not working this way.