### PR TITLE
Add min and max brightness at qa devices

### DIFF
--- a/docs/devices/QADZ1.md
+++ b/docs/devices/QADZ1.md
@@ -18,7 +18,7 @@ pageClass: device-page
 | Model | QADZ1  |
 | Vendor  | [QA](/supported-devices/#v=QA)  |
 | Description | Dimmer 1 channel |
-| Exposes | power_on_behavior, switch_type, light (state, brightness) |
+| Exposes | power_on_behavior, switch_type, light (state, brightness, min_brightness, max_brightness) |
 | Picture | ![QA QADZ1](https://www.zigbee2mqtt.io/images/devices/QADZ1.png) |
 
 
@@ -54,7 +54,7 @@ To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/
 The possible values are: `toggle`, `state`, `momentary`.
 
 ### Light 
-This light supports the following features: `state`, `brightness`.
+This light supports the following features: `state`, `brightness`, `min_brightness` and `max_brightness`.
 - `state`: To control the state publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"state": "ON"}`, `{"state": "OFF"}` or `{"state": "TOGGLE"}`. To read the state send a message to `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"state": ""}`.
 - `brightness`: To control the brightness publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"brightness": VALUE}` where `VALUE` is a number between `0` and `254`. To read the brightness send a message to `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"brightness": ""}`.
 

--- a/docs/devices/QADZ1.md
+++ b/docs/devices/QADZ1.md
@@ -54,7 +54,7 @@ To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/
 The possible values are: `toggle`, `state`, `momentary`.
 
 ### Light 
-This light supports the following features: `state`, `brightness`, `min_brightness` and `max_brightness`.
+This light supports the following features: `state`, `brightness`, `min_brightness`, `max_brightness`.
 - `state`: To control the state publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"state": "ON"}`, `{"state": "OFF"}` or `{"state": "TOGGLE"}`. To read the state send a message to `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"state": ""}`.
 - `brightness`: To control the brightness publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"brightness": VALUE}` where `VALUE` is a number between `0` and `254`. To read the brightness send a message to `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"brightness": ""}`.
 

--- a/docs/devices/QADZ2.md
+++ b/docs/devices/QADZ2.md
@@ -86,7 +86,7 @@ To do this send a payload like below to `zigbee2mqtt/FRIENDLY_NAME/set`
 ````
 
 ### Light (l2 endpoint)
-This light supports the following features: `state`, `brightness`.
+This light supports the following features: `state`, `brightness`, `min_brightness`, `max_brightness`.
 - `state`: To control the state publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"state_l2": "ON"}`, `{"state_l2": "OFF"}` or `{"state_l2": "TOGGLE"}`. To read the state send a message to `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"state_l2": ""}`.
 - `brightness`: To control the brightness publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"brightness_l2": VALUE}` where `VALUE` is a number between `0` and `254`. To read the brightness send a message to `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"brightness_l2": ""}`.
 

--- a/docs/devices/QADZ2.md
+++ b/docs/devices/QADZ2.md
@@ -18,7 +18,7 @@ pageClass: device-page
 | Model | QADZ2  |
 | Vendor  | [QA](/supported-devices/#v=QA)  |
 | Description | Dimmer 2 channel |
-| Exposes | power_on_behavior, switch_type, light (state, brightness) |
+| Exposes | power_on_behavior, switch_type, light (state, brightness, min_brightness, max_brightness) |
 | Picture | ![QA QADZ2](https://www.zigbee2mqtt.io/images/devices/QADZ2.png) |
 
 
@@ -54,7 +54,7 @@ To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/
 The possible values are: `toggle`, `state`, `momentary`.
 
 ### Light (l1 endpoint)
-This light supports the following features: `state`, `brightness`.
+This light supports the following features: `state`, `brightness`, `min_brightness`, `max_brightness`.
 - `state`: To control the state publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"state_l1": "ON"}`, `{"state_l1": "OFF"}` or `{"state_l1": "TOGGLE"}`. To read the state send a message to `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"state_l1": ""}`.
 - `brightness`: To control the brightness publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"brightness_l1": VALUE}` where `VALUE` is a number between `0` and `254`. To read the brightness send a message to `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"brightness_l1": ""}`.
 


### PR DESCRIPTION
I've tested that devices and they exposes that options: `min_brightness` and `max_brightness`