### PR TITLE
Aqara dimmer H2: loss of network connection

### DIFF
--- a/docs/devices/KD-R01D.md
+++ b/docs/devices/KD-R01D.md
@@ -29,6 +29,9 @@ This device is shipped with Thread/Matter firmware. A smartphone, the Aqara Home
 
 ### Resetting:
 A double-click on the dimmer knob immediately followed by a 5-second long-press will reset the device and put it back into pairing mode. Make sure the gap between the double click and the long press does not exceed 3 seconds. The indicator light will flash blue when the reset was successful.
+
+### Network connection lost
+When the indicator ring flashes red, the device indicates a loss of network connection. Ensure the coordinator is up and running, and signal range to the coordinator or the next Zigbee router is good enough.
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
A red flashing indicator ring signals a connection loss to the Zigbee network.