### PR TITLE
Allow whiteLabels of whiteLabels

### DIFF
--- a/docgen/generate_device.ts
+++ b/docgen/generate_device.ts
@@ -67,7 +67,14 @@ pageClass: device-page
 | Description | ${device.description} |
 | Exposes | ${exposesDescription} |
 | Picture | ![${device.vendor} ${device.model}](${image}) |
-${device.whiteLabel ? `| White-label | ${device.whiteLabel.map((d) => `${d.vendor ? d.vendor + ' ' : ''}${d.model}`).join(', ')} |\n` : ''}
+${
+    device.whiteLabel
+        ? `| White-label | ${device.whiteLabel
+              .filter((d) => !d.linkToModel || d.linkToModel === device.model)
+              .map((d) => `${d.vendor ? d.vendor + ' ' : ''}${d.model}`)
+              .join(', ')} |\n`
+        : ''
+}
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ${notes || '\n'}

--- a/docgen/generate_device.ts
+++ b/docgen/generate_device.ts
@@ -70,7 +70,7 @@ pageClass: device-page
 ${
     device.whiteLabel
         ? `| White-label | ${device.whiteLabel
-              .filter((d) => !d.linkToModel || d.linkToModel === device.model)
+              .filter((d) => !d.whiteLabelOf || d.whiteLabelOf === device.model)
               .map((d) => `${d.vendor ? d.vendor + ' ' : ''}${d.model}`)
               .join(', ')} |\n`
         : ''

--- a/docgen/generate_supported-devices.ts
+++ b/docgen/generate_supported-devices.ts
@@ -28,7 +28,7 @@ export default async function generate_supportedDevices() {
                     vendor: w.vendor ?? definition.vendor,
                     description: w.description ?? definition.description,
                     isWhiteLabel: true,
-                    whiteLabelOf: 'linkToModel' in w && w.linkToModel ? definitionMap.get(w.linkToModel) : definition,
+                    whiteLabelOf: 'whiteLabelOf' in w && w.whiteLabelOf ? definitionMap.get(w.whiteLabelOf) : definition,
                 };
 
                 delete whiteLabelDefinition.whiteLabel;

--- a/docgen/generate_supported-devices.ts
+++ b/docgen/generate_supported-devices.ts
@@ -15,18 +15,20 @@ export default async function generate_supportedDevices() {
     try {
     } catch (e) {}
 
+    const definitionMap = new Map(allDefinitions.map((d) => [d.model, d]));
+
     let definitions: (Definition & {isWhiteLabel?: boolean; whiteLabelOf?: Definition})[] = [...allDefinitions];
 
     for (const definition of allDefinitions) {
         if (definition.whiteLabel) {
-            for (const whiteLabel of definition.whiteLabel) {
+            for (const w of definition.whiteLabel) {
                 const whiteLabelDefinition = {
                     ...definition,
-                    model: whiteLabel.model,
-                    vendor: whiteLabel.vendor ?? definition.vendor,
-                    description: whiteLabel.description ?? definition.description,
+                    model: w.model,
+                    vendor: w.vendor ?? definition.vendor,
+                    description: w.description ?? definition.description,
                     isWhiteLabel: true,
-                    whiteLabelOf: definition,
+                    whiteLabelOf: 'linkToModel' in w && w.linkToModel ? definitionMap.get(w.linkToModel) : definition,
                 };
 
                 delete whiteLabelDefinition.whiteLabel;

--- a/docgen/utils.ts
+++ b/docgen/utils.ts
@@ -66,12 +66,13 @@ for (const definition of baseDefinitions) {
     if ('whiteLabel' in resolvedDefinition && resolvedDefinition.whiteLabel) {
         for (const whiteLabel of resolvedDefinition.whiteLabel.filter((w) => 'fingerprint' in w && w.fingerprint)) {
             const {vendor, model, description} = whiteLabel;
+            const whiteLabelsOfWhiteLabel = resolvedDefinition.whiteLabel.filter((d) => 'linkToModel' in d && d.linkToModel === model);
             allDefinitionsTemp.push({
                 ...resolvedDefinition,
                 vendor: vendor ?? definition.vendor,
                 model,
                 description: description || resolvedDefinition.description,
-                whiteLabel: undefined,
+                whiteLabel: whiteLabelsOfWhiteLabel.length ? whiteLabelsOfWhiteLabel : undefined,
                 // @ts-expect-error for expose generator
                 whiteLabelFingerprint: 'fingerprint' in whiteLabel ? whiteLabel.fingerprint : undefined,
             });

--- a/docgen/utils.ts
+++ b/docgen/utils.ts
@@ -66,7 +66,7 @@ for (const definition of baseDefinitions) {
     if ('whiteLabel' in resolvedDefinition && resolvedDefinition.whiteLabel) {
         for (const whiteLabel of resolvedDefinition.whiteLabel.filter((w) => 'fingerprint' in w && w.fingerprint)) {
             const {vendor, model, description} = whiteLabel;
-            const whiteLabelsOfWhiteLabel = resolvedDefinition.whiteLabel.filter((d) => 'linkToModel' in d && d.linkToModel === model);
+            const whiteLabelsOfWhiteLabel = resolvedDefinition.whiteLabel.filter((d) => 'whiteLabelOf' in d && d.whiteLabelOf === model);
             allDefinitionsTemp.push({
                 ...resolvedDefinition,
                 vendor: vendor ?? definition.vendor,


### PR DESCRIPTION
- requires https://github.com/Koenkk/zigbee-herdsman-converters/pull/12132

WhiteLabels without fingerprints don't generate device pages. They are linked to the main model.

**I added the possibility to link them to a specific model** (to a whiteLabel with fingerprint).

I need this because firmware is not unique per brand.
I can not rename the `_TZ3000_zgyzgdua` fingerprint to Nous, because there is `_TZ3000_zgyzgdua` from Moes and more Tuya vendors.

<img width="80%" alt="inception" src="https://github.com/user-attachments/assets/25502098-68c6-4663-a41c-00af6cffaadf" />
<p>

<img width="30%" src="https://github.com/user-attachments/assets/2595c18d-283d-4c38-8e28-7e512d37d032" />
<img width="30%" src="https://github.com/user-attachments/assets/4c8b5d28-d55d-41ff-bd2d-d0a26c76a515" />
