### PR TITLE
Add pairing instructions to RS_241_T documentation

### DIFF
--- a/docs/devices/RS_241_T.md
+++ b/docs/devices/RS_241_T.md
@@ -26,7 +26,14 @@ pageClass: device-page
 
 
 <!-- Notes END: Do not edit below this line -->
+### Pairing
+Factory reset the light bulb ([video](https://www.youtube.com/watch?v=4zkpZSv84H4)).
 
+Power the bulb, then do 6 times the following cycle:
+1. power off
+2. power on
+3. wait ~0.5s
+The bulb should now set its lightness its the maximum to indicate it is in pairing mode.
 
 ## OTA updates
 This device supports OTA updates, for more information see [OTA updates](../guide/usage/ota_updates.md).


### PR DESCRIPTION
Added pairing instructions for the RS_241_T light bulb.

Yet another one :) 
I have added a new model to my setup, and saw the pairing step was missing from the docs. Here it is now !
