### PR TITLE
SM323_v2: add Home Assistant blueprint note

### DIFF
--- a/docs/devices/SM323_v2.md
+++ b/docs/devices/SM323_v2.md
@@ -23,14 +23,15 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+
 ## Notes
-### Pairing
-There are two different options to reset the device and enter pairing mode:
 
-* button: Press the RESET button 5 times. On the device, inaccessible with the faceplate attached
-* power: Cycle the power from the consumer unit 5 times. This is especially useful when there is no direct physical access to the button.
+### Two-way mirroring with Home Assistant
 
-A successful reset will be indicated by the connected light source flashing twice. Upon successful pairing, the light will flash 5 times and then remain steadily on.
+To make two SM323 dimmers act as a single virtual two-way – both following each other's on/off and brightness, with no traveller wire – you can use the Samotech SM-series Direct Mirror Pair blueprint for Home Assistant. It works with both ZHA and Zigbee2MQTT.
+
+[Import the blueprint](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Ffidusachates%2Fhome-assistant-blueprints%2Fmain%2Fsamotech-sm-series-direct-mirror-pair.yaml) · [Setup guide](https://www.samotech.co.uk/samotech-direct-mirror-pair-home-assistant)
+
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
Adds a Home Assistant blueprint note to the editable Notes section of the SM323_v2 docs page.

The blueprint (Direct Mirror Pair, MIT-licensed, public on GitHub) lets two SM323 units behave as a virtual two-way without a traveller wire – useful information for owners of this device. Submitted as the device manufacturer (Samotech).

Only content between the `Notes BEGIN` / `Notes END` markers has been changed; everything else is left for docgen.