### PR TITLE
Update E2490.md with direct binding limitations

### DIFF
--- a/docs/devices/E2490.md
+++ b/docs/devices/E2490.md
@@ -118,6 +118,8 @@ They can't be unbound / bound to anything else ([binding](../guide/usage/binding
 To directly control devices, follow the [Touchlink steps](#touchlink). That will unlock the 3 channels and add the target devices to the respective groups.  
 After you've unlocked the 3 channels, you can create the groups in Zigbee2MQTT and add / remove any devices you want to control (skipping the Touchlink steps).  
 
+If you try to use the remotes with direct binding (remote talking directly to the bulb), you will run into a wall. Because every Bilresa remote is hardcoded to broadcast to the same three group IDs ($21658$, $21659$, and $21660$), any bulb added to "Group 1" will respond to every Bilresa remote in your house at once.
+
 Zigbee2MQTT doesn't know the remote controls the groups. **So you must additionally set up reporting for the target devices** to keep their real states in sync with the virtual states.
 
 ### Action mapping


### PR DESCRIPTION
Clarify limitations of direct binding with Bilresa remotes and emphasize the need for reporting setup.