### PR TITLE
Rewrite OTA updates doc

### DIFF
--- a/docs/guide/usage/ota_updates.md
+++ b/docs/guide/usage/ota_updates.md
@@ -3,41 +3,49 @@
 
 # OTA updates
 
-This feature allows to update your Zigbee devices over-the-air.
+This feature allows updating the firmware of Zigbee devices over-the-air.
 
-::: tip TIP
-Always check if the firmware update will bring you advantages. Firmware updates are often NOT made for Zigbee2MQTT, but for working with apps and hubs from the brand.
-In some cases the firmware update can cause your device to react differently than what Zigbee2MQTT expects, resulting in undesired behavior, no-longer accessible features, etc., at least until Zigbee2MQTT is updated to take those changes into account.
-If you get annoyed by the notifications that there are updates available, then turn the automatic check off.
+::: warning
+Firmware updates can provide bug fixes, security updates and other welcomed features.
+However, they can also change device behavior in ways that may affect Zigbee2MQTT compatibility and potentially introduce buggy, or even malicious functionality.
+**Review the release notes before applying a firmware update.**
 :::
 
-Not all manufacturers make their updates available, you can watch for new additions in [zigbee-OTA Releases](https://github.com/Koenkk/zigbee-OTA/releases), which, if available, include the changes in these new updates.
+By default, Zigbee2MQTT matches and retrieves OTA images from the [Koenkk/zigbee-OTA](https://github.com/Koenkk/zigbee-OTA) repository (if it has internet access).
+This repository is a mirror of manufacturer-provided firmware updates, both manually and automatically curated.
+[Using custom/local sources](#using-custom-firmware-files-or-index) is explained further down the page.
 
-To check whether your specific device supports OTA updates via Zigbee2MQTT, go to the supported devices page, click on your device and look for the _OTA updates_ section.
+::: tip
+Most actions and configurations on this page can be done via the frontend.
+:::
 
-## Automatic checking for available updates
+## Update status
 
-Zigbee devices supporting OTA can periodically request a firmware update check. Upon reception of such a request, Zigbee2MQTT will automatically check if an update is available and reply to the device accordingly. If an update is available, and you had previously scheduled an auto-update, Zigbee2MQTT will also signal the device to start the update.
-
-The update state will be published to `zigbee2mqtt/[DEVICE_FRIENDLY_NAME]`, example payload: `{"update":{"state":"available"}}`.
+The update state is published to `zigbee2mqtt/[DEVICE_FRIENDLY_NAME]`, example payload: `{"update":{"state":"available"}}`.
 The possible states are:
 
 - `idle`: No update available/in progress
 - `available`: An update is available for this device
-- `scheduled`: An update is scheduled on the next update check request from the device.
-- `updating`: An update is in progress.
-    - During this the progress in % and remaining time in seconds is also added to the payload (reported every 30sec), example: `{"update":{"state":"updating","progress":13.37,"remaining":219}}`.
-    - The first progress report (at 0%) gives an estimated remaining time based on the OTA settings. The actual remaining time will adjust with each progress report based on the current state (greatly affected by the network).
+- `scheduled`: An update may start on the next update check requested by the device
+- `updating`: An update is in progress
+    - During this the progress in % and remaining time in seconds is also added to the payload (reported every 30sec), example: `{"update":{"state":"updating","progress":13.37,"remaining":219}}`
+    - The first progress report (at 0%) gives an estimated remaining time based on the OTA settings. The actual remaining time will adjust with each progress report based on the current state (greatly affected by the network)
 
-You can set the minimum time that should pass between two firmware update checks, in minutes. The default is 1440 minutes (1 day). This does not prevent a device from requesting, Zigbee2MQTT will just ignore these messages if within that time.
-Here it is set to check at most every two days:
+## Checking for updates
+
+### Automatic checking
+
+Zigbee devices supporting OTA can periodically request a firmware update check. Upon reception of such a request, Zigbee2MQTT will check for updates (on the default source) and publish the result to MQTT.
+
+Some devices request updates too often. Zigbee2MQTT limits the checks to once per day (1440 min). The **update check interval** is configurable, but it does not prevent a device from requesting. Zigbee2MQTT will just ignore these messages if within that interval.  
+Here it is set to check at most once every two days, in `configuration.yaml`:
 
 ```yaml
 ota:
     update_check_interval: 2880
 ```
 
-It is also possible to completely ignore these device-initiated requests for updates checks (Zigbee2MQTT will always reply "no image available") by modifying the `configuration.yaml` file. In the example below, only manual firmware update checks will proceed:
+It is also possible to completely **ignore the update checks** initiated by devices (Zigbee2MQTT will always reply "no image available"). If `configuration.yaml` is modified like this, only manual checks will proceed:
 
 ```yaml
 ota:
@@ -46,209 +54,147 @@ ota:
 
 This is also available per-device. See [Device options](../configuration/devices-groups.md).
 
-:::tip TIP
-Disabling automatic update checks does not disable [scheduled OTA](#scheduling-update-on-next-device-request).
-:::
+Disabling automatic update checks does not prevent [scheduled OTA](#scheduling-update-on-next-device-request).
 
-## Manually check if an update is available
+### Manual checking
 
-To check if an upgrade is available for your device send a message to `zigbee2mqtt/bridge/request/device/ota_update/check` with payload `{"id":"deviceID"}` where deviceID can be the `ieee_address` or `friendly_name` of the device. Example; request: `{"id":"my_remote"}`, response: `{"data":{"id":"my_remote","update_available":false},"status":"ok"}`. If an update is available (`"update_available":true`), the response will also contain:
+To manually check for **updates**, send a message to `zigbee2mqtt/bridge/request/device/ota_update/check` with payload `{"id":"deviceID"}` where deviceID can be the `ieee_address` or `friendly_name` of the device.  
+To check if a **downgrade** is available, send the message to `zigbee2mqtt/bridge/request/device/ota_update/check/downgrade` instead.
+
+Zigbee2MQTT will request the current firmware information from the device (manufacturer code, image type and installed version). Only after reception, it will look up the OTA index.
+If the device does not respond, wake it up (e.g. push a button) right before checking, or wait for the automatic check.
+
+Example request: `{"id":"my_remote"}`, response: `{"data":{"id":"my_remote","update_available":false},"status":"ok"}`.
+
+If an update is available (`"update_available":true`), the response will also contain:
 
 - `source`: the URL or file path to the OTA file
 - `release_notes`: (if provided) the release notes for the source
 - `downgrade`: true if the availability is for a downgrade
 
-:::tip TIP
-For battery powered end-devices you may need to trigger them by e.g. pushing a button right before checking for an OTA.
+## Starting an update
+
+::: warning WARNINGS
+The update process greatly varies in duration: 10-100 minutes depending on device, settings and network stability. The device is usable during this time, but heavy traffic is added on the network. Therefore, the best practice is to **update one device at a time, while the network is in low demand.**
+
+When uploading the OTA file completes, the device will reboot with the new firmware. **The reboot may cause unwanted interruptions or turn-ons, due to power-on behavior (e.g. light-up in the middle of the night)!**
+
+Since updating can drastically change the device behavior, Zigbee2MQTT treats it similarly to pairing a new device. It will automatically re-interview to detect new capabilities and **re-configure to ensure normal operation (this may overwrite custom reporting intervals with the default values)**
 :::
 
-### Downgrade
+### Manual update request
 
-Same as above, but send the message to `zigbee2mqtt/bridge/request/device/ota_update/check/downgrade` instead.
+When an **update** is available, start it by sending a message to `zigbee2mqtt/bridge/request/device/ota_update/update` with payload `{"id":"deviceID"}` where deviceID can be the `ieee_address` or `friendly_name` of the device.  
+When a **downgrade** is available, start it by sending the message to `zigbee2mqtt/bridge/request/device/ota_update/update/downgrade` instead.
 
-## Update firmware
+If the device does not respond, wake it up (e.g. push a button) right before starting, or [schedule](#scheduling-update-on-next-device-request) the update.  
+The progress is published to the respective device topic, as described [above](#device-state).
 
-When an update is available for your device, you can upgrade it by sending a message to `zigbee2mqtt/bridge/request/device/ota_update/update` with payload `{"id":"deviceID"}` where deviceID can be the `ieee_address` or `friendly_name` of the device, example request: `{"id":"my_remote"}`. Once the update is completed, a response is sent, example response: `{"data":{"id":"my_remote","from":{"file_version":5,"software_build_id":1,"date_code":"20190101"},"to":{"file_version":10,"software_build_id":2,"date_code":"20190102"}},"status":"ok"}`. Note that since `software_build_id` and `date_code` are optional device attributes, they may not be in the payload if not supported by the device.
-
-::: tip TIP
-An update typically takes 10-20 minutes (although some devices may take a lot longer). While a device is updating a lot of traffic is generated on the network, therefore it is not recommended to execute multiple updates at the same time, and ideally to update while the network is less in-demand.
-:::
-
-:::tip TIP
-Upon completion of uploading an OTA file to a device, the device will apply the update, reboot, then re-announce itself. Zigbee2MQTT allocates 2 minutes before considering the update done, if the device did not re-announce itself. After this, Zigbee2MQTT will re-interview the device to ensure any new capability is detected.
-:::
-
-#### Override OTA settings
-
-You can override OTA settings per-request by providing the following in the payload: `image_block_request_timeout`, `image_block_response_delay`, `default_maximum_data_size`. Any combination is accepted; any setting not provided will use the one in the `configuration.yaml` if present, or the default.
-
-See [Advanced configuration](#advanced-configuration) for details about these settings.
-
-### Downgrade
-
-Same as above but send the message to `zigbee2mqtt/bridge/request/device/ota_update/update/downgrade` instead.
+Once the update is completed, a response is sent, example response: `{"data":{"id":"my_remote","from":{"file_version":5,"software_build_id":1,"date_code":"20190101"},"to":{"file_version":10,"software_build_id":2,"date_code":"20190102"}},"status":"ok"}`.  
+Note that `software_build_id` and `date_code` are optional device attributes.
 
 ### Scheduling update on next device request
 
+It's possible to schedule the update for the next time the device requests an OTA update check.
+
 :::tip TIP
-This can help for battery-powered devices that will usually fail to respond to [manual update requests](#update-firmware) unless physically woken up right before triggering. Some brands/models are also known to only update this way (e.g. some Legrand devices).
+This can help for battery-powered devices that usually don't respond to [manual update requests](#manual-update-request) unless physically woken up right before triggering. Some brands/models are known to only update this way (e.g. some Legrand devices).
 :::
 
-You can schedule an automatic update for the next time the device requests an OTA update check.
-Send a message to `zigbee2mqtt/bridge/request/device/ota_update/schedule` with payload `{"id":"deviceID"}` where deviceID can be the `ieee_address` or `friendly_name` of the device, example request: `{"id":"my_remote"}`.
+To schedule, send a message to `zigbee2mqtt/bridge/request/device/ota_update/schedule` with payload `{"id":"deviceID"}` where deviceID can be the `ieee_address` or `friendly_name` of the device, example request: `{"id":"my_remote"}`.  
 The same applies for downgrade with topic `zigbee2mqtt/bridge/request/device/ota_update/schedule/downgrade`.
 
 To unschedule, send the same payload, but with the topic `zigbee2mqtt/bridge/request/device/ota_update/unschedule`.
 
-Any new schedule request for the same device will automatically unschedule the previous (if any). For e.g. sending a downgrade schedule request while an upgrade is already scheduled will result in downgrade being scheduled, and upgrade being unscheduled.
+Scheduling status is saved in the database, and restored after Zigbee2MQTT restarts.
 
-Any [manual update request](#update-firmware) will automatically unschedule any existing schedule for the device if the update succeeds.
+If a scheduled update fails, it will remain scheduled (Device will try again, on the next check).  
+If there is no update available when the device requests, the schedule is removed.  
+A [manual update request](#manual-update-request) will remove the existing schedule, only if the update succeeds.
 
-If a scheduled update fails, it will remain scheduled (for the next check from the device).
+## Downgrading
 
-Devices scheduling information is saved in the database, and restored after a Zigbee2MQTT restart.
+Downgrading the firmware is also possible. Follow the same updating steps, but use the respective `downgrade` topics, as described above.
 
-## Using custom firmware files or index
+The default source ([Koenkk/zigbee-OTA](https://github.com/Koenkk/zigbee-OTA)) usually stores the latest and latest-1 images. This allows for one version downgrade. Otherwise, the older firmware must be provided by the user as a [custom source](#using-custom-firmware-files-or-index).
 
-:::caution CAUTION
-Improper use of custom OTA firmware files or index can result in bricked devices. Due to the nature of "custom firmware", several of the regular OTA constraints are bypassed in this mode. **Use trusted sources!**
-:::
+Even though Zigbee specification allows firmware downgrading, some devices may reject older firmware versions. Additionally, updating to a firmware of same version is not supported by Zigbee specification. This cannot be forced by Zigbee2MQTT.
 
-### URL / file path
-
-The following topics support supplying `url` in the payload, which can point to either an accessible URL, or a location on the file system where Zigbee2MQTT is installed. If `url` is a relative path, Zigbee2MQTT will assume this is relative to its data directory. If the pointed location is a JSON file (`*.json`), it will be treated as an index, else as a firmware file.
-
-- `bridge/request/device/ota_update/check`
-    - Only index (JSON) is supported, used for checking for availability of upgrade (instead of the default URL provided by Zigbee2MQTT)
-- `bridge/request/device/ota_update/check/downgrade`
-    - Only index (JSON) is supported, used for checking for availability of downgrade (instead of the default URL provided by Zigbee2MQTT)
-- `bridge/request/device/ota_update/update`
-- `bridge/request/device/ota_update/update/downgrade`
-- `bridge/request/device/ota_update/schedule`
-- `bridge/request/device/ota_update/schedule/downgrade`
-
-### Hex payload
-
-The following topics support supplying `hex` in the payload, which takes the form `"hex":{"data":"1EF1EEB0...","file_name":"my-file.ota"}`, where `data` is the full OTA file in hex string form. The `file_name` is optional, if not provided, one will be generated from the device's IEEE. This is used to store the firmware file under the Zigbee2MQTT data subdirectory `ota` upon receipt.
-
-Note: This is mainly intended for frontend use, where this payload is automatically built in the background from a "file upload" dialog.
-
-- `bridge/request/device/ota_update/update`
-- `bridge/request/device/ota_update/update/downgrade`
-- `bridge/request/device/ota_update/schedule`
-- `bridge/request/device/ota_update/schedule/downgrade`
-
-:::tip TIP
-The following tool can be used for various operations (inspect, edit, etc.) related to custom firmware: [https://nerivec.github.io/zigbee-ota-file-editor/](https://nerivec.github.io/zigbee-ota-file-editor/)
-:::
-
-## Troubleshooting
-
-- `Device didn't respond to OTA request` or `Update failed with reason: 'aborted by device'`: try restarting the device by disconnecting the power/battery for a few seconds, then try OTA again, make sure to activate the device by pressing a button on it right before sending the update request.
-- For battery powered devices make sure that the battery is 70%+ as OTA updating is very power consuming. Some devices check for a minimum battery level prior to updating and will refuse to update if too low.
-- Make sure your log level is set to `info`. When set to `warning` or `error`, frontend will not report some messages indicating the current OTA status.
+Backing-up the currently installed version is not possible.
 
 ## Advanced configuration
 
-You can increase (or decrease, albeit less useful) the default timeout for the reception of chunk requests from the device. This can help if you notice a device is unusually slow at this. The default is however already 150000ms and should fit most cases.
+### Change update parameters
 
-:::tip TIP
-The below settings can also be set per-update-request (see [Update firmware](#update-firmware)), in the request payload directly.
-:::
+The following OTA settings can be adjusted globally (by editing `configuration.yaml`) or per request (by providing them in the payload): `image_block_request_timeout`, `image_block_response_delay`, `default_maximum_data_size`.
 
 ```yaml
 ota:
     image_block_request_timeout: 150000
-```
-
-You can increase or decrease the default speed (the minimum delay between two chunks) at which Zigbee2MQTT responds during the update process to send chunks of images. The default is 250ms. A higher speed will result in faster OTA updates, but may require a far more stable network to avoid issues, crashes. A lower speed will result in slower OTA updates, but may noticeably increase reliability, and overall network stability.
-
-```yaml
-ota:
     image_block_response_delay: 250
-```
-
-Minimum: 50
-
-You can increase or decrease the size of image chunks sent by Zigbee2MQTT during the update process. The default is 50 bytes. The behavior is similar to `image_block_response_delay` regarding the effect of higher or lower values.
-
-_Note that for some known combinations (manufacturer/version/etc.), expected sizes will always override this setting to ensure they work correctly._
-
-```yaml
-ota:
     default_maximum_data_size: 50
 ```
 
-Minimum: 10, Maximum: 100
+Increasing the **timeout for reception of chunk requests** from the device can help if a device is unusually slow at this. The default is however already 150000ms and should fit most cases.
 
-::: warning ATTENTION
-Some devices will refuse higher sizes than 50 bytes, some 64 bytes. Several network parameters must also be taken into account to derive this value. It is not recommended to change this setting unless you have a very good reason (instructed to do so in an issue for example).
-:::
+The **minimum delay between two chunks** can be decreased for faster OTA updates, but it may require a far more stable network to avoid issues and crashes. The default is 250ms and the minimum is 50ms.
 
-## Local OTA index and firmware files
+The **size of image chunks** sent by Zigbee2MQTT is by default limited to 50 bytes. Similarly, bigger chunks will increase the OTA speed, but reduce network stability. Minimum is 10B and maximum is 100B.  
+Some devices will refuse higher sizes than 50/64 bytes.  
+Zigbee2MQTT will ignore the custom value for some devices and automatically use the correct size that they expect.
+
+### Using custom firmware files or index
+
+Devices can be updated from custom sources, by supplying the firmware files directly, or by listing them in a custom index.
 
 :::caution CAUTION
-Improper use of local OTA index & firmware files can result in bricked devices. There are special checks that should nearly always be added for certain manufacturers (e.g. Tuya & derived) to prevent mismatches (mostly due to several manufacturers improperly implementing the Zigbee specification).
+Improper use of custom OTA index or firmware files can brick devices. Due to the nature of "custom firmware", several of the regular OTA constraints are bypassed in this mode. **Use trusted sources!**
 :::
 
-An OTA index file is a list of firmware images available in designated locations. When checking if an update is available, Zigbee2MQTT determines current hardware and firmware version for a particular device, and then searches for a suitable upgrade image in the index file. Zigbee2MQTT uses the [Zigbee-OTA](https://github.com/Koenkk/zigbee-OTA) firmware repository which contains the [upgrade index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index.json), and the [downgrade index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index1.json).
+An OTA index file is a list of firmware images available in designated locations. By default, Zigbee2MQTT uses the [upgrade index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index.json), and the [downgrade index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index1.json) from the [zigbee-OTA](https://github.com/Koenkk/zigbee-OTA) repository.
 
-Sometimes it is necessary to add a firmware image that is not in that repository. This could be helpful when developing a DIY device, or install a test/alternate image for a mass-produced device. In this case you can supply Zigbee2MQTT with an alternate index file, located locally or on a web server. This index file will point Zigbee2MQTT to the firmware image files. Records in the override OTA index file will take precedence over the records in the Zigbee-OTA repository, so that it is possible to alter the image for a particular device. If the default Zigbee2MQTT index URLs (see above) are inaccessible (e.g. air gap network), and a local OTA index is provided, only the local OTA index will be used.
+A custom update index can be supplied globally (by editing `configuration.yaml`) or per update request. Accepted formats are: local file path (absolute or relative) and web URL.
+
+The override OTA index file shall have the same structure as the [zigbee-OTA index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index.json).
+See the [repository README](https://github.com/Koenkk/zigbee-OTA/tree/master?tab=readme-ov-file#notes-for-maintainers--developers) if an image requires extra metadata.
+
+:::tip TIP
+The following tool can generate indexes and do more helpful operations: [https://nerivec.github.io/zigbee-ota-file-editor/](https://nerivec.github.io/zigbee-ota-file-editor/)
+:::
+
+If the default Zigbee2MQTT index is inaccessible (e.g. air gapped network), only the local OTA index will be used.  
+If both indexes are available, records in the override index will take precedence over the ones in the default index.
+
+#### Global index override
+
+In this example, `my_index.json` is located in the same directory as `configuration.yaml`:
 
 ```yaml
 ota:
     zigbee_ota_override_index_location: my_index.json
+    # or
+    zigbee_ota_override_index_location: https://example.com/ota/index.json
 ```
 
-A local index file is searched in the data directory (next to `configuration.yaml`). The file name also could be a full path to the file, taking into account that the host file system may not be available when running Zigbee2MQTT in a virtualized environment (Docker, etc.). Alternatively, Zigbee2MQTT supports index files located on a remote HTTP(s) server. In this case `zigbee_ota_override_index_location` should point to the URL of the index file.
+#### Per request custom index / firmware
 
-```yaml
-ota:
-    zigbee_ota_override_index_location: https://example.com/ota/my_index.json
-```
+The following topics support supplying `url` in the payload (also accepting local paths and web URLs) to update with custom files.
 
-The override OTA index file shall have the same structure as the [Zigbee-OTA index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index.json).
+If the pointed location is a JSON file (`*.json`), it will be treated as an index, else as a firmware file.
 
-For local files, only image location is required through `url` (either a full path to the image file, or relative to the Zigbee2MQTT data directory). Zigbee2MQTT can derive the rest from the files themselves:
+- Only index supported
+    - `bridge/request/device/ota_update/check`
+    - `bridge/request/device/ota_update/check/downgrade`
+- Index, firmware file and hex data supported
+    - `bridge/request/device/ota_update/update`
+    - `bridge/request/device/ota_update/update/downgrade`
+    - `bridge/request/device/ota_update/schedule`
+    - `bridge/request/device/ota_update/schedule/downgrade`
 
-```json
-[
-    {
-        "url": "./path/to/my/image.ota"
-    }
-]
-```
+The full OTA file can also be supplied in hex string form: `"hex":{"data":"1EF1EEB0...","file_name":"my-file.ota"}`. The firmware file will be stored in `data/ota/` upon receipt. This is mainly intended for frontend use (where this payload is built from a "file upload" dialog).
 
-For hosted files, on top of `url`, all required metadata must be provided (`imageType`, `manufacturerCode`, `fileVersion`, all expected to match that of the file at `url`):
+## Troubleshooting
 
-```json
-[
-    {
-        "url": "https://example.com/path/to/my/image.ota",
-        "imageType": 1,
-        "manufactureCode": 1001,
-        "fileVersion": 321
-    }
-]
-```
-
-:::tip TIP
-The following tool can help to generate this information: [https://nerivec.github.io/zigbee-ota-file-editor/](https://nerivec.github.io/zigbee-ota-file-editor/)
-:::
-
-See [Zigbee-OTA README](https://github.com/Koenkk/zigbee-OTA/tree/master?tab=readme-ov-file#notes-for-maintainers--developers) if an image requires extra metadata.
-
-Normally Zigbee2MQTT compares the current device's firmware version with the version of the available image, and allows flashing only if `fileVersion` is higher than the current one for upgrades, or lower for downgrades. To force Zigbee2MQTT to use an arbitrary version you can set `force` to `true`:
-
-```json
-[
-    {
-        "url": "HelloZigbee.ota",
-        "force": true
-    }
-]
-```
-
-::: tip TIP
-Even though Zigbee specification allows firmware downgrading, some devices may reject older firmware versions. Additionally, updating to a firmware of same version is not supported by Zigbee specification. This cannot be forced by Zigbee2MQTT.
-:::
+- `Device didn't respond to OTA request` or `Update failed with reason: 'aborted by device'`: try restarting the device by disconnecting the power/battery for a few seconds, then try OTA again, make sure to activate the device by pressing a button on it right before sending the update request
+- For battery powered devices make sure that the battery is 70%+ as OTA updating is very power consuming. Some devices check for a minimum battery level prior to updating and will refuse to update if too low
+- Make sure your log level is set to `info`. When set to `warning` or `error`, frontend will not report some messages indicating the current OTA status


### PR DESCRIPTION
addressing https://github.com/Koenkk/zigbee2mqtt/issues/32001#issuecomment-4459376722

Sorry @Nerivec, I couldn't fit the warnings without rewriting the whole doc 🫣 This took me soo long until I was happy with the result 🥲 Edit where you find issues

There was some duplication, long wording for unnecessary information, unclear structure. 
I aimed to make the page readable start-to-finish, use fewer words, group similar info, have clear subtitles.