### PR TITLE
fix: add `enable_external_js` warnings

### DIFF
--- a/docs/advanced/more/external_converters.md
+++ b/docs/advanced/more/external_converters.md
@@ -4,6 +4,12 @@ sidebar: auto
 
 # External converters
 
+:::warning WARNING
+External converters are disabled by default in new installations in version 2.11.0 and later.
+See [`enable_external_js`](../../guide/configuration/all-settings.md#enable-external-js) to enable it.
+See [more details](../../guide/installation/14_securing.md#external-extensions-and-converters)
+:::
+
 Zigbee2MQTT uses [zigbee-herdsman-converters](https://github.com/Koenkk/zigbee-herdsman-converters) to parse messages to and from devices.
 
 External converters provide a way to test support for new devices, they work identically to internal converters.

--- a/docs/advanced/more/external_extensions.md
+++ b/docs/advanced/more/external_extensions.md
@@ -4,6 +4,12 @@ sidebar: auto
 
 # External extensions
 
+:::warning WARNING
+External extensions are disabled by default in new installations in version 2.11.0 and later.
+See [`enable_external_js`](../../guide/configuration/all-settings.md#enable-external-js) to enable it.
+See [more details](../../guide/installation/14_securing.md#external-extensions-and-converters)
+:::
+
 External extensions provide a way to extend Zigbee2MQTT behavior, they work identically to internal extensions.
 
 To get familiar with the Extension framework, refer to the [source code of internal extensions](https://github.com/Koenkk/zigbee2mqtt/tree/master/lib/extension).


### PR DESCRIPTION
For https://github.com/Koenkk/zigbee2mqtt/pull/31826
Note: will need to run docgen for URLs to be valid.