### PR TITLE
Fix "last updated" info

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -11,6 +11,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v4

--- a/vuepress.config.ts
+++ b/vuepress.config.ts
@@ -108,6 +108,7 @@ const conf = defineUserConfig({
         repoLabel: 'GitHub (docs)',
         docsBranch: isDevelop ? 'develop' : 'master',
         editLinkText: 'Help to make the docu better and edit this page on Github ✌',
+        lastUpdatedText: 'Page was last updated on',
         logo: '/logo.png',
         docsDir: 'docs',
         navbar,


### PR DESCRIPTION
All pages in Z2M docs (both guides and devices) currently show:
> Last Updated: 5/15/26, 2:52 PM

https://www.zigbee2mqtt.io/guide/supported-hardware.html
https://www.zigbee2mqtt.io/devices/014G2480.html

This is wrong and causes confusion (here https://github.com/Koenkk/zigbee2mqtt/issues/31765)

1. Message refers to the page itself, not necessarily to the device implementation
**⤷ changed "Last Updated" to "Page was last updated on"**

2. The correct date can be seen in git history. But the workflow fetches only the last commit by default
**⤷ changed action to fetch all history**

https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docs/guide/supported-hardware.md
https://github.com/Koenkk/zigbee2mqtt.io/blob/master/docs/devices/014G2480.md

I tested on my fork: build (without devices) and upload dist (generated html files) as artifact
[Before](https://github.com/andrei-lazarov/zigbee2mqtt.io/actions/runs/25943437438): wrong dates
[After](https://github.com/andrei-lazarov/zigbee2mqtt.io/actions/runs/25943641069): correct dates

Still, I'm not sure how the deploy branch works, so hopefully I made the fix in the correct place