### PR TITLE
Add pairing instructions to WS90 documentation

### DIFF
--- a/docs/devices/WS90.md
+++ b/docs/devices/WS90.md
@@ -23,8 +23,9 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
-
-
+### Pairing
+Press the calibration button twice. This will activate Zigbee pairing mode for 3 minutes.
+If pairing is successful, the LED will flash one time.
 <!-- Notes END: Do not edit below this line -->
 
 


### PR DESCRIPTION
Added pairing instructions for the WS90 device.
Information source: https://www.shelly.com/blogs/documentation/ecowitt-ws90-7-in-1-weather-station-1 (User Guide)
Teste it is correct with may WS90 by Pairing it to Z2M the added way.