### PR TITLE
Updates Aqara H2 EU behaviour

### DIFF
--- a/docs/devices/WS-K07E.md
+++ b/docs/devices/WS-K07E.md
@@ -142,7 +142,7 @@ If value equals `true` multi click is ON, if `false` OFF.
 
 ### Action (enum)
 Triggered action (e.g. a button click).
-Since the top button is a physical relais it only exposes 'single_up'. The down button exposes more states such as 'double_down'.
+Since the top button is a physical relay it only exposes 'single_up'. The down button exposes more states such as 'double_down'.
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The possible values are: `single_up`, `single_down`, `double_down`, `release_down`, `hold_down`.

--- a/docs/devices/WS-K07E.md
+++ b/docs/devices/WS-K07E.md
@@ -142,7 +142,8 @@ If value equals `true` multi click is ON, if `false` OFF.
 
 ### Action (enum)
 Triggered action (e.g. a button click).
+Since the top button is a physical relais it only exposes 'single_up'. The down button exposes more states such as 'double_down'.
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
-The possible values are: `hold_up`, `hold_down`, `single_up`, `single_down`, `double_up`, `double_down`, `release_up`, `release_down`.
+The possible values are: `single_up`, `single_down`, `double_down`, `release_down`, `hold_down`.
 


### PR DESCRIPTION
Removes invalid information regarding the Aqara H2 EU. After testing, it does NOT expose double_up, hold_up and release_up.