### PR TITLE
Update Legrand 412170: add note about device_mode auto producing erratic behavior

### DIFF
--- a/docs/devices/412170.md
+++ b/docs/devices/412170.md
@@ -27,7 +27,7 @@ pageClass: device-page
 
 ## Notes
 
-The factory-default device_mode produces erratic relay behavior with the L to C1 push-button wiring shown in Legrand's wiring instructions. Set device_mode to switch for predictable operation. The auto value appears to be a leftover from cloning the 412171 contactor entry: this 412170 has no corresponding "Off-peak/peak time" setting in the official Legrand Home+Control app (unlike the 412171, which does).
+The factory-default device_mode produces erratic relay behavior with the L to C1 push-button wiring shown in Legrand's wiring instructions. Set device_mode to switch for predictable operation. The auto value appears to be a leftover from cloning the 412171 contactor entry: this 412170 has no corresponding "Off-peak/peak time" (auto) setting in the official Legrand Home+Control app (unlike the 412171, which does).
 
 
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/412170.md
+++ b/docs/devices/412170.md
@@ -25,6 +25,10 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Notes
+
+The factory-default device_mode produces erratic relay behavior with the L to C1 push-button wiring shown in Legrand's wiring instructions. Set device_mode to switch for predictable operation. The auto value appears to be a leftover from cloning the 412171 contactor entry: this 412170 has no corresponding "Off-peak/peak time" setting in the official Legrand Home+Control app (unlike the 412171, which does).
+
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
Adds a notes section to the 412170 device page warning users that the factory-default `device_mode` produces erratic relay behavior with the L to C1 push-button wiring shown in Legrand's wiring instructions, and that setting `device_mode` to `switch` is required for predictable operation.

Goes with Koenkk/zigbee-herdsman-converters#12141 which updates the inline `withDescription` text in the converter. Background info including info on Wireshark capture against the official Legrand Gateway, Home+Control app comparison with the 412171, etc. are in the linked PR.
