### PR TITLE
docs(zboss): point ESP32-C6/H2 firmware links at the maintained repo

### DIFF
--- a/docs/guide/adapters/zboss.md
+++ b/docs/guide/adapters/zboss.md
@@ -8,7 +8,7 @@ Support for this adapter is **experimental**, not recommended yet for production
 
 The adapter for the ZBOSS protocol is based on the example of ZBOSS NCP Host [Zigbee NCP (Network Co-Processor)](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/zigbee/ncp/README.html) for Nordic Semiconductor chips, such as nRF5340, nRF52840, nRF52833, nRF21540.
 
-Also, thanks to the special firmware https://github.com/andryblack/esp-coordinator, ZBOSS protocol can be used to interact with the Espressif ESP32-C6/H2 chips.
+Also, thanks to the special firmware https://github.com/tostmann/esp-coordinator, ZBOSS protocol can be used to interact with the Espressif ESP32-C6/H2 chips.
 
 The interaction between the chip and the host occurs according to [ZBOSS NCP Serial Protocol](https://cloud.dsr-corporation.com/index.php/s/BAn4LtRWbJjFiAm).
 
@@ -45,8 +45,6 @@ Currently tested on nRF52840 Dongle, Nice!Nano v2 (nRF52840) and ESP32-C6/H2 dev
 
 <img alt="Nice!Nano v2" src="https://github.com/user-attachments/assets/db2f3041-e36c-4921-b078-7cf0236eeae3" width="75" />
 
-- [Experimental ESP32-C6 firmware](https://github.com/andryblack/esp-coordinator)
-
-    More recent build with stability fixes [Updated ESP32-C6 firmware](https://github.com/diepeterpan/esp-coordinator)
+- [ESP32-C6 firmware](https://github.com/tostmann/esp-coordinator) — actively maintained successor of the original `andryblack/esp-coordinator` (which is archived and points there); a [browser-based web flasher](https://install.busware.de/zboss/) is available
 
 <img src="https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c6/_images/esp32-c6-devkitc-1-isometric_v1.2.png" width="200" />


### PR DESCRIPTION
Both ESP32 firmware links on the ZBOSS adapters page currently point at archived repositories:

- [`andryblack/esp-coordinator`](https://github.com/andryblack/esp-coordinator) is archived/read-only; its README points to the successor repo.
- [`diepeterpan/esp-coordinator`](https://github.com/diepeterpan/esp-coordinator) ("more recent build with stability fixes") has also been archived since 2025-08.

This PR points both references at the actively maintained successor, [`tostmann/esp-coordinator`](https://github.com/tostmann/esp-coordinator) (regular releases — currently v1.3.45 —, issue tracker in active use, browser-based web flasher), and removes the dead second link.

Disclosure: I maintain that repository, so judge the wording accordingly — but the factual core of the PR is simply that the two current links lead users to archived code.