### PR TITLE
Revert "Update pairing notes for WT-A03E.md"

### DIFF
--- a/docs/devices/WT-A03E.md
+++ b/docs/devices/WT-A03E.md
@@ -30,9 +30,7 @@ pageClass: device-page
 The thermostat needs to be flashed with the correct firmware before it can be used with Zigbee. This works without using a proprietary hub, but requires a iOS/Android device with Bluetooth and an Aqara account.
 
 1. Download the Aqara app, sign in and proceed to adding a new device.
-2. Put the thermostat into pairing mode by:
-    1. pressing and holding the center button for 10 seconds until the display starts flashing and showing "F1" (this step is unneeded in case of a brand new device).
-    2. pressing the center button 3 times. The display will now show "F2" and the device should now show up in the app.
+2. Put the thermostat into pairing mode by pressing and holding the center button for 10 seconds until the display starts flashing. The device should now show up in the app.
 3. Select the thermostat in the app and when prompted, choose Zigbee as the connection method. The app will then flash the correct firmware.
 4. Once the flashing process is complete, the thermostat will start pairing using Zigbee.
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/WT-A03E.md
+++ b/docs/devices/WT-A03E.md
@@ -30,7 +30,7 @@ pageClass: device-page
 The thermostat needs to be flashed with the correct firmware before it can be used with Zigbee. This works without using a proprietary hub, but requires a iOS/Android device with Bluetooth and an Aqara account.
 
 1. Download the Aqara app, sign in and proceed to adding a new device.
-2. Put the thermostat into pairing mode by pressing and holding the center button for 10 seconds until the display starts flashing. The device should now show up in the app.
+2. (Skip this step in case of a new device) Put the thermostat into pairing mode by pressing and holding the center button for 10 seconds until the display starts flashing. The device should now show up in the app.
 3. Select the thermostat in the app and when prompted, choose Zigbee as the connection method. The app will then flash the correct firmware.
 4. Once the flashing process is complete, the thermostat will start pairing using Zigbee.
 <!-- Notes END: Do not edit below this line -->


### PR DESCRIPTION
- Reverts Koenkk/zigbee2mqtt.io#5006
- Adds clarification about pairing for new devices

Sorry, I got confused by how the app detects new devices.

From [the manual](https://www.aqara-shop.co.uk/wp-content/uploads/2025/10/W600-User-Manual.pdf):
- ”F1" means "before installation" mode.
- "F2" means the device is calibrating.

So the previous instructions were correct.