### PR TITLE
Fix italics for windfront markdown

### DIFF
--- a/docgen/device_page_notes/ikea_kajplats.ts
+++ b/docgen/device_page_notes/ikea_kajplats.ts
@@ -34,7 +34,7 @@ View available updates [here](https://webui.dcl.csa-iot.org/models) (search *KAJ
 ## Issues
 - The device may come with null model and manufacturer attributes. In this case, Zigbee2MQTT will recognize it generically. A firmware update may fix it
 - Power-on behavior may not work, only in Zigbee mode, on some models (at least one variant of [LED2401G5](./LED2401G5.md))
-- Scenes, groups and the _OffWithEffect_ command may fail, with the INSUFFICIENT_SPACE error. See more info and workaround in [this issue](https://github.com/Koenkk/zigbee2mqtt/issues/30211#issuecomment-4019236515)
+- Scenes, groups and the *OffWithEffect* command may fail, with the INSUFFICIENT_SPACE error. See more info and workaround in [this issue](https://github.com/Koenkk/zigbee2mqtt/issues/30211#issuecomment-4019236515)
 
 `;
     }

--- a/docs/devices/1TST-EU.md
+++ b/docs/devices/1TST-EU.md
@@ -168,7 +168,7 @@ Get or set weekly schedule
 
 Attribute Value | Description
 ----------------|---------------------------------------------------------------------------
-0               | 0 – Simple/setpoint mode. This mode means the thermostat setpoint is altered only by manual up/down changes at the thermostat or remotely, not by internal schedule programming. / 1 – Schedule programming mode. This enables or disables any programmed weekly schedule configurations. _Note: It does not clear or delete previous weekly schedule programming configurations._
+0               | 0 – Simple/setpoint mode. This mode means the thermostat setpoint is altered only by manual up/down changes at the thermostat or remotely, not by internal schedule programming. / 1 – Schedule programming mode. This enables or disables any programmed weekly schedule configurations. *Note: It does not clear or delete previous weekly schedule programming configurations.*
 1               | 0 - Auto/recovery mode set to OFF / 1 – Auto/recovery mode set to ON
 2               | 0 – Economy/EnergyStar mode set to OFF / 1 – Economy/EnergyStar mode set to ON
 

--- a/docs/devices/C4.md
+++ b/docs/devices/C4.md
@@ -57,7 +57,7 @@ Valid template types are:
 General attributes:
 * `input`: Optional, selects the input(s) to use for a template. If not specified, the first template will use input 0 and then it will be incremented automatically for every further template. In case a templates uses two inputs, `input` and `input+1` will be used and following template will use `input+2`.
 * `inputs`: Optional, selects both inputs separately for templates using two inputs. Allows to e.g. switch up and down inputs in case they are wired differently. The following template will use `Math.max(...inputs)+1`.
-* `endpoint`: Optional, selects the _outbound_ endpoint to use for sending the commands. The C4 only contains _outbound_ endpoints starting with endpoint 1 (see above). For the other ubisys devices endpoint 1 usually is an _inbound_ endpoint controlling the load, but starting at 2 or 3 they also contain _outbound_ endpoints that are per default bound to their respective load controlling endpoint but can also be changed (e.g. from switch to push button) or unbound and rebound to e.g. control a different light using the second input of a S1-R or D1. If not specified, the first template will use the first available _outbound_ endpoint on the specific device and then it will be incremented automatically for every further template. For a C4, cover templates will start at endpoint 5 (since endpoints 1-4 do not host a window covering cluster and can therefore only be used for lights etc).
+* `endpoint`: Optional, selects the *outbound* endpoint to use for sending the commands. The C4 only contains *outbound* endpoints starting with endpoint 1 (see above). For the other ubisys devices endpoint 1 usually is an *inbound* endpoint controlling the load, but starting at 2 or 3 they also contain *outbound* endpoints that are per default bound to their respective load controlling endpoint but can also be changed (e.g. from switch to push button) or unbound and rebound to e.g. control a different light using the second input of a S1-R or D1. If not specified, the first template will use the first available *outbound* endpoint on the specific device and then it will be incremented automatically for every further template. For a C4, cover templates will start at endpoint 5 (since endpoints 1-4 do not host a window covering cluster and can therefore only be used for lights etc).
 
 The input(s) and endpoint used will also be output to the Zigbee2MQTT log (flagged as warnings but only to make sure they do not get suppressed).
 
@@ -73,7 +73,7 @@ Attributes only used with scene templates
 * `scene_id_2`: Optional, if present it specifies the scene id to send for the secondary function of the template (i.e. long button press or switch turned off).
 * `group_id_2`: Optional, specifies the group id to send with `scene_id_2`. Only needed if different from `group_id`.
 
-**On the C4, the respective _outbound_ endpoint also needs to be bound to one or more target devices (see [Binding](#binding) below) for most of the template types (besides scene control).**
+**On the C4, the respective *outbound* endpoint also needs to be bound to one or more target devices (see [Binding](#binding) below) for most of the template types (besides scene control).**
 
 Please also note that there seems to be a size limit on the amount of data that can successfully be written using `input_action_templates`, so not all combinations theoretically possible will work in reality.
 
@@ -215,11 +215,11 @@ devices:
 ```
 
 ### Binding
-Most of the `input_actions` and `input_action_templates` (besides scene control) do not reference a target device directly but make use of the binding table of a specific _outbound_ endpoint (for C4 see [General](#general) above, for other ubisys devices take a look at the respective ubisys reference manual). For the C4, Zigbee2MQTT will always bind all endpoints to the coordinator automatically (so Zigbee2MQTT will be able to forward button presses to MQTT), but to control any other Zigbee device or group directly, it is necessary to bind the _outbound_ endpoints used to the target (device or group).
+Most of the `input_actions` and `input_action_templates` (besides scene control) do not reference a target device directly but make use of the binding table of a specific *outbound* endpoint (for C4 see [General](#general) above, for other ubisys devices take a look at the respective ubisys reference manual). For the C4, Zigbee2MQTT will always bind all endpoints to the coordinator automatically (so Zigbee2MQTT will be able to forward button presses to MQTT), but to control any other Zigbee device or group directly, it is necessary to bind the *outbound* endpoints used to the target (device or group).
 
-When binding (or unbinding), it is important to explicitly specify the _outbound_ endpoint as the source, e.g. `zigbee2mqtt/bridge/request/device/bind` payload `{"from": "SOURCE_DEVICE_FRIENDLY_NAME/2", "to": "TARGET"}` (also see [Binding specific endpoint](../guide/usage/binding.md#binding-specific-endpoint)). Endpoints can be specified in numeric form and it is usually not necessary to specify an endpoint for the target device.
+When binding (or unbinding), it is important to explicitly specify the *outbound* endpoint as the source, e.g. `zigbee2mqtt/bridge/request/device/bind` payload `{"from": "SOURCE_DEVICE_FRIENDLY_NAME/2", "to": "TARGET"}` (also see [Binding specific endpoint](../guide/usage/binding.md#binding-specific-endpoint)). Endpoints can be specified in numeric form and it is usually not necessary to specify an endpoint for the target device.
 
-For ubisys devices other than the C4 this also allows to use the secondary input to control a different device. Example: Use the secondary input on a D1 (uses _outbound_ endpoint 3 in the factory configuration) to control a separate Zigbee bulb:
+For ubisys devices other than the C4 this also allows to use the secondary input to control a different device. Example: Use the secondary input on a D1 (uses *outbound* endpoint 3 in the factory configuration) to control a separate Zigbee bulb:
 ```
 mosquitto_pub -t zigbee2mqtt/bridge/request/device/bind -m '{"from": "DIMMER_FRIENDLY_NAME/3", "to": "ANOTHER_BULB_FRIENDLY_NAME"}'
 ```

--- a/docs/devices/E2112.md
+++ b/docs/devices/E2112.md
@@ -47,7 +47,7 @@ The link icon on the display will blink until it connects to the network.
 ### Binding
 
 The sensor can directly control IKEA air purifiers (Trigger when air quality is poor)
-- Pairing outside the network is possible through _Find & Bind_
+- Pairing outside the network is possible through *Find & Bind*
   - Hold the sensor pair button for 3s. The link icon starts blinking
   - Hold the purifier pair button for 3s
   - When successful, the link icon stops blinking

--- a/docs/devices/E2490.md
+++ b/docs/devices/E2490.md
@@ -43,7 +43,7 @@ pageClass: device-page
 
 - Partial and conflicting binding support: All remotes control the same devices. See [Binding](#binding)
 
-- Slow actions, out-of-sync _On/Off_ commands, malformed _MoveToLevel_ command: See [Action mapping](#action-mapping)
+- Slow actions, out-of-sync *On/Off* commands, malformed *MoveToLevel* command: See [Action mapping](#action-mapping)
 
 ### Battery
 Uses 2 x AAA battery.  
@@ -59,10 +59,10 @@ While sleeping, it will not respond to any Zigbee2MQTT commands.
 
 The remote can be used in one of the following modes:
 1. paired to a [Matter/Thread network](#matter)  
-_(with no binding support yet?)_
+*(with no binding support yet?)*
 
 2. paired to a [Zigbee network](#zigbee)  
-_(with partial binding support: all BILRESA remotes will control the same 1-3 groups)_
+*(with partial binding support: all BILRESA remotes will control the same 1-3 groups)*
 
 3. without network, bound to 1-3 groups of devices, via [Touchlink](#touchlink)  
 
@@ -79,7 +79,7 @@ Single-pressing the pair button also switches the device to Matter mode.
 #### Zigbee
 
 It's important to pair this device directly through a modern and updated coordinator.  
-Pairing with old versions, or through bad routers _(e.g. Telink Tuya, AwoX)_ will cause issues.
+Pairing with old versions, or through bad routers *(e.g. Telink Tuya, AwoX)* will cause issues.
 
 You must go through this sequence to pair the remote to a Zigbee network. All steps are necessary:
 
@@ -94,17 +94,17 @@ You must go through this sequence to pair the remote to a Zigbee network. All st
 
 This remote uses [Touchlink](./../guide/usage/touchlink.md) to **set-up** Zigbee binding. It works both inside and outside the network. Follow these steps:
 
-1. Optionally, factory reset the remote _(to leave the network and clear bindings)_
+1. Optionally, factory reset the remote *(to leave the network and clear bindings)*
 2. Power off nearby devices, that you **don't want** to control with it 
 3. **Press the pair button 4 times to activate Touchlink mode**
 4. First LED quickly blinks amber, indicating channel 1.  
    **Press the front-bottom button to choose which channel to bind.**  
    Channel 2 unlocks after successfully binding channel 1. Similarly, c3 unlocks after c2.  
-   _Note: You can bind multiple channels to the same device_
+   *Note: You can bind multiple channels to the same device*
 5. **Bring the remote close to the target device to start binding**
-   - _If the remote is not connected to a network:_ It will remove the target device from its network and add it to the remote's hidden Zigbee network
-   - _If the remote is connected to the network, but the target is not:_ target identifies, but nothing happens
-   - _If both remote and target are connected the same network:_ It will add the target device to the group corresponding to the selected channel (21658-21660)  
+   - *If the remote is not connected to a network:* It will remove the target device from its network and add it to the remote's hidden Zigbee network
+   - *If the remote is connected to the network, but the target is not:* target identifies, but nothing happens
+   - *If both remote and target are connected the same network:* It will add the target device to the group corresponding to the selected channel (21658-21660)  
 6. When successful, the target device identifies, and the remote LEDs stop blinking
 
 *Cloning* the remote via Touchlink was tested, but not successful.
@@ -112,7 +112,7 @@ This remote uses [Touchlink](./../guide/usage/touchlink.md) to **set-up** Zigbee
 ### Binding
 Tested on model E2490, v1.8.5 (initial firmware):  
 
-**All remotes directly control groups 21658, 21659, 21660** _(channels 1-3)._ Group 21658 conflicts with the [BILRESA dual-button](./E2489.md)!  
+**All remotes directly control groups 21658, 21659, 21660** *(channels 1-3).* Group 21658 conflicts with the [BILRESA dual-button](./E2489.md)!  
 They can't be unbound / bound to anything else ([binding](../guide/usage/binding.md) requests from the coordinator appear successful, but have **no effect**).  
 
 To directly control devices, follow the [Touchlink steps](#touchlink). That will unlock the 3 channels and add the target devices to the respective groups.  
@@ -134,14 +134,14 @@ Zigbee2MQTT doesn't know the remote controls the groups. **So you must additiona
 
 - Long-pressing the wheel is confirmed to generate no Zigbee events
 
-- The remote alternates between _On_ and _Off_ commands instead of sending _Toggle_  
+- The remote alternates between *On* and *Off* commands instead of sending *Toggle*  
   - Current on/off states are stored on the remote - one for each channel  
   - **Benefit**: all group members stay in sync with each other, instead of toggling individually  
-  _(i.e. Prevents light1 on, light2 off)_  
+  *(i.e. Prevents light1 on, light2 off)*  
   - **Downside**: controlling the group from Zigbee2MQTT will get it out-of-sync  
-  _(e.g. Remote sends Off when group is already Off)_ 
+  *(e.g. Remote sends Off when group is already Off)* 
 
-- The remote sends multiple _MoveToLevel_ commands while rotating the wheel
+- The remote sends multiple *MoveToLevel* commands while rotating the wheel
   - Current brightness value is stored on the remote. The same value is used for all channels  
   - Rotate clockwise to increase, counter-clockwise to decrease
   - The command is malformed. It's missing 2 parameters (option mask and override). And level 255 is undefined according to Zigbee specification

--- a/docs/devices/HT402.md
+++ b/docs/devices/HT402.md
@@ -26,7 +26,7 @@ pageClass: device-page
 ## Notes
 
 ### Setting outdoor temperature
-To set _outdoor temperature_, you need to send the value to the following MQTT topic:
+To set *outdoor temperature*, you need to send the value to the following MQTT topic:
 ```
 zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_outdoor_temperature
 ```

--- a/docs/devices/L12Z.md
+++ b/docs/devices/L12Z.md
@@ -29,7 +29,7 @@ See: [https://nous.technology/product/l12z.html?show=manual](https://nous.techno
 
 ### Pairing
 
-Press the _big_ reset button on the back of the device for 5s till the blue LED blink.
+Press the *big* reset button on the back of the device for 5s till the blue LED blink.
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/MINI-ZBDIM.md
+++ b/docs/devices/MINI-ZBDIM.md
@@ -33,7 +33,7 @@ This device can be added to groups, but it does **not** respond to any group com
 
 #### Inverted moving
 
-This device performs inverse effects on receipt of _Move_  
+This device performs inverse effects on receipt of *Move*  
 (whether it's sent through Zigbee2MQTT, or a bound remote). Tested on version v1.0.5
 
 For example `{"brightness_move": -40}` will start **increasing** the brightness (instead of decreasing it).

--- a/docs/devices/QS-Zigbee-C01.md
+++ b/docs/devices/QS-Zigbee-C01.md
@@ -25,7 +25,7 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
 
-_How to reset_
+*How to reset*
 * Press the reset key (upper right in hole) for about 10 seconds until the indicator LED inside the module flashes quickly.
 * Alternatively turn on/off the wired switch  for 5 times until the indicator LED inside the module flashes quickly. (The relay should click 10 times, so if you have a momentary switch connected to the module, you should push it 10 times)
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/QS-Zigbee-C03.md
+++ b/docs/devices/QS-Zigbee-C03.md
@@ -27,11 +27,11 @@ pageClass: device-page
 
 Note, that some devices are marked as "CP03" instead of "C03", althoug identical.
 
-_How to reset_
+*How to reset*
 * Press the reset key (upper right in hole) 5 times until the indicator LED inside the module flashes quickly.
 * Alternatively turn on/off the wired switch for 5 times until the indicator LED inside the module flashes quickly.
 
-_How to use calibration_
+*How to use calibration*
 * Activate calibration mode
 * Open the shutter completely and press stop
 * Set the number to 100 and press the refresh button

--- a/docs/devices/SMT402.md
+++ b/docs/devices/SMT402.md
@@ -26,7 +26,7 @@ pageClass: device-page
 ## Notes
 
 ### Setting outdoor temperature
-To set _outdoor temperature_, you need to send the value to the following MQTT topic:
+To set *outdoor temperature*, you need to send the value to the following MQTT topic:
 ```
 zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_outdoor_temperature
 ```

--- a/docs/devices/STZB402.md
+++ b/docs/devices/STZB402.md
@@ -26,7 +26,7 @@ pageClass: device-page
 ## Notes
 
 ### Setting outdoor temperature
-To set _outdoor temperature_, you need to send the value to the following MQTT topic:
+To set *outdoor temperature*, you need to send the value to the following MQTT topic:
 ```
 zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_outdoor_temperature
 ```

--- a/docs/devices/TH1123ZB-G2.md
+++ b/docs/devices/TH1123ZB-G2.md
@@ -26,7 +26,7 @@ pageClass: device-page
 ## Notes
 
 ### Setting outdoor temperature
-To set _outdoor temperature_, you need to send the value to the following MQTT topic:
+To set *outdoor temperature*, you need to send the value to the following MQTT topic:
 ```
 zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_outdoor_temperature
 ```

--- a/docs/devices/TH1123ZB.md
+++ b/docs/devices/TH1123ZB.md
@@ -26,7 +26,7 @@ pageClass: device-page
 ## Notes
 
 ### Enabling time
-To enable _time_ you need to send a _blank_ message to the following MQTT topic:
+To enable *time* you need to send a *blank* message to the following MQTT topic:
 ```
 zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_time
 ```
@@ -34,7 +34,7 @@ Every time the above message is sent, Zigbee2MQTT will calculate the current tim
 
 
 ### Setting outdoor temperature
-To set _outdoor temperature_, you need to send the value to the following MQTT topic:
+To set *outdoor temperature*, you need to send the value to the following MQTT topic:
 ```
 zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_outdoor_temperature
 ```

--- a/docs/devices/TH1124ZB-G2.md
+++ b/docs/devices/TH1124ZB-G2.md
@@ -26,7 +26,7 @@ pageClass: device-page
 ## Notes
 
 ### Setting outdoor temperature
-To set _outdoor temperature_, you need to send the value to the following MQTT topic:
+To set *outdoor temperature*, you need to send the value to the following MQTT topic:
 ```
 zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_outdoor_temperature
 ```

--- a/docs/devices/TH1124ZB.md
+++ b/docs/devices/TH1124ZB.md
@@ -26,7 +26,7 @@ pageClass: device-page
 ## Notes
 
 ### Setting outdoor temperature
-To set _outdoor temperature_, you need to send the value to the following MQTT topic:
+To set *outdoor temperature*, you need to send the value to the following MQTT topic:
 ```
 zigbee2mqtt/<FRIENDLY_NAME>/set/thermostat_outdoor_temperature
 ```

--- a/docs/devices/ZB-ERSM-01.md
+++ b/docs/devices/ZB-ERSM-01.md
@@ -44,7 +44,7 @@ You have 3 possibilities of pairing:
 6. Open the shutter by pushing the "open" button every 0.5 seconds until the shutter is totally open
 7. Exit calibration mode (now the opening time is set, calibration is done)
 
-**Caution**: _In calibration mode, any shutter movement command lasts 1 second maximum. For continuous movement, the Zigbee Down/Close command must be sent approximately every 0.5 seconds._
+**Caution**: *In calibration mode, any shutter movement command lasts 1 second maximum. For continuous movement, the Zigbee Down/Close command must be sent approximately every 0.5 seconds.*
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/ZB-TDD6-RCW-4.md
+++ b/docs/devices/ZB-TDD6-RCW-4.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 ### Known issues
 
-- Device sends _Leave_ events when power is restored, but it doesn't actually leave the network
+- Device sends *Leave* events when power is restored, but it doesn't actually leave the network
   - Discussion [here](https://github.com/Koenkk/zigbee-herdsman/issues/1648)
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/ZNJLBL01LM.md
+++ b/docs/devices/ZNJLBL01LM.md
@@ -29,7 +29,7 @@ pageClass: device-page
 ### Pairing
 Hold the reset button, on the bottom of the device, for 5 seconds.
 
-_Pairing the device with a new bridge will **not** reset the fully open/closed position._
+*Pairing the device with a new bridge will **not** reset the fully open/closed position.*
 
 ### Fully open and fully closed positions
 The rotation range (fully open and fully closed) can be reset by holding the both the up and down buttons for 3 seconds until the light turns blue.

--- a/docs/devices/ZS-EUB_2gang.md
+++ b/docs/devices/ZS-EUB_2gang.md
@@ -27,7 +27,7 @@ This device does not act as a Zigbee router, even when the optional neutral conn
 
 ### Pairing
 
-Press and hold the _left_ switch for 7 seconds, until the indicator on the switch flashes fast. After about 3 seconds pairing should be complete.
+Press and hold the *left* switch for 7 seconds, until the indicator on the switch flashes fast. After about 3 seconds pairing should be complete.
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
Replaced `_italic_` occurences (found in devices folder) with `*italic*` so it displays properly in windfront