### PR TITLE
Fix broken OSRAM device pairing links

### DIFF
--- a/docs/devices/4052899926158.md
+++ b/docs/devices/4052899926158.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 
 ### Pairing
-Follow instruction from [Manual reset](http://belkin.force.com/Articles/articles/en_US/Troubleshooting_and_Tutorials/Resetting-the-OSRAM-LIGHTIFY-Tunable-White-60-Bulb#a).
+Follow instruction from [Manual reset](https://www.belkin.com/support-article/?articleNum=159344).
 After resetting the bulb will automatically connect.
 
 

--- a/docs/devices/4058075816718.md
+++ b/docs/devices/4058075816718.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 
 ### Pairing
-Follow instruction from [Manual reset](http://belkin.force.com/Articles/articles/en_US/Troubleshooting_and_Tutorials/Resetting-the-OSRAM-LIGHTIFY-Tunable-White-60-Bulb#a).
+Follow instruction from [Manual reset](https://www.belkin.com/support-article/?articleNum=159344).
 After resetting the bulb will automatically connect.
 
 

--- a/docs/devices/4058075816794.md
+++ b/docs/devices/4058075816794.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 
 ### Pairing
-Follow instruction from [Manual reset](http://belkin.force.com/Articles/articles/en_US/Troubleshooting_and_Tutorials/Resetting-the-OSRAM-LIGHTIFY-Tunable-White-60-Bulb#a).
+Follow instruction from [Manual reset](https://www.belkin.com/support-article/?articleNum=159344).
 After resetting the bulb will automatically connect.
 
 

--- a/docs/devices/AA68199.md
+++ b/docs/devices/AA68199.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 
 ### Pairing
-Follow instruction from [Manual reset](http://belkin.force.com/Articles/articles/en_US/Troubleshooting_and_Tutorials/Resetting-the-OSRAM-LIGHTIFY-Tunable-White-60-Bulb#a).
+Follow instruction from [Manual reset](https://www.belkin.com/support-article/?articleNum=159344).
 After resetting the bulb will automatically connect.
 
 

--- a/docs/devices/AA69697.md
+++ b/docs/devices/AA69697.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 
 ### Pairing
-Follow instruction from [Manual reset](http://belkin.force.com/Articles/articles/en_US/Troubleshooting_and_Tutorials/Resetting-the-OSRAM-LIGHTIFY-Tunable-White-60-Bulb#a).
+Follow instruction from [Manual reset](https://www.belkin.com/support-article/?articleNum=159344).
 After resetting the bulb will automatically connect.
 
 

--- a/docs/devices/AA70155.md
+++ b/docs/devices/AA70155.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 
 ### Pairing
-Follow instruction from [Manual reset](http://belkin.force.com/Articles/articles/en_US/Troubleshooting_and_Tutorials/Resetting-the-OSRAM-LIGHTIFY-Tunable-White-60-Bulb#a).
+Follow instruction from [Manual reset](https://www.belkin.com/support-article/?articleNum=159344).
 After resetting the bulb will automatically connect.
 
 

--- a/docs/devices/AB32840.md
+++ b/docs/devices/AB32840.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 
 ### Pairing
-Follow instruction from [Manual reset](http://belkin.force.com/Articles/articles/en_US/Troubleshooting_and_Tutorials/Resetting-the-OSRAM-LIGHTIFY-Tunable-White-60-Bulb#a).
+Follow instruction from [Manual reset](https://www.belkin.com/support-article/?articleNum=159344).
 After resetting the bulb will automatically connect.
 
 

--- a/docs/devices/AB35996.md
+++ b/docs/devices/AB35996.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 
 ### Pairing
-Follow instruction from [Manual reset](http://belkin.force.com/Articles/articles/en_US/Troubleshooting_and_Tutorials/Resetting-the-OSRAM-LIGHTIFY-Tunable-White-60-Bulb#a).
+Follow instruction from [Manual reset](https://www.belkin.com/support-article/?articleNum=159344).
 After resetting the bulb will automatically connect.
 
 

--- a/docs/devices/AB401130055.md
+++ b/docs/devices/AB401130055.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 
 ### Pairing
-Follow instruction from [Manual reset](http://belkin.force.com/Articles/articles/en_US/Troubleshooting_and_Tutorials/Resetting-the-OSRAM-LIGHTIFY-Tunable-White-60-Bulb#a).
+Follow instruction from [Manual reset](https://www.belkin.com/support-article/?articleNum=159344).
 After resetting the bulb will automatically connect.
 
 

--- a/docs/devices/AC03642.md
+++ b/docs/devices/AC03642.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 
 ### Pairing
-Follow instruction from [Manual reset](http://belkin.force.com/Articles/articles/en_US/Troubleshooting_and_Tutorials/Resetting-the-OSRAM-LIGHTIFY-Tunable-White-60-Bulb#a).
+Follow instruction from [Manual reset](https://www.belkin.com/support-article/?articleNum=159344).
 After resetting the bulb will automatically connect.
 
 

--- a/docs/devices/AC03645.md
+++ b/docs/devices/AC03645.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 
 ### Pairing
-Follow instruction from [Manual reset](http://belkin.force.com/Articles/articles/en_US/Troubleshooting_and_Tutorials/Resetting-the-OSRAM-LIGHTIFY-Tunable-White-60-Bulb#a).
+Follow instruction from [Manual reset](https://www.belkin.com/support-article/?articleNum=159344).
 After resetting the bulb will automatically connect.
 
 

--- a/docs/devices/AC03648.md
+++ b/docs/devices/AC03648.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 
 ### Pairing
-Follow instruction from [Manual reset](http://belkin.force.com/Articles/articles/en_US/Troubleshooting_and_Tutorials/Resetting-the-OSRAM-LIGHTIFY-Tunable-White-60-Bulb#a).
+Follow instruction from [Manual reset](https://www.belkin.com/support-article/?articleNum=159344).
 After resetting the bulb will automatically connect.
 
 

--- a/docs/devices/AC08562.md
+++ b/docs/devices/AC08562.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 
 ### Pairing
-Follow instruction from [Manual reset](http://belkin.force.com/Articles/articles/en_US/Troubleshooting_and_Tutorials/Resetting-the-OSRAM-LIGHTIFY-Tunable-White-60-Bulb#a).
+Follow instruction from [Manual reset](https://www.belkin.com/support-article/?articleNum=159344).
 After resetting the bulb will automatically connect.
 
 


### PR DESCRIPTION
## Summary
- Fixed broken Belkin force.com URLs that were returning 404 errors
- Updated 13 OSRAM LIGHTIFY device documentation files with current Belkin support article URLs