### PR TITLE
Update Legrand 067776A: Add info for pairing on older fw, calibration for venetian mode, tilt control in UI

### DIFF
--- a/docs/devices/067776A.md
+++ b/docs/devices/067776A.md
@@ -47,14 +47,16 @@ Face the shutter you wish to calibrate. LED has to blink orange for this procedu
 * **Step 2:** Hold the down button on your switch and release when the shutter is fully closed.
 * **Step 3:** Now hold the up button of your switch and release when the shutter is fully open.
 * **Step 4:** Hold the down button on your switch and release when the shutter is fully closed.
-* **Step 5:** Finally, hold the up button on your switch to open the shutter blades. Release as soon as the blades are fully open. 
-Your orientable sun shade is now calibrated! Hold the buttons of your switch to control the opening of the blades.
+* **Step 5:** Finally, hold the up button on your switch to open the shutter blades. Release as soon as the blades are fully open.
+
+Your orientable sun shade is now calibrated! Hold the buttons of your switch to control the opening of the blades.  
+**Tilt control**: After setting calibration mode to `venetian_bso`, you may need to restart Zigbee2MQTT for tilt control to show up in the UI.
 
 ### Model number
 Model number depends on the country and the colour of the devices.
-French models are branded as Céliane with Netatmo, and model numbers for this device depends on the colour, with the following numbers: "0 677 26A", "0 677 76A" and "0 648 96A".
-Spanish models are branded as Legrand Valena Next, and model numbers for this device depends on the colour, with the following numbers: "7 418 07A", "7 418 37A" and "7 418 67A".
-Recent German and Austrian Models are are branded as Legrand Seano with Netatmo, and model numbers for this device depend on the colour, with the following numbers: "7 656 38", "7 657 38", "7 658 38" and "7 659 38".
+* French models are branded as Céliane with Netatmo, and model numbers for this device depends on the colour, with the following numbers: "0 677 26A", "0 677 76A" and "0 648 96A".
+* Spanish models are branded as Legrand Valena Next, and model numbers for this device depends on the colour, with the following numbers: "7 418 07A", "7 418 37A" and "7 418 67A".
+* Recent German and Austrian Models are are branded as Legrand Seano with Netatmo, and model numbers for this device depend on the colour, with the following numbers: "7 656 38", "7 657 38", "7 658 38" and "7 659 38".
 
 ### Variants
 There is a variant of this device that is an internal module (i.e. not a switch) with model "0 676 97".  It only has two buttons (one for 'setup', the other that will toggle

--- a/docs/devices/067776A.md
+++ b/docs/devices/067776A.md
@@ -27,24 +27,34 @@ pageClass: device-page
 
 ### Pairing
 
-Devices shipped with older firmware may fail to fully pair on first attempt (LED stays blinking green even after Zigbee2MQTT reports successful interview). If this occurs, follow the workaround in [#20617](https://github.com/Koenkk/zigbee2mqtt/issues/20617), which involves resetting the device, restarting Zigbee2MQTT, and re-pairing. Devices on newer firmware (tested on firmware build `67`) pair normally without the workaround. After pairing on older firmware, an OTA update to the latest version is recommended.
+Devices shipped with older firmware may fail to fully pair on first attempt (LED stays blinking green even after Zigbee2MQTT reports successful interview). If this occurs, follow the workaround in [#20617](https://github.com/Koenkk/zigbee2mqtt/issues/20617), which involves resetting the device, restarting Zigbee2MQTT, and re-pairing. Devices on newer firmware (tested on firmware build `67` and `71`) pair normally without the workaround. After pairing on older firmware, an OTA update to the latest version is recommended.
 
-### Calibration
-You can calibrate your device (to enable position support) by closing the shutter (or opening it if your cover 
-position is inverted) and pressing both the up and down buttons for about 5 seconds until you see a blinking yellow 
-light. The shutter will begin calibrating itself and will open and close a few times (this process takes a few 
-minutes to complete).  To initiate calibrate using Z2M (rather than the buttons), perform the following steps:
+### Calibration using Z2M
+To start calibration using Z2M, perform the following steps:
 * Ensure that the device is fully joined to the Z2M coordinator (green light solid, *not* flashing)
-* Use the device's 'Exposes' page in Z2M to set the calibration mode (typically 'specific_nllv').  If it is already in the desired calibration mode, switch to a different calibration mode,
-  wait a few seconds, then switch back.
-* The LED should start flashing orange.  Nothing will happen immediately - this is OK.  Wait a few minutes, then the device will automatically lower the cover, wait a few minutes, then raise it
-  again (or maybe do some other calibration steps depending upon your setup)
+* Use the device's 'Exposes' page in Z2M to set the calibration mode (typically `specific_nllv`).  If it is already in the desired calibration mode, switch to `up_down_stop`, wait a few seconds, then switch back.
+* The LED should start flashing orange.  Nothing will happen immediately - this is OK.  Wait a few minutes, then the device will automatically lower the cover, wait a few minutes, then raise it again (or maybe do some other calibration steps depending upon your setup)
 * The LED will stop flashing orange once calibration is complete (might take up to 5 minutes total)
+
+### Calibration from the device
+You can launch calibration directly from your device by simultaneously pressing the up and down buttons for 7 seconds. The LED starts flashing in orange. The shutter will begin calibrating itself and will open and close a few times (this process takes around 5 
+minutes to complete). Do not press any button on the product during this calibration procedure.
+
+### Calibration for Venetian mode (BSO)
+For mode `venetian_bso` (orientable sun shades) you need to follow the same special calibration procedure as outlined in Legrand's Home+Control app as follows. 
+Face the shutter you wish to calibrate. LED has to blink orange for this procedure. Duration about 5 minutes. As soon as you set mode `venetian_bso` via Z2M the device starts blinking orange and you can begin:
+* **Step 1:** Hold the down button of your switch and release when the shutter is half open (50% open). If you release a little too early or too late, still go to the next step.
+* **Step 2:** Hold the down button on your switch and release when the shutter is fully closed.
+* **Step 3:** Now hold the up button of your switch and release when the shutter is fully open.
+* **Step 4:** Hold the down button on your switch and release when the shutter is fully closed.
+* **Step 5:** Finally, hold the up button on your switch to open the shutter blades. Release as soon as the blades are fully open. 
+Your orientable sun shade is now calibrated! Hold the buttons of your switch to control the opening of the blades.
 
 ### Model number
 Model number depends on the country and the colour of the devices.
-French models are branded as Céliane with Netatmo, and models for this device depends on the colour, with the following numbers: "0 677 26A", "0 677 76A" and "0 648 96A".
-Spanish models are branded as Legrand Valena Next, and models for this device depends on the colour, with the following numbers: "7 418 07A", "7 418 37A" and "7 418 67A".
+French models are branded as Céliane with Netatmo, and model numbers for this device depends on the colour, with the following numbers: "0 677 26A", "0 677 76A" and "0 648 96A".
+Spanish models are branded as Legrand Valena Next, and model numbers for this device depends on the colour, with the following numbers: "7 418 07A", "7 418 37A" and "7 418 67A".
+Recent German and Austrian Models are are branded as Legrand Seano with Netatmo, and model numbers for this device depend on the colour, with the following numbers: "7 656 38", "7 657 38", "7 658 38" and "7 659 38".
 
 ### Variants
 There is a variant of this device that is an internal module (i.e. not a switch) with model "0 676 97".  It only has two buttons (one for 'setup', the other that will toggle

--- a/docs/devices/067776A.md
+++ b/docs/devices/067776A.md
@@ -25,6 +25,10 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Notes
 
+### Pairing
+
+Devices shipped with older firmware may fail to fully pair on first attempt (LED stays blinking green even after Zigbee2MQTT reports successful interview). If this occurs, follow the workaround in [#20617](https://github.com/Koenkk/zigbee2mqtt/issues/20617), which involves resetting the device, restarting Zigbee2MQTT, and re-pairing. Devices on newer firmware (tested on firmware build `67`) pair normally without the workaround. After pairing on older firmware, an OTA update to the latest version is recommended.
+
 ### Calibration
 You can calibrate your device (to enable position support) by closing the shutter (or opening it if your cover 
 position is inverted) and pressing both the up and down buttons for about 5 seconds until you see a blinking yellow 


### PR DESCRIPTION
Adds information
* for a pairing workaround needed for devices with older firmware
* info for the calibration procedure in mode venetian_bso (venetian blinds) 
* Info to restart z2m to show show tilt control in UI after changing mode



