### PR TITLE
docs(S4PL-00416EU): rewrite "Noisy status updates" with concrete debounce recipe

### DIFF
--- a/docs/devices/S4PL-00416EU.md
+++ b/docs/devices/S4PL-00416EU.md
@@ -34,7 +34,24 @@ Re-enable Zigbee pairing mode by pressing and holding the first button while pre
 To reset the device to factory settings, either use the Web UI (if WiFi is enabled) or press and hold the button next to the first socket (from the power cord) and the button next to the last socket simultaneously for 10 seconds. The device will indicate a factory reset with red flashing LED rings. Press and hold both buttons for five seconds to trigger a reboot without a factory reset.
 
 ### Noisy status updates
-Reportedly, the device is frequently publishing status updates to the network [GitHub issue](https://github.com/Koenkk/zigbee2mqtt/issues/30544), [Shelly community](https://community.shelly.cloud/topic/11528-zigbee-network-instability-flooding-with-two%C2%A0shelly-power-strip-4-gen4%C2%A0zigbee2mqtt-cc2652p7/). Depending on your network and the number of Shelly power strips, this may cause instabilities. In that case, try modifying the reporting settings or enable debouncing as described [here](https://github.com/maxim-mityutko/hass/blob/38341583e521ed77459e5974e02b1e6d44ff1f5a/docs/tests/shelly-power-strip-4-gen4.md).
+The device publishes power, voltage and frequency updates very frequently (around once per second), which can flood your MQTT broker and, with several power strips, destabilise the Zigbee network ([GitHub issue](https://github.com/Koenkk/zigbee2mqtt/issues/30544), [Shelly community](https://community.shelly.cloud/topic/11528-zigbee-network-instability-flooding-with-two%C2%A0shelly-power-strip-4-gen4%C2%A0zigbee2mqtt-cc2652p7/)).
+
+The simplest mitigation is to enable [debouncing](../guide/configuration/devices-groups.md#specific-device-options) for this device in your `configuration.yaml`. The example below batches the noisy attributes into one MQTT publish every 5 seconds while still propagating switch state changes immediately:
+
+```yaml
+devices:
+  '0xYYYYYYYYYYYYYYYY': # replace with your device's IEEE address
+    friendly_name: My Power Strip
+    debounce: 5
+    debounce_ignore:
+      - state_1
+      - state_2
+      - state_3
+      - state_4
+      - action
+```
+
+You can also tune the per-attribute reporting thresholds from the device page in Zigbee2MQTT's web UI; see this [community write-up](https://github.com/maxim-mityutko/hass/blob/38341583e521ed77459e5974e02b1e6d44ff1f5a/docs/tests/shelly-power-strip-4-gen4.md) for details.
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
# docs(S4PL-00416EU): rewrite "Noisy status updates" with a concrete debounce recipe

> **Disclosure:** the wording and this PR description were drafted by an AI coding assistant under my direction. The before/after numbers below were measured live on my Shelly Power Strip 4 Gen4.

The existing note on the [S4PL-00416EU device page](https://www.zigbee2mqtt.io/devices/S4PL-00416EU.html) acknowledged the device's frequent reporting but only linked to a third-party HASS write-up without telling users what to do. This PR replaces it with a copy-pasteable `configuration.yaml` snippet that uses Zigbee2MQTT's built-in `debounce` / `debounce_ignore` options:

```yaml
devices:
  '0xYYYYYYYYYYYYYYYY':
    friendly_name: My Power Strip
    debounce: 5
    debounce_ignore:
      - state_1
      - state_2
      - state_3
      - state_4
      - action
```

`debounce_ignore` is the important part: it makes sure switch state changes (and external button-press actions) flush the debounce buffer immediately, so user-visible behavior stays snappy.

## Verified on a real device

Shelly Power Strip 4 Gen4 (S4PL-00416EU) on the Zigbee firmware, zhc 26.12.0 / z2m 2.x:

- Without debounce: ~30 publishes / 30 s on the device topic.
- With `debounce: 5` and `state_*` in `debounce_ignore`: ~5 publishes / 30 s.
- Switch state changes still propagate immediately (~200 ms after device acknowledgement, vs. up to +5 s if `state_*` weren't ignored).

Refs [Koenkk/zigbee2mqtt#30544](https://github.com/Koenkk/zigbee2mqtt/issues/30544), [Shelly community thread](https://community.shelly.cloud/topic/11528-zigbee-network-instability-flooding-with-two%C2%A0shelly-power-strip-4-gen4%C2%A0zigbee2mqtt-cc2652p7/).
