### PR TITLE
docs(S4PL-00416EU): note about unexpected switch-off / power_on_behavior

### DIFF
--- a/docs/devices/S4PL-00416EU.md
+++ b/docs/devices/S4PL-00416EU.md
@@ -35,6 +35,9 @@ To reset the device to factory settings, either use the Web UI (if WiFi is enabl
 
 ### Noisy status updates
 Reportedly, the device is frequently publishing status updates to the network [GitHub issue](https://github.com/Koenkk/zigbee2mqtt/issues/30544), [Shelly community](https://community.shelly.cloud/topic/11528-zigbee-network-instability-flooding-with-two%C2%A0shelly-power-strip-4-gen4%C2%A0zigbee2mqtt-cc2652p7/). Depending on your network and the number of Shelly power strips, this may cause instabilities. In that case, try modifying the reporting settings or enable debouncing as described [here](https://github.com/maxim-mityutko/hass/blob/38341583e521ed77459e5974e02b1e6d44ff1f5a/docs/tests/shelly-power-strip-4-gen4.md).
+
+### Unexpected switch-off after reboot or power loss
+By default, the sockets turn **off** after any reboot or power loss, which can look like the strip "randomly" switching off (see this [Shelly community thread](https://community.shelly.cloud/topic/11999-unexpected-switch-off/)). To have sockets restore their previous state instead, set `power_on_behavior` to `previous` on each socket. The setting is saved on the device and persists across reboots.
 <!-- Notes END: Do not edit below this line -->
 
 

--- a/docs/devices/S4PL-00416EU.md
+++ b/docs/devices/S4PL-00416EU.md
@@ -37,7 +37,7 @@ To reset the device to factory settings, either use the Web UI (if WiFi is enabl
 Reportedly, the device is frequently publishing status updates to the network [GitHub issue](https://github.com/Koenkk/zigbee2mqtt/issues/30544), [Shelly community](https://community.shelly.cloud/topic/11528-zigbee-network-instability-flooding-with-two%C2%A0shelly-power-strip-4-gen4%C2%A0zigbee2mqtt-cc2652p7/). Depending on your network and the number of Shelly power strips, this may cause instabilities. In that case, try modifying the reporting settings or enable debouncing as described [here](https://github.com/maxim-mityutko/hass/blob/38341583e521ed77459e5974e02b1e6d44ff1f5a/docs/tests/shelly-power-strip-4-gen4.md).
 
 ### Unexpected switch-off after reboot or power loss
-By default, the sockets turn **off** after any reboot or power loss, which can look like the strip "randomly" switching off (see this [Shelly community thread](https://community.shelly.cloud/topic/11999-unexpected-switch-off/)). To have sockets restore their previous state instead, set `power_on_behavior` to `previous` on each socket. The setting is saved on the device and persists across reboots.
+By default, the sockets turn **off** after any reboot or power loss, which can look like the strip "randomly" switching off (see this [Shelly community thread](https://community.shelly.cloud/topic/11999-unexpected-switch-off/)). To have sockets restore their previous state instead, set each socket's power-on behavior to `previous` (i.e. `power_on_behavior_1`, `power_on_behavior_2`, `power_on_behavior_3`, and `power_on_behavior_4` to `previous`). The setting is saved on the device and persists across reboots.
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
# Add note about unexpected switch-off on Shelly Power Strip 4 Gen4

> **Disclosure:** the wording and this PR description were drafted by an AI coding assistant under my direction; the underlying behavior was verified live on a Shelly Power Strip 4 Gen4 before submission.

Adds a Notes section entry to the [S4PL-00416EU device page](https://www.zigbee2mqtt.io/devices/S4PL-00416EU.html) explaining:

- The "unexpected switch-off" behavior reported by many users on the Shelly community ([thread #11999](https://community.shelly.cloud/topic/11999-unexpected-switch-off/)) — by default sockets turn off after any power loss / reboot.
- How to fix it via the new per-socket `power_on_behavior` expose (set to `previous`).
- That the setting is saved on the device and persists across reboots.

## Companion PR

This depends on the converter PR adding the expose: **Koenkk/zigbee-herdsman-converters#12086**

The auto-generated sections of the device page (Exposes table, "Power on behavior (enum, N endpoint)" sections, etc.) will be regenerated by docgen after the converter PR is merged and a new release is published — this PR only edits the hand-editable `## Notes` section.
