### PR TITLE
Add Giscus-powered discussion section on device pages

### DIFF
--- a/docgen/generate_device.ts
+++ b/docgen/generate_device.ts
@@ -52,6 +52,7 @@ title: "${device.vendor} ${device.model} control via MQTT"
 description: "Integrate your ${device.vendor} ${device.model} via Zigbee2MQTT with whatever smart home infrastructure you are using without the vendor's bridge or gateway."
 addedAt: ${addedAt}
 pageClass: device-page
+model: "${device.model}"
 ---
 
 <!-- !!!! -->

--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -1,4 +1,5 @@
 import {defineClientConfig} from '@vuepress/client';
+import GiscusInjector from './components/GiscusInjector.vue';
 
 export default defineClientConfig({
     async enhance({app, router, siteData}) {
@@ -9,5 +10,5 @@ export default defineClientConfig({
         }
     },
     setup() {},
-    rootComponents: [],
+    rootComponents: [GiscusInjector],
 });

--- a/docs/.vuepress/components/GiscusInjector.vue
+++ b/docs/.vuepress/components/GiscusInjector.vue
@@ -1,203 +1,203 @@
 <script setup lang="ts">
-import {onMounted, onUnmounted} from 'vue'
+import {onMounted, onUnmounted} from 'vue';
 
 interface GiscusConfig {
-    repo: string
-    repoId: string
-    category: string
-    categoryId: string
-    mapping: string
-    termPrefix: string
-    lang: string
+    repo: string;
+    repoId: string;
+    category: string;
+    categoryId: string;
+    mapping: string;
+    termPrefix: string;
+    lang: string;
 }
 
 declare const window: Window & {
-    __GISCUS_CONFIG__?: GiscusConfig
-}
+    __GISCUS_CONFIG__?: GiscusConfig;
+};
 
 function getConfig(): GiscusConfig | null {
-    const c = window.__GISCUS_CONFIG__
-    if (!c || !c.repo || !c.repoId || !c.category || !c.categoryId) return null
-    return c
+    const c = window.__GISCUS_CONFIG__;
+    if (!c || !c.repo || !c.repoId || !c.category || !c.categoryId) return null;
+    return c;
 }
 
 function getLang(configLang: string): string {
-    const browserLang = navigator.language || ''
-    if (configLang && configLang !== 'en') return configLang
-    if (browserLang.startsWith('ru')) return 'ru'
-    if (browserLang.startsWith('zh')) return 'zh'
-    if (browserLang.startsWith('ja')) return 'ja'
-    if (browserLang.startsWith('ko')) return 'ko'
-    if (browserLang.startsWith('de')) return 'de'
-    if (browserLang.startsWith('fr')) return 'fr'
-    if (browserLang.startsWith('es')) return 'es'
-    if (browserLang.startsWith('pt')) return 'pt'
-    if (browserLang.startsWith('uk')) return 'ru'
-    return 'en'
+    const browserLang = navigator.language || '';
+    if (configLang && configLang !== 'en') return configLang;
+    if (browserLang.startsWith('ru')) return 'ru';
+    if (browserLang.startsWith('zh')) return 'zh';
+    if (browserLang.startsWith('ja')) return 'ja';
+    if (browserLang.startsWith('ko')) return 'ko';
+    if (browserLang.startsWith('de')) return 'de';
+    if (browserLang.startsWith('fr')) return 'fr';
+    if (browserLang.startsWith('es')) return 'es';
+    if (browserLang.startsWith('pt')) return 'pt';
+    if (browserLang.startsWith('uk')) return 'ru';
+    return 'en';
 }
 
 function getModelFromPath(path: string): string {
-    const match = path.match(/\/devices\/([^/]+)\.html/)
-    return match ? match[1] : ''
+    const match = path.match(/\/devices\/([^/]+)\.html/);
+    return match ? match[1] : '';
 }
 
-let giscusContainer: HTMLDivElement | null = null
-let floatingBtn: HTMLButtonElement | null = null
-let currentTerm = ''
-let scrollHandler: (() => void) | null = null
-let messageHandler: ((e: MessageEvent) => void) | null = null
+let giscusContainer: HTMLDivElement | null = null;
+let floatingBtn: HTMLButtonElement | null = null;
+let currentTerm = '';
+let scrollHandler: (() => void) | null = null;
+let messageHandler: ((e: MessageEvent) => void) | null = null;
 
 function hideFloatingButton() {
     if (floatingBtn) {
-        floatingBtn.style.display = 'none'
+        floatingBtn.style.display = 'none';
     }
 }
 
 function removeWidget() {
     if (giscusContainer) {
-        giscusContainer.remove()
-        giscusContainer = null
+        giscusContainer.remove();
+        giscusContainer = null;
     }
     if (floatingBtn) {
-        floatingBtn.remove()
-        floatingBtn = null
+        floatingBtn.remove();
+        floatingBtn = null;
     }
     if (scrollHandler) {
-        window.removeEventListener('scroll', scrollHandler, {passive: true})
-        scrollHandler = null
+        window.removeEventListener('scroll', scrollHandler, {passive: true});
+        scrollHandler = null;
     }
     if (messageHandler) {
-        window.removeEventListener('message', messageHandler)
-        messageHandler = null
+        window.removeEventListener('message', messageHandler);
+        messageHandler = null;
     }
-    currentTerm = ''
+    currentTerm = '';
 }
 
 function createFloatingButton() {
-    if (floatingBtn) return
+    if (floatingBtn) return;
 
-    floatingBtn = document.createElement('button')
-    floatingBtn.type = 'button'
-    floatingBtn.className = 'giscus-float-btn'
-    floatingBtn.setAttribute('aria-label', 'Jump to discussions')
-    floatingBtn.title = 'Discussions'
-    floatingBtn.innerHTML = `<div class="giscus-float-icon">💬</div>`
+    floatingBtn = document.createElement('button');
+    floatingBtn.type = 'button';
+    floatingBtn.className = 'giscus-float-btn';
+    floatingBtn.setAttribute('aria-label', 'Jump to discussions');
+    floatingBtn.title = 'Discussions';
+    floatingBtn.innerHTML = `<div class="giscus-float-icon">💬</div>`;
 
     floatingBtn.addEventListener('click', () => {
-        document.getElementById('giscus-comments')?.scrollIntoView({behavior: 'smooth'})
-    })
+        document.getElementById('giscus-comments')?.scrollIntoView({behavior: 'smooth'});
+    });
 
     scrollHandler = () => {
-        const target = document.getElementById('giscus-comments')
-        if (!target || !floatingBtn) return
-        const rect = target.getBoundingClientRect()
+        const target = document.getElementById('giscus-comments');
+        if (!target || !floatingBtn) return;
+        const rect = target.getBoundingClientRect();
         if (rect.top < window.innerHeight) {
-            floatingBtn.style.opacity = '0'
-            floatingBtn.style.pointerEvents = 'none'
+            floatingBtn.style.opacity = '0';
+            floatingBtn.style.pointerEvents = 'none';
         } else {
-            floatingBtn.style.opacity = ''
-            floatingBtn.style.pointerEvents = ''
+            floatingBtn.style.opacity = '';
+            floatingBtn.style.pointerEvents = '';
         }
-    }
+    };
 
-    window.addEventListener('scroll', scrollHandler, {passive: true})
-    document.body.appendChild(floatingBtn)
+    window.addEventListener('scroll', scrollHandler, {passive: true});
+    document.body.appendChild(floatingBtn);
 }
 
 function injectWidget() {
-    const config = getConfig()
-    if (!config) return
+    const config = getConfig();
+    if (!config) return;
 
-    const target = document.querySelector('[vp-content]')
-    if (!target) return
+    const target = document.querySelector('[vp-content]');
+    if (!target) return;
 
-    const model = getModelFromPath(window.location.pathname)
-    if (!model) return
+    const model = getModelFromPath(window.location.pathname);
+    if (!model) return;
 
-    const term = `${config.termPrefix}${model}`
-    if (term === currentTerm) return
+    const term = `${config.termPrefix}${model}`;
+    if (term === currentTerm) return;
 
-    removeWidget()
-    currentTerm = term
+    removeWidget();
+    currentTerm = term;
 
-    const lang = getLang(config.lang)
+    const lang = getLang(config.lang);
 
-    createFloatingButton()
+    createFloatingButton();
 
     // Giscus widget
-    giscusContainer = document.createElement('div')
-    giscusContainer.className = 'giscus-wrapper'
-    giscusContainer.id = 'giscus-comments'
-    giscusContainer.style.marginTop = '2rem'
-    giscusContainer.style.paddingTop = '2rem'
-    giscusContainer.style.borderTop = '1px solid var(--c-border)'
-    giscusContainer.style.scrollMarginTop = '4rem'
+    giscusContainer = document.createElement('div');
+    giscusContainer.className = 'giscus-wrapper';
+    giscusContainer.id = 'giscus-comments';
+    giscusContainer.style.marginTop = '2rem';
+    giscusContainer.style.paddingTop = '2rem';
+    giscusContainer.style.borderTop = '1px solid var(--c-border)';
+    giscusContainer.style.scrollMarginTop = '4rem';
 
-    const script = document.createElement('script')
-    script.src = 'https://giscus.app/client.js'
-    script.setAttribute('data-repo', config.repo)
-    script.setAttribute('data-repo-id', config.repoId)
-    script.setAttribute('data-category', config.category)
-    script.setAttribute('data-category-id', config.categoryId)
-    script.setAttribute('data-mapping', config.mapping || 'specific')
-    script.setAttribute('data-term', term)
-    script.setAttribute('data-strict', '0')
-    script.setAttribute('data-reactions-enabled', '1')
-    script.setAttribute('data-emit-metadata', '0')
-    script.setAttribute('data-input-position', 'top')
-    script.setAttribute('data-theme', 'preferred_color_scheme')
-    script.setAttribute('data-lang', lang)
-    script.setAttribute('crossorigin', 'anonymous')
-    script.async = true
+    const script = document.createElement('script');
+    script.src = 'https://giscus.app/client.js';
+    script.setAttribute('data-repo', config.repo);
+    script.setAttribute('data-repo-id', config.repoId);
+    script.setAttribute('data-category', config.category);
+    script.setAttribute('data-category-id', config.categoryId);
+    script.setAttribute('data-mapping', config.mapping || 'specific');
+    script.setAttribute('data-term', term);
+    script.setAttribute('data-strict', '0');
+    script.setAttribute('data-reactions-enabled', '1');
+    script.setAttribute('data-emit-metadata', '0');
+    script.setAttribute('data-input-position', 'top');
+    script.setAttribute('data-theme', 'preferred_color_scheme');
+    script.setAttribute('data-lang', lang);
+    script.setAttribute('crossorigin', 'anonymous');
+    script.async = true;
 
-    script.onerror = () => hideFloatingButton()
+    script.onerror = () => hideFloatingButton();
 
-    giscusContainer.appendChild(script)
-    target.appendChild(giscusContainer)
+    giscusContainer.appendChild(script);
+    target.appendChild(giscusContainer);
 
     // Listen for Giscus error messages from iframe
     messageHandler = (e: MessageEvent) => {
         if (typeof e.data === 'object' && e.data?.giscus?.error) {
-            hideFloatingButton()
+            hideFloatingButton();
         }
-    }
-    window.addEventListener('message', messageHandler)
+    };
+    window.addEventListener('message', messageHandler);
 }
 
 function tryInject() {
-    const model = getModelFromPath(window.location.pathname)
+    const model = getModelFromPath(window.location.pathname);
     if (!model) {
-        removeWidget()
-        return
+        removeWidget();
+        return;
     }
-    injectWidget()
+    injectWidget();
 }
 
-let retryInterval: ReturnType<typeof setInterval> | null = null
+let retryInterval: ReturnType<typeof setInterval> | null = null;
 
 onMounted(() => {
-    tryInject()
+    tryInject();
 
     const observer = new MutationObserver(() => {
-        tryInject()
-    })
+        tryInject();
+    });
 
-    observer.observe(document.body, {childList: true, subtree: true})
+    observer.observe(document.body, {childList: true, subtree: true});
 
     retryInterval = setInterval(() => {
         if (currentTerm) {
-            if (retryInterval) clearInterval(retryInterval)
-            return
+            if (retryInterval) clearInterval(retryInterval);
+            return;
         }
-        tryInject()
-    }, 500)
+        tryInject();
+    }, 500);
 
     onUnmounted(() => {
-        observer.disconnect()
-        if (retryInterval) clearInterval(retryInterval)
-        removeWidget()
-    })
-})
+        observer.disconnect();
+        if (retryInterval) clearInterval(retryInterval);
+        removeWidget();
+    });
+});
 </script>
 
 <template>

--- a/docs/.vuepress/components/GiscusInjector.vue
+++ b/docs/.vuepress/components/GiscusInjector.vue
@@ -1,0 +1,205 @@
+<script setup lang="ts">
+import {onMounted, onUnmounted} from 'vue'
+
+interface GiscusConfig {
+    repo: string
+    repoId: string
+    category: string
+    categoryId: string
+    mapping: string
+    termPrefix: string
+    lang: string
+}
+
+declare const window: Window & {
+    __GISCUS_CONFIG__?: GiscusConfig
+}
+
+function getConfig(): GiscusConfig | null {
+    const c = window.__GISCUS_CONFIG__
+    if (!c || !c.repo || !c.repoId || !c.category || !c.categoryId) return null
+    return c
+}
+
+function getLang(configLang: string): string {
+    const browserLang = navigator.language || ''
+    if (configLang && configLang !== 'en') return configLang
+    if (browserLang.startsWith('ru')) return 'ru'
+    if (browserLang.startsWith('zh')) return 'zh'
+    if (browserLang.startsWith('ja')) return 'ja'
+    if (browserLang.startsWith('ko')) return 'ko'
+    if (browserLang.startsWith('de')) return 'de'
+    if (browserLang.startsWith('fr')) return 'fr'
+    if (browserLang.startsWith('es')) return 'es'
+    if (browserLang.startsWith('pt')) return 'pt'
+    if (browserLang.startsWith('uk')) return 'ru'
+    return 'en'
+}
+
+function getModelFromPath(path: string): string {
+    const match = path.match(/\/devices\/([^/]+)\.html/)
+    return match ? match[1] : ''
+}
+
+let giscusContainer: HTMLDivElement | null = null
+let floatingBtn: HTMLButtonElement | null = null
+let currentTerm = ''
+let scrollHandler: (() => void) | null = null
+let messageHandler: ((e: MessageEvent) => void) | null = null
+
+function hideFloatingButton() {
+    if (floatingBtn) {
+        floatingBtn.style.display = 'none'
+    }
+}
+
+function removeWidget() {
+    if (giscusContainer) {
+        giscusContainer.remove()
+        giscusContainer = null
+    }
+    if (floatingBtn) {
+        floatingBtn.remove()
+        floatingBtn = null
+    }
+    if (scrollHandler) {
+        window.removeEventListener('scroll', scrollHandler, {passive: true})
+        scrollHandler = null
+    }
+    if (messageHandler) {
+        window.removeEventListener('message', messageHandler)
+        messageHandler = null
+    }
+    currentTerm = ''
+}
+
+function createFloatingButton() {
+    if (floatingBtn) return
+
+    floatingBtn = document.createElement('button')
+    floatingBtn.type = 'button'
+    floatingBtn.className = 'giscus-float-btn'
+    floatingBtn.setAttribute('aria-label', 'Jump to discussions')
+    floatingBtn.title = 'Discussions'
+    floatingBtn.innerHTML = `<div class="giscus-float-icon">💬</div>`
+
+    floatingBtn.addEventListener('click', () => {
+        document.getElementById('giscus-comments')?.scrollIntoView({behavior: 'smooth'})
+    })
+
+    scrollHandler = () => {
+        const target = document.getElementById('giscus-comments')
+        if (!target || !floatingBtn) return
+        const rect = target.getBoundingClientRect()
+        if (rect.top < window.innerHeight) {
+            floatingBtn.style.opacity = '0'
+            floatingBtn.style.pointerEvents = 'none'
+        } else {
+            floatingBtn.style.opacity = ''
+            floatingBtn.style.pointerEvents = ''
+        }
+    }
+
+    window.addEventListener('scroll', scrollHandler, {passive: true})
+    document.body.appendChild(floatingBtn)
+}
+
+function injectWidget() {
+    const config = getConfig()
+    if (!config) return
+
+    const target = document.querySelector('[vp-content]')
+    if (!target) return
+
+    const model = getModelFromPath(window.location.pathname)
+    if (!model) return
+
+    const term = `${config.termPrefix}${model}`
+    if (term === currentTerm) return
+
+    removeWidget()
+    currentTerm = term
+
+    const lang = getLang(config.lang)
+
+    createFloatingButton()
+
+    // Giscus widget
+    giscusContainer = document.createElement('div')
+    giscusContainer.className = 'giscus-wrapper'
+    giscusContainer.id = 'giscus-comments'
+    giscusContainer.style.marginTop = '2rem'
+    giscusContainer.style.paddingTop = '2rem'
+    giscusContainer.style.borderTop = '1px solid var(--c-border)'
+    giscusContainer.style.scrollMarginTop = '4rem'
+
+    const script = document.createElement('script')
+    script.src = 'https://giscus.app/client.js'
+    script.setAttribute('data-repo', config.repo)
+    script.setAttribute('data-repo-id', config.repoId)
+    script.setAttribute('data-category', config.category)
+    script.setAttribute('data-category-id', config.categoryId)
+    script.setAttribute('data-mapping', config.mapping || 'specific')
+    script.setAttribute('data-term', term)
+    script.setAttribute('data-strict', '0')
+    script.setAttribute('data-reactions-enabled', '1')
+    script.setAttribute('data-emit-metadata', '0')
+    script.setAttribute('data-input-position', 'top')
+    script.setAttribute('data-theme', 'preferred_color_scheme')
+    script.setAttribute('data-lang', lang)
+    script.setAttribute('crossorigin', 'anonymous')
+    script.async = true
+
+    script.onerror = () => hideFloatingButton()
+
+    giscusContainer.appendChild(script)
+    target.appendChild(giscusContainer)
+
+    // Listen for Giscus error messages from iframe
+    messageHandler = (e: MessageEvent) => {
+        if (typeof e.data === 'object' && e.data?.giscus?.error) {
+            hideFloatingButton()
+        }
+    }
+    window.addEventListener('message', messageHandler)
+}
+
+function tryInject() {
+    const model = getModelFromPath(window.location.pathname)
+    if (!model) {
+        removeWidget()
+        return
+    }
+    injectWidget()
+}
+
+let retryInterval: ReturnType<typeof setInterval> | null = null
+
+onMounted(() => {
+    tryInject()
+
+    const observer = new MutationObserver(() => {
+        tryInject()
+    })
+
+    observer.observe(document.body, {childList: true, subtree: true})
+
+    retryInterval = setInterval(() => {
+        if (currentTerm) {
+            if (retryInterval) clearInterval(retryInterval)
+            return
+        }
+        tryInject()
+    }, 500)
+
+    onUnmounted(() => {
+        observer.disconnect()
+        if (retryInterval) clearInterval(retryInterval)
+        removeWidget()
+    })
+})
+</script>
+
+<template>
+    <div />
+</template>

--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -189,3 +189,48 @@ footer a {
         }
     }
 }
+
+.giscus-float-btn {
+    position: fixed !important;
+    top: 4.5rem;
+    right: 1rem;
+    z-index: 100;
+    width: 48px;
+    height: 48px;
+    padding: 12px;
+    border-radius: 50%;
+    border-width: 0;
+    background: var(--c-bg, #fff);
+    color: var(--c-text, #2c3e50);
+    box-shadow: 2px 2px 10px 4px var(--c-shadow, rgba(0, 0, 0, 0.05));
+    cursor: pointer;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    opacity: 0.85;
+
+    &:hover {
+        opacity: 1;
+        transform: scale(1.05);
+    }
+
+    .giscus-float-icon {
+        font-size: 1.2rem;
+        line-height: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        height: 24px;
+    }
+}
+
+.dark .giscus-float-btn {
+    background: var(--c-bg, #1e1e1e);
+    box-shadow: 2px 2px 10px 4px var(--c-shadow, rgba(0, 0, 0, 0.3));
+}
+
+@media (max-width: 959px) {
+    .giscus-float-btn {
+        transform-origin: 100% 0;
+        transform: scale(0.8);
+    }
+}

--- a/vuepress.config.ts
+++ b/vuepress.config.ts
@@ -101,6 +101,19 @@ const conf = defineUserConfig({
                 content: '#ffc135',
             },
         ],
+        [
+            'script',
+            {},
+            `window.__GISCUS_CONFIG__=${JSON.stringify({
+                repo: process.env.GISCUS_REPO || '',
+                repoId: process.env.GISCUS_REPO_ID || '',
+                category: process.env.GISCUS_CATEGORY || '',
+                categoryId: process.env.GISCUS_CATEGORY_ID || '',
+                mapping: process.env.GISCUS_MAPPING || 'specific',
+                termPrefix: process.env.GISCUS_TERM_PREFIX || 'Device: ',
+                lang: process.env.GISCUS_LANG || 'en',
+            })}`,
+        ],
     ],
 
     theme: defaultTheme({


### PR DESCRIPTION
## Add Giscus-powered discussion section on device pages

### What this PR does
This PR adds a **comment & discussion widget** at the bottom of every supported device page (e.g., `/devices/WSDCGQ11LM.html`).  
It is based on **[Giscus](https://giscus.app/)** and stores all discussions in **GitHub Discussions** of a repository you control.  

After merging and enabling, users will be able to:
- Leave comments, tips, and questions directly on the device page
- Use full Markdown (code blocks, images, links)
- Authenticate via their GitHub account
- React, pin, and moderate comments just like in GitHub Discussions

All data remains inside the GitHub ecosystem, is searchable, and requires **zero backend**.

---

### How it looks
By default the widget is **hidden** – it only appears after you fill in the Giscus configuration via environment variables.

Example with discussion loaded:
<img width="1307" height="1231" alt="image" src="https://github.com/user-attachments/assets/a7d43ecc-16a5-4f53-873b-3f73437bab1f" />

---

### How to enable it (step by step)

#### 1. Choose a repository for discussions
You can use **`Koenkk/zigbee2mqtt`** or **`Koenkk/zigbee2mqtt.io`** — whichever you prefer for storing device discussions. The Giscus app will be installed on that repository, and all comment threads will live there.

#### 2. Enable Discussions in the chosen repository
Go to the repository settings:  
Settings → General → Features → ☑️ **Discussions**  
(If not already enabled.)

#### 3. Install the Giscus GitHub App
- Visit [github.com/apps/giscus](https://github.com/apps/giscus)
- Click **Install** / **Configure**
- Choose **Only select repositories** and select the repository from step 1
- Click **Install**

#### 4. Get your configuration values
- Go to [giscus.app](https://giscus.app)
- Fill in the **Repository** field exactly as `Koenkk/zigbee2mqtt` (or `Koenkk/zigbee2mqtt.io`)
- Under **Page ↔ Discussion Mapping** choose **"Discussion title contains a specific term"**
- In **Category** pick **`Devices`** (you can also create a dedicated one, but `Devices` fits perfectly)
- Copy the generated attributes:

  ```
  data-repo-id:      R_kgDOG...
  data-category-id:  DIC_kwDOG...
  ```

  Also note the exact `repo` and `category` strings.

#### 5. Configure environment variables
The widget reads its settings from environment variables:

| Variable            | Value from giscus.app       |
|---------------------|-----------------------------|
| `GISCUS_REPO`       | `Koenkk/zigbee2mqtt`        |
| `GISCUS_REPO_ID`    | `R_kg...`                   |
| `GISCUS_CATEGORY`   | `Devices`                   |
| `GISCUS_CATEGORY_ID`| `DIC_kw...`                 |

The `termPrefix` is `"Device: "` by default and does not need to be changed.

---

### How to test locally

1. **Install dependencies** (if not done yet):
   ```bash
   pnpm install
   ```

2. **Run the dev server with a single device** (so you don’t generate thousands of pages):
   ```bash
   GISCUS_REPO=Koenkk/zigbee2mqtt GISCUS_REPO_ID=R_xxx GISCUS_CATEGORY=Devices GISCUS_CATEGORY_ID=DIC_xxx INCLUDE_DEVICE=WSDCGQ11LM pnpm run dev
   ```
   (Replace the IDs with those from your test repository.)

3. Open `http://localhost:8080/devices/WSDCGQ11LM.html`  
   You should see the Giscus comment block at the bottom.

---

### How to deploy with these settings (GitHub Actions)
For the official `zigbee2mqtt.io` deployment, add the environment variables to your build workflow.

**Using repository secrets (recommended)**  
- Go to **Settings → Secrets and variables → Actions**
- Add the secrets:
  - `GISCUS_REPO` (e.g., `Koenkk/zigbee2mqtt`)
  - `GISCUS_REPO_ID`
  - `GISCUS_CATEGORY` (`Devices`)
  - `GISCUS_CATEGORY_ID`
- In your deploy workflow, pass them to the build step:
  ```
      GISCUS_REPO: ${{ secrets.GISCUS_REPO }}
      GISCUS_REPO_ID: ${{ secrets.GISCUS_REPO_ID }}
      GISCUS_CATEGORY: ${{ secrets.GISCUS_CATEGORY }}
      GISCUS_CATEGORY_ID: ${{ secrets.GISCUS_CATEGORY_ID }}
  ```

The site will then be built with the widget enabled, and every device page will automatically get its own discussion thread.

---

### Notes
- The widget **stays invisible** until **all four environment variables are set**, so merging this PR without adding them will not break anything.
- Discussion titles are automatically generated as `"Device: <model>"`, providing a stable link to each device’s thread.
- Moderation works entirely through GitHub Discussions – you have full control over comments.
- If you ever want to change the repository or category, simply update the environment variables and rebuild.

This feature brings the community right where the devices are, and I’m happy to help with any setup questions!