### PR TITLE
SM323_v2: sync description with herdsman-converters

### DIFF
--- a/docs/devices/SM323_v2.md
+++ b/docs/devices/SM323_v2.md
@@ -17,7 +17,7 @@ pageClass: device-page
 |-----|-----|
 | Model | SM323_v2  |
 | Vendor  | [Samotech](/supported-devices/#v=Samotech)  |
-| Description | Zigbee retrofit dimmer 250W |
+| Description | Zigbee dimmer switch SM323 |
 | Exposes | light (state, brightness), effect, power_on_behavior, power, voltage, current, energy, external_switch_type |
 | Picture | ![Samotech SM323_v2](https://www.zigbee2mqtt.io/images/devices/SM323_v2.png) |
 


### PR DESCRIPTION
Syncs the auto-generated description in `docs/devices/SM323_v2.md` with the already-merged change in zigbee-herdsman-converters PR Koenkk/zigbee-herdsman-converters#12326 ("Zigbee retrofit dimmer 250W" → "Zigbee dimmer switch SM323").

The docs page is currently still showing the old description because the regenerated md hasn't been produced yet. This is the same line docgen will write on its next run, so the edit is just pre-empting that to keep the live page consistent with the merged converter source in the meantime.

Submitted as the device manufacturer (Samotech).