### PR TITLE
Fix position of embedded images

### DIFF
--- a/docs/guide/adapters/flashing/flashing_the_cc2531.md
+++ b/docs/guide/adapters/flashing/flashing_the_cc2531.md
@@ -28,11 +28,12 @@ The following additional hardware is required in order to flash the CC2531:
 4. Connect **BOTH** the `CC2531 USB sniffer` and the `CC debugger` to your PC using USB.
 5. If the light on the CC debugger is RED press set reset button on the CC debugger. The light on the CC debugger should now turn GREEN. If not use [CC debugger user guide](http://www.ti.com/lit/ug/swru197h/swru197h.pdf) to troubleshoot your problem.
 
-   ![How to connect](../../../images/connected.jpg)
+    ![How to connect](../../../images/connected.jpg)
+
 6. Download the firmware [CC2531_DEFAULT_20211115.zip](https://github.com/Koenkk/Z-Stack-firmware/raw/Z-Stack_Home_1.2_20211115/20211116/coordinator/Z-Stack_Home_1.2/bin/default/CC2531_DEFAULT_20211115.zip)
 7. Start SmartRF Flash Programmer, setup as shown below and press `Perform actions`. Make sure to select the `.hex` file, not the `.bin` file!
 
-   ![SmartRF Flash Programmer](../../../images/smartrf.png)
+    ![SmartRF Flash Programmer](../../../images/smartrf.png)
 
 ## Linux or MacOS
 
@@ -93,7 +94,8 @@ make
 4. Connect **BOTH** the `CC2531 USB sniffer` and the `CC debugger` to your PC using USB.
 5. If the light on the CC debugger is RED, press the Reset button on the CC debugger. The light on the CC debugger should now turn GREEN. If not, try to reboot and retry or follow the [CC debugger user guide](http://www.ti.com/lit/ug/swru197h/swru197h.pdf) to troubleshoot your problem.
 
-   ![How to connect](../../../images/connected.jpg)
+    ![How to connect](../../../images/connected.jpg)
+
 6. Download the firmware [CC2531_DEFAULT_20211115.zip](https://github.com/Koenkk/Z-Stack-firmware/raw/Z-Stack_Home_1.2_20211115/20211116/coordinator/Z-Stack_Home_1.2/bin/default/CC2531_DEFAULT_20211115.zip).
 7. Flash your firmware:
 


### PR DESCRIPTION
On some lower resolutions, the images have some words in the same line (left of the image).
Moving the images to their own paragraph avoids this.

Screenshot of issue:
<img width="1250" height="927" alt="image" src="https://github.com/user-attachments/assets/27a00c41-b277-44ce-be5c-b141b939ab82" />
