### PR TITLE
IKEA Matter -  warnings for unofficial support

### DIFF
--- a/docgen/device_page_notes/ikea_kajplats.ts
+++ b/docgen/device_page_notes/ikea_kajplats.ts
@@ -2,7 +2,6 @@ export function ikeaKajplats(definition) {
     if (definition.vendor === 'IKEA' && definition.description.includes('KAJPLATS')) {
         const cycles = definition.description.includes('clear') ? '15' : '12';
         return `
-
 ## Related
 - [KAJPLATS color/white spectrum](./KAJPLATS_CWS.md)
 - [KAJPLATS white spectrum](./KAJPLATS_WS.md)

--- a/docgen/device_page_warnings/ikea_matter.ts
+++ b/docgen/device_page_warnings/ikea_matter.ts
@@ -1,0 +1,10 @@
+export function ikeaMatter(definition) {
+    if (definition.vendor === 'IKEA' && definition.description.includes('Matter')) {
+        return `
+## Unofficial support
+**This device is part of the IKEA Matter/Thread line-up.**  
+The hidden Zigbee mode is not officially supported by IKEA. It exists mainly to keep backwards compatibility via Touchlink.  
+As a result, the Zigbee firmware is stripped-down to the essentials, and could even be removed in OTA updates.
+`;
+    }
+}

--- a/docgen/device_page_warnings/index.ts
+++ b/docgen/device_page_warnings/index.ts
@@ -1,0 +1,10 @@
+import {ikeaMatter} from './ikea_matter';
+
+const warnings = [ikeaMatter];
+
+export function getWarnings(definition, exposes) {
+    return warnings
+        .map((n) => n(definition))
+        .filter((n) => n)
+        .join('\n');
+}

--- a/docgen/generate_device.ts
+++ b/docgen/generate_device.ts
@@ -8,6 +8,7 @@ import {generateExpose} from './device_page_exposes';
 import {generateOptions} from './device_page_options';
 import {devicesBaseDir, imageBaseDir, imageBaseUrl} from './constants';
 import {getNotes} from './device_page_notes';
+import {getWarnings} from './device_page_warnings';
 
 export function resolveDeviceFile(model) {
     return path.resolve(devicesBaseDir, `${normalizeModel(model)}.md`);
@@ -69,6 +70,7 @@ pageClass: device-page
 | Picture | ![${device.vendor} ${device.model}](${image}) |
 ${device.whiteLabel ? `| White-label | ${device.whiteLabel.map((d) => `${d.vendor ? d.vendor + ' ' : ''}${d.model}`).join(', ')} |\n` : ''}
 
+${getWarnings(device, exposes)}
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ${notes || '\n'}
 <!-- Notes END: Do not edit below this line -->

--- a/docs/devices/E2490.md
+++ b/docs/devices/E2490.md
@@ -29,8 +29,6 @@ pageClass: device-page
 [BILRESA dual-button](./E2489.md)
 
 ### Information
-**This device is part of the IKEA Matter/Thread line-up.**  
-  The hidden Zigbee mode is not officially supported by IKEA. It exists mainly to keep backwards compatibility via Touchlink. As a result, the Zigbee firmware is stripped-down to the essentials, and could even be removed in OTA updates
 - [FCC - emissions and teardown](https://apps.fcc.gov/oetcf/eas/reports/ViewExhibitReport.cfm?mode=Exhibits&RequestTimeout=500&calledFromFrame=N&application_id=KTcW2uUWouf6%2Fcr1RahcHg%3D%3D&fcc_id=FHO-E2490)
 - [CSA IoT - Matter compliance](https://csa-iot.org/csa_product/bilresa-scroll-wheel/)
 - [CSA IoT - Zigbee compliance](https://csa-iot.org/csa_product/bilresa-scroll-wheel-2/)


### PR DESCRIPTION
Adds this to all IKEA devices with "Matter" in their description

> ## Unofficial support
> **This device is part of the IKEA Matter/Thread line-up.**  
> The hidden Zigbee mode is not officially supported by IKEA. It exists mainly to keep backwards compatibility via Touchlink.  
> As a result, the Zigbee firmware is stripped-down to the essentials, and could even be removed in OTA updates.

I made a new function, so this displays **above** the user-submitted notes