### PR TITLE
add note about defective capacitor causing Zigbee plug control issues

### DIFF
--- a/docs/devices/HG06338.md
+++ b/docs/devices/HG06338.md
@@ -35,6 +35,10 @@ While pairing, keep the 3 gang switch close to the adapter.
 
 ### Node-Red
 How to use the connector strip with Node-Red: Use the "command node" of the node-red-contrib-zigbee-package. Drop-down-lists are helping you with the configuration.
+
+### Defective Capacitor
+If you have problems with turning on and off the sockets or you notice that it has begun to turn the three sockets on and off irregularly, you may [check the capacitors](https://www.mittelleiter-magazin.de/technik/lidl-zigbee-smarthome-steckdosenleiste-reparieren/) (only in German).  
+You may encounter the following error message: `z2m: Publish 'set' 'state' to '{friendly_name}' failed: 'Error: ZCL command {IEEE-address} genOnOff.on({},`
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
Add troubleshooting section suggesting users check for faulty capacitors if sockets behave erratically or Zigbee2MQTT reports delivery failures when switching socket states. Include example error message for reference.