### PR TITLE
Fix brand reporting table

### DIFF
--- a/docs/guide/usage/binding.md
+++ b/docs/guide/usage/binding.md
@@ -78,19 +78,18 @@ When a devices is being bound to, Zigbee2MQTT will automatically configure repor
 
 In order for this feature to work, the device has to support it. As devices from the same manufacturer (mostly) have the same features the table below might help to find out if your device supports it.
 
-| Brand            | On/Off | Brightness | Color | Color temperature | Color Mode |
-| :--------------- | :----: | :--------: | :---: | :---------------: | :--------: |
-| Philips Hue      |  N(1)  |    N(2)    |   N   |         N         |     N      |
-| Philips Hue (BT) |   Y    |     Y      |   Y   |         Y         |     N      |
-| Trådfri(3)       |   Y    |     Y      |   Y   |         N         |     Y      |
-| Innr             |   Y    |     Y      |   Y   |         Y         |     Y      |
-| GLEDOPTO         |   N    |     N      |   N   |         N         |     N      |
-| OSRAM            |   Y    |     Y      |   N   |         N         |     Y      |
-| Müller Licht     |   N    |     N      |   N   |         N         |     Y      |
+| Brand               | On/Off | Brightness | Color | Color temperature | Color mode |
+| :------------------ | :----: | :--------: | :---: | :---------------: | :--------: |
+| Philips Hue (ZB)    |   N¹   |     N²     |   N   |         N         |     N      |
+| Philips Hue (ZB+BT) |   Y    |     Y      |   Y   |         Y         |     N      |
+| IKEA                |   Y    |     Y      |   Y   |         Y         |     Y      |
+| Innr                |   Y    |     Y      |   Y   |         Y         |     Y      |
+| GLEDOPTO            |   N    |     N      |   N   |         N         |     N      |
+| OSRAM               |   Y    |     Y      |   N   |         N         |     Y      |
+| Müller Licht        |   N    |     N      |   N   |         N         |     Y      |
 
 1. Bulbs on old firmware (date 20170908 or older) do report On/Off
 2. Zigbee2MQTT will manual poll for change if a binding updates the bulb.
-3. The color/brightness of a Trådfri bulb can be changed while the state=off, it also reports back the change.
 
 If your devices do **not** support reporting put the device in a group and bind the remote to the group instead of directly to the device. This will make Zigbee2MQTT poll the device for updates when the bound remote controls the device. To minimize traffic this has not been enabled for all devices. If this does not work please create an issue for it [here](https://github.com/Koenkk/zigbee2mqtt/issues).
 

--- a/docs/guide/usage/binding.md
+++ b/docs/guide/usage/binding.md
@@ -78,18 +78,19 @@ When a devices is being bound to, Zigbee2MQTT will automatically configure repor
 
 In order for this feature to work, the device has to support it. As devices from the same manufacturer (mostly) have the same features the table below might help to find out if your device supports it.
 
-| Brand               | On/Off | Brightness | Color | Color temperature | Color mode |
-| :------------------ | :----: | :--------: | :---: | :---------------: | :--------: |
-| Philips Hue (ZB)    |   N¹   |     N²     |   N   |         N         |     N      |
-| Philips Hue (ZB+BT) |   Y    |     Y      |   Y   |         Y         |     N      |
-| IKEA                |   Y    |     Y      |   Y   |         Y         |     Y      |
-| Innr                |   Y    |     Y      |   Y   |         Y         |     Y      |
-| GLEDOPTO            |   N    |     N      |   N   |         N         |     N      |
-| OSRAM               |   Y    |     Y      |   N   |         N         |     Y      |
-| Müller Licht        |   N    |     N      |   N   |         N         |     Y      |
+| Brand              | On/Off | Brightness | Color | Color temperature | Color mode |
+| :----------------- | :----: | :--------: | :---: | :---------------: | :--------: |
+| Philips Hue (old)  |   N¹   |     N²     |   N   |         N         |     N      |
+| Philips Hue (new³) |   Y    |     Y      |   Y   |         Y         |     N      |
+| IKEA               |   Y    |     Y      |   Y   |         Y         |     Y      |
+| Innr               |   Y    |     Y      |   Y   |         Y         |     Y      |
+| GLEDOPTO           |   N    |     N      |   N   |         N         |     N      |
+| OSRAM              |   Y    |     Y      |   N   |         N         |     Y      |
+| Müller Licht       |   N    |     N      |   N   |         N         |     Y      |
 
 1. Bulbs on old firmware (date 20170908 or older) do report On/Off
 2. Zigbee2MQTT will manual poll for change if a binding updates the bulb.
+3. Devices manufactured after ~2019
 
 If your devices do **not** support reporting put the device in a group and bind the remote to the group instead of directly to the device. This will make Zigbee2MQTT poll the device for updates when the bound remote controls the device. To minimize traffic this has not been enabled for all devices. If this does not work please create an issue for it [here](https://github.com/Koenkk/zigbee2mqtt/issues).
 

--- a/docs/guide/usage/binding.md
+++ b/docs/guide/usage/binding.md
@@ -90,7 +90,7 @@ In order for this feature to work, the device has to support it. As devices from
 
 1. Bulbs on old firmware (date 20170908 or older) do report On/Off
 2. Zigbee2MQTT will manual poll for change if a binding updates the bulb.
-3. Devices manufactured after ~2019
+3. Lamps & bulbs released starting around 2019
 
 If your devices do **not** support reporting put the device in a group and bind the remote to the group instead of directly to the device. This will make Zigbee2MQTT poll the device for updates when the bound remote controls the device. To minimize traffic this has not been enabled for all devices. If this does not work please create an issue for it [here](https://github.com/Koenkk/zigbee2mqtt/issues).
 


### PR DESCRIPTION
IDK about this table, kinda out-of-place... not all devices follow the "brand rule"..
Maybe we can have a Reporting doc page and move it there.

- I can confirm reporting fails for old Hue bulbs (even on 2024 firmware) with table_full / unsupported_manuf_general_command.
- I can confirm reporting works for new Hue bulbs, but not color temp.
- All reporting works on my IKEA bulbs (latest tradfri and kajplats)..
  - **changed color temp to Yes** 
- Changing brightness while bulb is off is not specific to IKEA.. should work on most bulbs
  - **removed**

cc @burmistrzak 