### PR TITLE
feat: add "securing" page

### DIFF
--- a/docs/advanced/zigbee/03_secure_network.md
+++ b/docs/advanced/zigbee/03_secure_network.md
@@ -1,32 +1,10 @@
 ---
+title: Secure your Zigbee network
+head:
+    - - meta
+      - http-equiv: refresh
+        content: 0; URL=https://www.zigbee2mqtt.io/guide/installation/14_securing.html#zigbee-network
+    - - link
+      - rel: canonical
+        href: https://www.zigbee2mqtt.io/guide/installation/14_securing.html#zigbee-network
 ---
-
-# Secure your Zigbee network
-
-To make sure your Zigbee network is as secure as possible, consider the following:
-
-## Change Zigbee network encryption key
-
-**Changing the network key requires re-pairing of all devices!**
-
-Zigbee2MQTT releases prior to 1.33.0 use a known default encryption key (Zigbee Transport Key). Therefore it is recommended to change the network encryption key on those versions. Release 1.33.0 and later will generate a random encryption key on startup.
-
-To use a different encryption key add the following to your `configuration.yaml`:
-
-**Do not use this exact key.**
-
-```yaml
-advanced:
-    network_key: [7, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 11, 12, 13]
-```
-
-The network encryption key size is `128-bit` which is essentially 16 decimal values between `0` and `255` or 16 hexadecimal values between `0x00`and `0xFF`.
-
-If you need to transform your decimals to hexadecimals (or vice versa) please use a [converter](https://www.binaryhexconverter.com/decimal-to-hex-converter). Example: 92 (decimal) would become 5C (hexadecimal).
-
-To let Zigbee2MQTT generate a new network key on next startup, add the following to `configuration.yaml`:
-
-```yaml
-advanced:
-    network_key: GENERATE
-```

--- a/docs/guide/configuration/more-config-options.md
+++ b/docs/guide/configuration/more-config-options.md
@@ -24,15 +24,3 @@ map_options:
                 active: '#009900'
                 inactive: '#994444'
 ```
-
-## External converters
-
-You can define external converters to e.g. add support for a DiY device. The extension can be a file with `.js`
-extension in the `external_converters` directory (at the same level in the file system as the zigbee2mqtt configuration.yaml file)
-or a NPM package. Ensure that default export from your external converter exports an
-array or device object (refer to the definition in the `devices` folder of zigbee-herdsman-converters). Some examples
-can be found [here](https://github.com/Koenkk/zigbee2mqtt.io/tree/master/docs/externalConvertersExample).
-
-Note that external converters take precedence of standard converters
-
-See also [How to support new devices](../../advanced/support-new-devices/01_support_new_devices.md).

--- a/docs/guide/installation/01_linux.md
+++ b/docs/guide/installation/01_linux.md
@@ -1,5 +1,5 @@
 ---
-next: ../configuration/
+next: 14_securing.md
 ---
 
 # Linux

--- a/docs/guide/installation/02_docker.md
+++ b/docs/guide/installation/02_docker.md
@@ -1,5 +1,5 @@
 ---
-next: ../configuration/
+next: 14_securing.md
 ---
 
 # Docker

--- a/docs/guide/installation/03_ha_addon.md
+++ b/docs/guide/installation/03_ha_addon.md
@@ -1,5 +1,5 @@
 ---
-next: ../configuration/
+next: 14_securing.md
 ---
 
 # Home Assistant addon

--- a/docs/guide/installation/04_openhabian.md
+++ b/docs/guide/installation/04_openhabian.md
@@ -1,5 +1,5 @@
 ---
-next: ../configuration/
+next: 14_securing.md
 ---
 
 # openHABian

--- a/docs/guide/installation/05_windows.md
+++ b/docs/guide/installation/05_windows.md
@@ -1,5 +1,5 @@
 ---
-next: ../configuration/
+next: 14_securing.md
 ---
 
 # Windows

--- a/docs/guide/installation/06_freebsd_jail.md
+++ b/docs/guide/installation/06_freebsd_jail.md
@@ -1,5 +1,5 @@
 ---
-next: ../configuration/
+next: 14_securing.md
 ---
 
 # FreeBSD jail

--- a/docs/guide/installation/08_kubernetes.md
+++ b/docs/guide/installation/08_kubernetes.md
@@ -1,5 +1,5 @@
 ---
-next: ../configuration/
+next: 14_securing.md
 ---
 
 # Kubernetes

--- a/docs/guide/installation/14_securing.md
+++ b/docs/guide/installation/14_securing.md
@@ -150,7 +150,7 @@ The Network Address is randomly assigned on device join and usually remains the 
 The "permit join" state determines whether new devices are allowed to join the network.
 Joining is enabled temporarily (for 254 seconds by default) via the dedicated frontend button or via MQTT. You can also close the joining window manually once pairing is complete.
 
-:::warning WARNING
+:::tip TIP
 Freshly joined devices may automatically permit joining on themselves for a specific duration (max 254 seconds).
 :::
 
@@ -169,11 +169,12 @@ See also [Add install code via MQTT](../../guide/usage/mqtt_topics_and_messages.
 For stricter control over which devices are allowed on the network, use a passlist or blocklist.
 See [Device blocklist / passlist](../configuration/block-pass-list.md) for more details.
 
-:::tip
+:::tip TIP
 Devices that are not allowed are removed from the network on startup (e.g. configuration changes since last run), and on join attempts.
+Note: removal is a request sent to the targeted device to "ask it" to leave, a malicious device could purposely ignore it.
 :::
 
-:::tip
+:::tip TIP
 Using a passlist is the most restrictive and therefore most secure option, only explicitly trusted devices can join.
 :::
 

--- a/docs/guide/installation/14_securing.md
+++ b/docs/guide/installation/14_securing.md
@@ -177,6 +177,13 @@ Devices that are not allowed are removed from the network on startup (e.g. confi
 Using a passlist is the most restrictive and therefore most secure option, only explicitly trusted devices can join.
 :::
 
+### Inter-PAN
+
+Inter-PAN messages are **unsecured messages** sent to or received from unjoined devices 1-hop away.
+Touchlink (previously known as ZLL) uses inter-PAN messaging.
+
+Inter-PAN is usually reserved for highly specific operations (e.g. resetting a device to factory settings), and undesired messages are aggressively dropped; this limits the impact of its lack of security.
+
 ### Zigbee 4.0
 
 Zigbee 4.0 provides several security enhancements.

--- a/docs/guide/installation/14_securing.md
+++ b/docs/guide/installation/14_securing.md
@@ -183,7 +183,12 @@ Using a passlist is the most restrictive and therefore most secure option, only 
 Inter-PAN messages are **unsecured messages** sent to or received from unjoined devices 1-hop away.
 Touchlink (previously known as ZLL) uses inter-PAN messaging.
 
-Inter-PAN is usually reserved for highly specific operations (e.g. resetting a device to factory settings), and undesired messages are aggressively dropped; this limits the impact of its lack of security.
+Inter-PAN is usually reserved for highly specific operations (e.g. resetting a device to factory settings via Touchlink), undesired messages are aggressively dropped, and close physical proximity is required.
+This limits the impact of its lack of security.
+
+:::warning WARNING
+Avoid devices that keep Touchlink permanently enabled, especially in places with relative ease of access; a malicious user could otherwise disrupt the network.
+:::
 
 ### Zigbee 4.0
 

--- a/docs/guide/installation/14_securing.md
+++ b/docs/guide/installation/14_securing.md
@@ -56,7 +56,7 @@ Refer to the available documentation and guides for your broker.
 :::
 
 :::caution CAUTION
-Using `reject_unauthorized: false` in production is dangerous. Its disables TLS certificate validation and makes the connection vulnerable to man-in-the-middle attacks.
+Using `reject_unauthorized: false` in production is dangerous. Its disables TLS certificate validation and makes the connection vulnerable.
 :::
 
 ## Frontend
@@ -154,6 +154,16 @@ Joining is enabled temporarily (for 254 seconds by default) via the dedicated fr
 Freshly joined devices may automatically permit joining on themselves for a specific duration (max 254 seconds).
 :::
 
+#### Install codes
+
+Joining with an install code provides better security (if available).
+A code is randomly assigned during the manufacturing process of a device.
+The code allows to encrypt the initial network key transport from the Trust Center (coordinator) to the joining device.
+
+Ask the vendor or refer to each device's documentation to check if an install code is available (usually printed on the device, plainly or as a QR code).
+Codes can be added through the frontend.
+See also [Add install code via MQTT](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestinstall_codeadd).
+
 ### Device passlist and blocklist
 
 For stricter control over which devices are allowed on the network, use a passlist or blocklist.
@@ -167,6 +177,13 @@ Devices that are not allowed are removed from the network on startup (e.g. confi
 Using a passlist is the most restrictive and therefore most secure option, only explicitly trusted devices can join.
 :::
 
+### Zigbee 4.0
+
+Zigbee 4.0 provides several security enhancements.
+You can read more about it in the announcement from the CSA: [https://csa-iot.org/newsroom/the-connectivity-standards-alliance-announces-zigbee-4-0-and-suzi-empowering-the-next-generation-of-secure-interoperable-iot-devices/](https://csa-iot.org/newsroom/the-connectivity-standards-alliance-announces-zigbee-4-0-and-suzi-empowering-the-next-generation-of-secure-interoperable-iot-devices/)
+
+NOTE: It will take time before devices catch up to the new standard and support all these enhancements.
+
 ## External extensions and converters
 
 By design, external extensions and converters execute arbitrary user-provided JavaScript code within the Zigbee2MQTT process.
@@ -179,15 +196,15 @@ Treat them with the same level of scrutiny as any other code/scripts running on 
 
 ## Firmware updates (OTA)
 
-Firmware updates can change device behavior in ways that may affect Zigbee2MQTT compatibility, and could in theory introduce malicious or buggy functionality.
+Firmware updates can provide bug fixes, security updates and other welcomed features.
+However, they can also change device behavior in ways that may affect Zigbee2MQTT compatibility and potentially introduce buggy, or even malicious functionality.
+Review the release notes before applying a firmware update.
+See [OTA updates](../usage/ota_updates.md) for more details.
 
-Zigbee2MQTT retrieves OTA images from the [Koenkk/zigbee-OTA](https://github.com/Koenkk/zigbee-OTA) repository by default.
+By default, Zigbee2MQTT matches and retrieves OTA images from the [Koenkk/zigbee-OTA](https://github.com/Koenkk/zigbee-OTA) repository.
+This repository is a mirror of manufacturer-provided firmware updates, both manually and automatically curated.
 
 :::caution CAUTION
 Only use firmware from trusted sources.
 Avoid using custom OTA index URLs unless you fully trust the source.
-:::
-
-:::tip TIP
-Review the release notes before applying a firmware update. See [OTA updates](../usage/ota_updates.md) for more details.
 :::

--- a/docs/guide/installation/14_securing.md
+++ b/docs/guide/installation/14_securing.md
@@ -133,7 +133,7 @@ See [Zigbee network configuration](../configuration/zigbee-network.md) for more 
 
 The PAN ID and Extended PAN ID identify your network. These are not security measures.
 
-Changing them is possible and require re-pairing all devices.
+Changing them is possible and requires re-pairing all devices.
 This is mostly done in case you need to avoid a conflict with another nearby network.
 
 ### IEEE and Network addresses

--- a/docs/guide/installation/14_securing.md
+++ b/docs/guide/installation/14_securing.md
@@ -1,0 +1,193 @@
+---
+sidebarDepth: 1
+next: ../configuration/
+---
+
+# Securing the installation
+
+::: warning
+This page provides an overview of how security applies to a typical installation.
+Each setup being slightly different, not all, and/or more, could apply.
+:::
+
+A useful way to think about Zigbee2MQTT in terms of security is to compare it to the software running on a network router: it provides configuration and control of a network.
+As such, it is, by default, only locally accessible.
+
+With Zigbee2MQTT being a bridge, the various software components attached to it (MQTT broker, automation software, etc.) must each be secured properly as well. Refer to their respective documentation.
+
+Exposing any of these components publicly requires careful security planning.
+Untrusted access must never be permitted.
+
+## Host system
+
+- **Dedicated user**: run Zigbee2MQTT under a dedicated, unprivileged user account (not `root`). This limits the blast radius if the process is ever compromised.
+- **Restrict data directory access**: the data directory contains the full configuration, network state, and device data. Only the Zigbee2MQTT user should have access to it.
+- **Keep the host system up to date**: apply operating system and dependency (Node.js, MQTT broker, etc.) security updates regularly and keep Zigbee2MQTT itself updated.
+
+## Configuration file
+
+The `configuration.yaml` file contains sensitive information such as MQTT credentials and the Zigbee network key.
+
+- **Restrict file permissions**: ensure only the user running Zigbee2MQTT can read/write the file.
+
+    ```bash
+    chmod 600 configuration.yaml
+    ```
+
+- **Use a secrets file**: avoid storing credentials in plain text in `configuration.yaml`.
+  Instead, use a separate `secret.yaml` file referenced with the `!secret.yaml` syntax. See [Specifying in a different file](../configuration/mqtt.md#specifying-mqtt-serveruserpassword-and-network_key-in-a-different-file).
+
+    Apply the same permission restriction to `secret.yaml`:
+
+    ```bash
+    chmod 600 secret.yaml
+    ```
+
+## MQTT
+
+MQTT is the primary entry point in and out of Zigbee2MQTT.
+It is used to publish data and to control every aspect of Zigbee2MQTT (configuration, network, devices, etc.).
+
+See [MQTT configuration](../configuration/mqtt.md) for the full reference.
+
+:::caution CAUTION
+Do not expose the MQTT broker publicly without securing its access.
+Refer to the available documentation and guides for your broker.
+:::
+
+:::caution CAUTION
+Using `reject_unauthorized: false` in production is dangerous. Its disables TLS certificate validation and makes the connection vulnerable to man-in-the-middle attacks.
+:::
+
+## Frontend
+
+The frontend uses the same API as MQTT, but wrapped in a [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) for in-browser access.
+Anyone who can reach the frontend has full control over Zigbee2MQTT, same as MQTT.
+
+:::caution CAUTION
+Do not expose the frontend publicly without securing its access.
+:::
+
+### Authentication
+
+Enable token-based authentication with the [`auth_token` option](../configuration/frontend.md#advanced-configuration).
+
+Use the same precautions as any password.
+Store it in `secret.yaml` (see [Configuration file](#configuration-file)) rather than directly in `configuration.yaml`.
+
+### Encryption (HTTPS / WSS)
+
+Enable HTTPS/WSS directly within Zigbee2MQTT by providing a [certificate and private key](../configuration/frontend.md#advanced-configuration).
+
+Alternatively, terminate TLS at a reverse proxy (Nginx, Apache, etc.) placed in front of the frontend.
+See [Frontend configuration](../configuration/frontend.md) for proxy configuration examples.
+
+### Bind address
+
+By default, the frontend listens on all interfaces (`0.0.0.0`).
+If remote access is not required, restrict it to localhost:
+
+```yaml
+frontend:
+    host: 127.0.0.1
+```
+
+Alternatively, use a Unix socket to avoid any network exposure:
+
+```yaml
+frontend:
+    host: '/run/zigbee2mqtt/zigbee2mqtt.sock'
+```
+
+:::warning WARNING
+Beware of the specific requirements of some systems in this regard (Docker, Home Assistant, etc.).
+:::
+
+## Zigbee network
+
+### Network encryption key
+
+Zigbee communication is encrypted using a 128-bit network key.
+
+:::caution CAUTION
+Changing this key requires re-pairing all devices.
+:::
+
+:::caution CAUTION
+If you are currently running a network with the old default key `[1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 13]`, it is strongly suggested you change it.
+:::
+
+To generate a new random key on next startup, use [Onboarding](../getting-started/README.md#onboarding), or update it manually:
+
+```yaml
+advanced:
+    network_key: GENERATE
+```
+
+Zigbee2MQTT will replace `GENERATE` with a randomly generated key on startup.
+Of course, you can also set a specific key manually.
+
+See [Zigbee network configuration](../configuration/zigbee-network.md) for more details.
+
+### PAN ID and Extended PAN ID
+
+The PAN ID and Extended PAN ID identify your network. These are not security measures.
+
+Changing them is possible and require re-pairing all devices.
+This is mostly done in case you need to avoid a conflict with another nearby network.
+
+### IEEE and Network addresses
+
+The IEEE and Network addresses identify your devices. These are not security measures.
+
+The IEEE address is statically assigned to the Zigbee chip in the device (although it can be changed in some cases).
+Two devices with the same IEEE address cannot join a same network.
+
+The Network Address is randomly assigned on device join and usually remains the same until reset/rejoin (although it may change at the discretion of the device).
+
+### Joining (permit join)
+
+The "permit join" state determines whether new devices are allowed to join the network.
+Joining is enabled temporarily (for 254 seconds by default) via the dedicated frontend button or via MQTT. You can also close the joining window manually once pairing is complete.
+
+:::warning WARNING
+Freshly joined devices may automatically permit joining on themselves for a specific duration (max 254 seconds).
+:::
+
+### Device passlist and blocklist
+
+For stricter control over which devices are allowed on the network, use a passlist or blocklist.
+See [Device blocklist / passlist](../configuration/block-pass-list.md) for more details.
+
+:::tip
+Devices that are not allowed are removed from the network on startup (e.g. configuration changes since last run), and on join attempts.
+:::
+
+:::tip
+Using a passlist is the most restrictive and therefore most secure option, only explicitly trusted devices can join.
+:::
+
+## External extensions and converters
+
+By design, external extensions and converters execute arbitrary user-provided JavaScript code within the Zigbee2MQTT process.
+This grants significant customization flexibility, but also means that malicious or buggy code can compromise the entire Zigbee2MQTT instance, and potentially the host system.
+
+:::caution CAUTION
+Only add external extensions and converters from trusted, reviewed sources.
+Treat them with the same level of scrutiny as any other code/scripts running on your system.
+:::
+
+## Firmware updates (OTA)
+
+Firmware updates can change device behavior in ways that may affect Zigbee2MQTT compatibility, and could in theory introduce malicious or buggy functionality.
+
+Zigbee2MQTT retrieves OTA images from the [Koenkk/zigbee-OTA](https://github.com/Koenkk/zigbee-OTA) repository by default.
+
+:::caution CAUTION
+Only use firmware from trusted sources.
+Avoid using custom OTA index URLs unless you fully trust the source.
+:::
+
+:::tip TIP
+Review the release notes before applying a firmware update. See [OTA updates](../usage/ota_updates.md) for more details.
+:::

--- a/docs/guide/installation/20_zigbee2mqtt-fails-to-start.md
+++ b/docs/guide/installation/20_zigbee2mqtt-fails-to-start.md
@@ -1,4 +1,5 @@
 ---
+title: Zigbee2MQTT fails to start
 head:
     - - meta
       - http-equiv: refresh

--- a/docs/how_tos/how_to_secure_network.md
+++ b/docs/how_tos/how_to_secure_network.md
@@ -2,8 +2,8 @@
 head:
     - - meta
       - http-equiv: refresh
-        content: 0; URL=https://www.zigbee2mqtt.io/advanced/zigbee/03_secure_network.html
+        content: 0; URL=https://www.zigbee2mqtt.io/guide/installation/14_securing.html#zigbee-network
     - - link
       - rel: canonical
-        href: https://www.zigbee2mqtt.io/advanced/zigbee/03_secure_network.html
+        href: https://www.zigbee2mqtt.io/guide/installation/14_securing.html#zigbee-network
 ---


### PR DESCRIPTION
Tried to cover all relevant aspects I could think of while remaining on "overall" architecture and every-day use (this is not a paper on Zigbee security :grin:).
Kept duplication to minimum, used links to relevant sections, and avoided stuff that is far better left to specific software's own docs (too many to even count anyway).
I also added some mentions on common misconceptions around PAN/IEEE/etc..
And consolidated a couple of sparse docs on the topic in that new page.

Let me know if you see anything else that might be worth adding, or if you spot any mistakes :grimacing: 

@burmistrzak @andrei-lazarov @sjorge 

@Koenkk thinking something like https://ecosystem.vuejs.press/plugins/tools/redirect.html might be useful to avoid keeping entire redirect pages? (it currently creates weird dupes when it's stuff that was in the sidebar - it remains there)

Code wise, it would be good to gate external JS extensions ([1](https://github.com/Koenkk/zigbee2mqtt/blob/master/lib/controller.ts#L67), [2](https://github.com/Koenkk/zigbee2mqtt/blob/master/lib/controller.ts#L77)) behind an option instead of automatically enabling them, since they are hugely permissive by design. This would "no-op" the related MQTT topics. Although until 3.0 it would have to be "enabled by default" to avoid a breaking change, unless we make an exception....