### PR TITLE
SM323_v1: sync description with herdsman-converters

### DIFF
--- a/docs/devices/SM323_v1.md
+++ b/docs/devices/SM323_v1.md
@@ -17,7 +17,7 @@ pageClass: device-page
 |-----|-----|
 | Model | SM323_v1  |
 | Vendor  | [Samotech](/supported-devices/#v=Samotech)  |
-| Description | Zigbee retrofit dimmer 250W |
+| Description | Zigbee dimmer switch |
 | Exposes | light (state, brightness), effect, power_on_behavior |
 | Picture | ![Samotech SM323_v1](https://www.zigbee2mqtt.io/images/devices/SM323_v1.png) |
 


### PR DESCRIPTION
Syncs the auto-generated description in `docs/devices/SM323_v1.md` with the description change submitted to zigbee-herdsman-converters in Koenkk/zigbee-herdsman-converters#12350 ("Zigbee retrofit dimmer 250W" → "Zigbee dimmer switch").

This pre-empts the next docgen run so the live page reflects the corrected wording without delay. Identical pattern to the recently-merged SM323_v2 sync PR #5191.

Submitted as the device manufacturer (Samotech).