### PR TITLE
Update home_assistant.md

### DIFF
--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -241,26 +241,26 @@ script:
         alias: Zigbee2MQTT Rename
         icon: 'mdi:pencil'
         sequence:
-          - action: mqtt.publish
-            data:
-                topic: zigbee2mqtt/bridge/request/device/rename
-                payload: >-
-                    {
-                      "from": "{{ states('input_select.zigbee2mqtt_old_name_select') }}",
-                      "to": "{{ states('input_text.zigbee2mqtt_new_name') }}"
-                    }
+            - action: mqtt.publish
+              data:
+                  topic: zigbee2mqtt/bridge/request/device/rename
+                  payload: >-
+                      {
+                        "from": "{{ states('input_select.zigbee2mqtt_old_name_select') }}",
+                        "to": "{{ states('input_text.zigbee2mqtt_new_name') }}"
+                      }
     zigbee2mqtt_remove:
         alias: Zigbee2MQTT Remove
         icon: 'mdi:trash-can'
         sequence:
-          - action: mqtt.publish
-            data:
-                topic: zigbee2mqtt/bridge/request/device/remove
-                payload: >-
-                    {
-                      "id": "{{ states('input_select.zigbee2mqtt_remove_select') }}",
-                      "force": {{ 'true' if is_state('input_boolean.zigbee2mqtt_force_remove', 'on') else 'false' }}
-                    }
+            - action: mqtt.publish
+              data:
+                  topic: zigbee2mqtt/bridge/request/device/remove
+                  payload: >-
+                      {
+                        "id": "{{ states('input_select.zigbee2mqtt_remove_select') }}",
+                        "force": {{ 'true' if is_state('input_boolean.zigbee2mqtt_force_remove', 'on') else 'false' }}
+                      }
 
 automation:
     - id: 'zigbee2mqtt_create_notification_on_successful_interview'

--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -241,10 +241,10 @@ script:
         alias: Zigbee2MQTT Rename
         icon: 'mdi:pencil'
         sequence:
-            service: mqtt.publish
-            data_template:
+          - action: mqtt.publish
+            data:
                 topic: zigbee2mqtt/bridge/request/device/rename
-                payload_template: >-
+                payload: >-
                     {
                       "from": "{{ states('input_select.zigbee2mqtt_old_name_select') }}",
                       "to": "{{ states('input_text.zigbee2mqtt_new_name') }}"
@@ -253,13 +253,13 @@ script:
         alias: Zigbee2MQTT Remove
         icon: 'mdi:trash-can'
         sequence:
-            service: mqtt.publish
-            data_template:
+          - action: mqtt.publish
+            data:
                 topic: zigbee2mqtt/bridge/request/device/remove
-                payload_template: >-
+                payload: >-
                     {
                       "id": "{{ states('input_select.zigbee2mqtt_remove_select') }}",
-                      "force": {{ is_state('input_boolean.zigbee2mqtt_force_remove', 'on') }}
+                      "force": {{ 'true' if is_state('input_boolean.zigbee2mqtt_force_remove', 'on') else 'false' }}
                     }
 
 automation:


### PR DESCRIPTION
Controlling Zigbee2MQTT via Home Assistant -> data_template & payload_template has been removed in HA202502 https://www.home-assistant.io/blog/2025/02/05/release-20252/

force: wants true or false, not True or False