### PR TITLE
fix: remove temperature from SIRZB-111.md

### DIFF
--- a/docs/devices/SIRZB-111.md
+++ b/docs/devices/SIRZB-111.md
@@ -32,10 +32,6 @@ pageClass: device-page
 ## Options
 *[How to use device type specific configuration](../guide/configuration/devices-groups.md#specific-device-options)*
 
-* `temperature_calibration`: Calibrates the temperature value (absolute offset), takes into effect on next report of device. The value must be a number.
-
-* `temperature_precision`: Number of digits after decimal point for temperature, takes into effect on next report of device. This option can only decrease the precision, not increase it. The value must be a number with a minimum value of `0` and with a with a maximum value of `3`
-
 
 ## Exposes
 
@@ -80,13 +76,6 @@ Value will **not** be published in the state.
 It's not possible to read (`/get`) this value.
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"alarm": NEW_VALUE}`.
 If value equals `START` alarm is ON, if `OFF` OFF.
-
-### Temperature (numeric)
-Measured temperature value.
-Value can be found in the published state on the `temperature` property.
-To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"temperature": ""}`.
-It's not possible to write (`/set`) this value.
-The unit of this value is `°C`.
 
 ### Battery (numeric)
 Remaining battery in %.


### PR DESCRIPTION
Remove temperature since the device doesn't have it.

This is releated to: https://github.com/Koenkk/zigbee-herdsman-converters/pull/9796