### PR TITLE
docs: add time sync workaround for HS3AQ.md

### DIFF
--- a/docs/devices/HS3AQ.md
+++ b/docs/devices/HS3AQ.md
@@ -71,3 +71,29 @@ Value can be found in the published state on the `temperature` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The unit of this value is `°C`.
 
+### Time synchronization
+
+This device does not sync time using the standard Zigbee protocol, but instead requires the seconds since midnight of the current day. To fix the asynchronous time, you can regularly publish this value to the `genTime` cluster. 
+
+Using Home Assistant, you can create an automation to sync the time every hour:
+
+```yaml
+alias: "Heiman HS3AQ Time Sync"
+mode: single
+trigger:
+  - platform: time_pattern
+    hours: "/1"
+action:
+  - action: mqtt.publish
+    data:
+      topic: "zigbee2mqtt/FRIENDLY_NAME/1/set"
+      payload: >-
+        {
+          "write": {
+            "cluster": "genTime",
+            "payload": {
+              "time": {{ (now().hour * 3600) + (now().minute * 60) + now().second }}
+            }
+          }
+        }
+(Note: Replace FRIENDLY_NAME with your device's friendly name).


### PR DESCRIPTION
The Heiman HS3AQ (Smart Air Quality Monitor) does not automatically synchronize its clock with the standard Zigbee time cluster. It requires the seconds since midnight of the current day to be pushed manually to the `genTime` cluster, otherwise the time on the display drifts or stays incorrect.

I have added a documentation section with a Home Assistant automation workaround that stochastically/regularly updates the time via MQTT to ensure the device display shows the correct local time.

This fix was tested and confirmed working with the HS3AQ model.