### PR TITLE
Add Sonoff plus vendor flashing instructions using web

### DIFF
--- a/docs/guide/adapters/zstack.md
+++ b/docs/guide/adapters/zstack.md
@@ -133,6 +133,7 @@ Note before buying that ITead slightly confusingly now sells both the Dongle Plu
 
 - [Coordinator firmware](https://github.com/Koenkk/Z-Stack-firmware/releases/download/Z-Stack_3.x.0_coordinator_20250321/CC1352P2_CC2652P_launchpad_coordinator_20250321.zip)
 - [Router firmware](https://github.com/Koenkk/Z-Stack-firmware/releases/download/Z-Stack_3.x.0_router_20250403/CC1352P2_CC2652P_launchpad_router_20250403.zip)
+- [Vendor flashing from web](https://dongle.sonoff.tech/sonoff-dongle-flasher/) Plug in dongle, open webpage, connect, select custom, upload hex file from above, flash. No software required.
 - [Vendor flashing instructions](https://sonoff.tech/wp-content/uploads/2021/09/Zigbee-3.0-USB-dongle-plus-firmware-flashing-1-1.docx) ([PDF version](https://github.com/Koenkk/zigbee2mqtt.io/raw/master/docs/guide/adapters/flashing/zigbee-3.0-usb-dongle-plus-firmware_flashing-1-1.pdf) and [required python script](https://github.com/Koenkk/zigbee2mqtt.io/raw/master/docs/guide/adapters/flashing/zigbee-3.0-usb-dongle-plus-uartLog.zip))
 - [Buy](https://itead.cc/product/sonoff-zigbee-3-0-usb-dongle-plus/)
 


### PR DESCRIPTION
Added a new vendor flashing option for the Sonoff plus dongle. This was recommended on their website as the fastest option, and for me it surely was a seamless experience.