### PR TITLE
fix: Clarify ZBT-2 hardware flow control

### DIFF
--- a/docs/guide/adapters/emberznet.md
+++ b/docs/guide/adapters/emberznet.md
@@ -54,12 +54,12 @@ Each category is ordered by chip, newer series first.
 
 Chip: [EFR32MG24A420F1536IM40](https://www.silabs.com/wireless/zigbee/efr32mg24-series-2-socs/device.EFR32MG24A420F1536IM40?tab=specs)
 
-With external antenna and hardware flow control support. Make sure to set the baudrate to 460800.
+With external antenna and internal hardware flow control (between ESP32-S3 and MG24). Make sure to set the baudrate to 460800.
 
 ```yaml
 serial:
     baudrate: 460800
-    rtscts: true
+    rtscts: false
 ```
 
 - [Product page](https://www.home-assistant.io/connect/zbt-2)


### PR DESCRIPTION
Comments in the Nabu Casa firmware repository [confirm](https://github.com/NabuCasa/silabs-firmware-builder/blob/ffbb9030b026b92b7347e127828803e84461363c/manifests/nabucasa/zbt2/zbt2_zigbee_ncp.yaml#L70) that the ZBT-2 only features hardware flow control **between** the **ESP32-S3** (acting as USB-UART adapter) and the **MG24** SoC.

The host application (i.e. Z2M) should use software flow control instead.