### PR TITLE
Enhance documentation for power drop threshold

### DIFF
--- a/docs/devices/3RSP02064Z.md
+++ b/docs/devices/3RSP02064Z.md
@@ -160,6 +160,11 @@ The unit of this value is `w`.
 ### Power drop threshold (numeric)
 Reports sudden power changes. Power rise and drop alerts can be enabled separately. Threshold adjustable..
 Value can be found in the published state on the `power_drop_threshold` property.
+
+## Notes
+
+### Instantaneous Reporting
+Out of the box, instant power reading (W) can be delayed for almost 1 minutes (or longer). To get faster reporting, set the "Power drop/rise" thresholds to 1W (or your choice). After doing this, power readings should come in nearly instantly.
 To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"power_drop_threshold": ""}`.
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"power_drop_threshold": NEW_VALUE}`.
 The minimal value is `1` and the maximum value is `3200`.

--- a/docs/devices/3RSP02064Z.md
+++ b/docs/devices/3RSP02064Z.md
@@ -160,13 +160,12 @@ The unit of this value is `w`.
 ### Power drop threshold (numeric)
 Reports sudden power changes. Power rise and drop alerts can be enabled separately. Threshold adjustable..
 Value can be found in the published state on the `power_drop_threshold` property.
-
-## Notes
-
-### Instantaneous Reporting
-Out of the box, instant power reading (W) can be delayed for almost 1 minutes (or longer). To get faster reporting, set the "Power drop/rise" thresholds to 1W (or your choice). After doing this, power readings should come in nearly instantly.
 To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"power_drop_threshold": ""}`.
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"power_drop_threshold": NEW_VALUE}`.
 The minimal value is `1` and the maximum value is `3200`.
 The unit of this value is `w`.
 
+## Notes
+
+### Instantaneous Reporting
+Out of the box, instant power reading (W) can be delayed for almost 1 minutes (or longer). To get faster reporting, set the "Power drop/rise" thresholds to 1W (or your choice). After doing this, power readings should come in nearly instantly.

--- a/docs/devices/3RSP02064Z.md
+++ b/docs/devices/3RSP02064Z.md
@@ -24,6 +24,10 @@ pageClass: device-page
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 
+## Notes
+
+### Instantaneous Reporting
+Out of the box, instant power reading (W) can be delayed for almost 1 minutes (or longer). To get faster reporting, set the "Power drop/rise" thresholds to 1W (or your choice). After doing this, power readings should come in nearly instantly.
 
 <!-- Notes END: Do not edit below this line -->
 
@@ -164,8 +168,3 @@ To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"power_drop_threshold": NEW_VALUE}`.
 The minimal value is `1` and the maximum value is `3200`.
 The unit of this value is `w`.
-
-## Notes
-
-### Instantaneous Reporting
-Out of the box, instant power reading (W) can be delayed for almost 1 minutes (or longer). To get faster reporting, set the "Power drop/rise" thresholds to 1W (or your choice). After doing this, power readings should come in nearly instantly.

--- a/docs/devices/3RSP02064Z.md
+++ b/docs/devices/3RSP02064Z.md
@@ -168,3 +168,4 @@ To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME
 To write (`/set`) a value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"power_drop_threshold": NEW_VALUE}`.
 The minimal value is `1` and the maximum value is `3200`.
 The unit of this value is `w`.
+


### PR DESCRIPTION
Added notes on instantaneous reporting and power drop threshold settings.

Out of the box, instant power doesn't really report (takes forever or doesn't change at all) - even which power cycling connected devices on the plug.

This was found by trial and error, and doesn't seem to be documented anywhere. I tried the normal Reporting Z2M settings first, but it had no effect. This did work, however.

<img width="915" height="301" alt="image" src="https://github.com/user-attachments/assets/540d9ea1-5c89-4fe9-9bc1-3faba81c9d23" />
