### PR TITLE
Update groups guide to reflect 2.0.0 change

### DIFF
--- a/docs/guide/usage/groups.md
+++ b/docs/guide/usage/groups.md
@@ -11,11 +11,11 @@ Groups are much more efficient than controlling devices separately as it signifi
 
 ## Creating a group
 
-Groups can be created via the frontend (easiest), [MQTT](./mqtt_topics_and_messages.md#zigbee2mqttbridgerequestgroupadd) or by adding them to the `configuration.yaml` as shown below.
+Groups can be created via the frontend (easiest), or [MQTT](./mqtt_topics_and_messages.md#zigbee2mqttbridgerequestgroupadd).
 
 ## Configuration
 
-Add the following to your `configuration.yaml`.
+The following is a reflection of the state in yaml, it cannot be added to `configuration.yaml`:
 
 ```yaml
 groups:


### PR DESCRIPTION
In verison 2.0.0, the ability to configure groups by configuration.yaml was removed.

See discussion at https://github.com/Koenkk/zigbee2mqtt/discussions/24198

> Removed configuring group members through configuration.yaml (groups.devices setting). This will not impact current group members; however, you will no longer be able to add or remove devices from a group through the configuration.yaml.

To save others wasting an hour of their life as I did, trying to get groups changes in configuration.yaml to work, let's update the guide to reflect this change.