### PR TITLE
docs: add Zemismart KES-606US (TS0726) scene mode initialization notes

### DIFF
--- a/docs/devices/TS0726_1_gang.md
+++ b/docs/devices/TS0726_1_gang.md
@@ -23,7 +23,20 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+### Zemismart KES-606US (`_TZ3000_ovbvmhiq`)
+
+This 1 gang variant is the Zemismart KES-606US-LH1. It additionally exposes an `indicator_mode` enum (`none` / `relay` / `pos`) to control the LED backlight behaviour.
+
+**Scene mode requires one-time initialization with the Tuya / Smart Life app before pairing to Zigbee2MQTT.** Without this step, setting `switch_mode` to `scene` will not emit `action` events. To enable it:
+
+1. Pair the switch to the Tuya Smart Life app (using a Tuya Zigbee gateway).
+2. Set the desired gang(s) to **Scene Mode** in the Smart Life device settings.
+3. Remove the device from Smart Life.
+4. Factory reset the switch and pair it to Zigbee2MQTT.
+
+After this, `switch_mode: scene` will emit `scene_1` actions that can be used in automations.
 
 <!-- Notes END: Do not edit below this line -->
 

--- a/docs/devices/TS0726_2_gang.md
+++ b/docs/devices/TS0726_2_gang.md
@@ -23,7 +23,20 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+### Zemismart KES-606US (`_TZ3000_icoxotza`)
+
+This 2 gang variant is the Zemismart KES-606US-L2. It additionally exposes an `indicator_mode` enum (`none` / `relay` / `pos`) to control the LED backlight behaviour. Each gang (`l1`, `l2`) has an independent `switch_mode`.
+
+**Scene mode requires one-time initialization with the Tuya / Smart Life app before pairing to Zigbee2MQTT.** Without this step, setting `switch_mode` to `scene` will not emit `action` events. To enable it:
+
+1. Pair the switch to the Tuya Smart Life app (using a Tuya Zigbee gateway).
+2. Set the desired gang(s) to **Scene Mode** in the Smart Life device settings.
+3. Remove the device from Smart Life.
+4. Factory reset the switch and pair it to Zigbee2MQTT.
+
+After this, `switch_mode: scene` will emit `scene_1` / `scene_2` actions that can be used in automations.
 
 <!-- Notes END: Do not edit below this line -->
 


### PR DESCRIPTION
Follow-up to Koenkk/zigbee-herdsman-converters#12405.

Adds notes for the Zemismart KES-606US variants (`_TZ3000_ovbvmhiq` 1-gang, `_TZ3000_icoxotza` 2-gang) documenting that scene mode requires a one-time initialization via the Tuya Smart Life app before pairing to Z2M, and the `indicator_mode` expose.