### PR TITLE
Document HA discovery device behavior

### DIFF
--- a/docs/devices/BTH-RM230Z.md
+++ b/docs/devices/BTH-RM230Z.md
@@ -26,6 +26,9 @@ pageClass: device-page
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
 ## Pairing
 To pair this device you have to install the device via its installation code. The installation code can be obtained by scanning the QR-code on the back of the cover with your smartphone. Then get the device into pairing mode. In zigbee2mqtt navigate to "Settings" --> "Tools" and click on "Add install code". Paste the code you got from the QR-code and confirm by clicking "OK", then ensure permit joining is active. Wait for your device to be joined.
+
+## Home Assistant discovery
+This thermostat is normally used as a heat-only thermostat. Zigbee2MQTT suppresses Home Assistant cooling mode by default; enable the `expose_cooling` device option only for installations that actually support cooling. The raw MQTT climate expose can still show cooling-oriented cluster fields reported by the firmware.
 <!-- Notes END: Do not edit below this line -->
 
 
@@ -165,4 +168,3 @@ Indicates whether the device encounters any errors or not.
 Value can be found in the published state on the `error_state` property.
 To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME/get` with payload `{"error_state": ""}`.
 It's not possible to write (`/set`) this value.
-

--- a/docs/devices/S4SN-0U61X.md
+++ b/docs/devices/S4SN-0U61X.md
@@ -24,7 +24,10 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+### Presence zones
+Zigbee2MQTT discovers configured presence zones from the Shelly device configuration over RPC. After the configuration has been read, only configured zones are exposed. Before this discovery has completed, or when the RPC read fails, Zigbee2MQTT falls back to the maximum supported zone list.
 
 <!-- Notes END: Do not edit below this line -->
 
@@ -169,4 +172,3 @@ To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME
 - `net_mask` (text): Subnet mask for the static IP configuration 
 - `gateway` (text): Default gateway address for static IP configuration 
 - `name_server` (text): Name server address for static IP configuration 
-

--- a/docs/devices/S4SW-002P16EU-COVER.md
+++ b/docs/devices/S4SW-002P16EU-COVER.md
@@ -39,9 +39,11 @@ The usage is automatically detected based on the endpoint configuration.  For no
 
 ### Cover Mode Features
 When operating in cover mode, this device provides:
-- Window covering controls (lift and tilt)
+- Window covering controls
 - Position feedback
 - State reporting (OPEN/CLOSE)
+
+Tilt support is only available when slat control is enabled on the Shelly device. The `cover_tilt_enabled` device option controls whether Zigbee2MQTT exposes tilt: `auto` reads the Shelly cover configuration over RPC, while `true` or `false` can be used to override the detected value.
 
 Vendor product page: [Shelly 2PM Gen4](https://kb.shelly.cloud/knowledge-base/shelly-2pm-gen4)
 
@@ -120,4 +122,3 @@ Triggered action (e.g. a button click).
 Value can be found in the published state on the `action` property.
 It's not possible to read (`/get`) or write (`/set`) this value.
 The possible values are: `input_1_on`, `input_1_off`, `input_1_toggle`, `input_1_hold`, `input_2_on`, `input_2_off`, `input_2_toggle`, `input_2_hold`.
-

--- a/docs/devices/SWV-ZFE.md
+++ b/docs/devices/SWV-ZFE.md
@@ -24,7 +24,13 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+### Home Assistant valve discovery
+The main `state` property opens and closes the valve. Zigbee2MQTT exposes this property as an MQTT switch, and Home Assistant discovery can map it to a valve entity when the converter marks the device as a water valve.
+
+### Partial watering settings
+The watering composites support partial updates in Zigbee2MQTT. When only one field is sent, Zigbee2MQTT merges it with the current device state before writing the full vendor payload. For `irrigation_plan_settings`, read `irrigation_plan_report` first if Zigbee2MQTT has not received the current plan state yet.
 
 <!-- Notes END: Do not edit below this line -->
 
@@ -223,4 +229,3 @@ Can be set by publishing to `zigbee2mqtt/FRIENDLY_NAME/set` with payload `{"read
 - `type` (enum): Reading type allowed values: `24_hours`, `30_days`, `6_months`
 - `time_start` (text): Start time in ISO format with timezone (e.g. YYYY-MM-DDTHH:mm:ss+08:00) 
 - `time_end` (text): End time in ISO format with timezone (e.g. YYYY-MM-DDTHH:mm:ss+08:00) 
-

--- a/docs/guide/configuration/devices-groups.md
+++ b/docs/guide/configuration/devices-groups.md
@@ -78,7 +78,7 @@ sure to set `mqtt.version` to `5` (see `mqtt` configuration above)
 QoS level for MQTT messages of this device. [What is QoS?](https://www.npmjs.com/package/mqtt#about-qos)
 
 **`homeassistant`**  
-Allows overriding the values of the Home Assistant discovery payload. See example above.
+Allows overriding the values of the Home Assistant discovery payload. Overrides can be set globally for the device or for a specific discovered entity under its `object_id`; setting a property to `null` removes it from the discovery payload. See [Home Assistant discovery overrides](../usage/integrations/home_assistant.md#overriding-discovery-properties) for examples.
 
 **`debounce`**  
 Debounces messages of this device. When setting e.g. `debounce: 1` and a message from a device is

--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -117,6 +117,11 @@ Group discovery properties can be overridden via `groups.<id>.homeassistant` in 
 
 Any Home Assistant MQTT discovery property can be overridden on a device. Two examples are shown below. For a full and current list of discovery properties, see [the Home Assistant MQTT Discovery integration](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery) and [the Home Assistant extension](https://github.com/Koenkk/zigbee2mqtt/blob/03ba647dc6b5f299f8f3ab441712999fcb3a253e/lib/extension/homeassistant.ts) in the Zigbee2MQTT source code.
 
+Overrides can be set at the device level or for a specific discovered entity under its `object_id`.
+The entity `object_id` is the part used in the Home Assistant discovery payload, for example `light`, `cover`, `climate`, `temperature`, or a generated composite child such as `manual_default_settings_irrigation_duration`.
+Device-specific overrides are applied after Zigbee2MQTT's built-in compatibility mappings, so they can be used to remove or adjust discovery properties that do not match your installation.
+Set a discovery property to `null` to remove it from the Home Assistant discovery payload.
+
 ### Changing `supported_color_modes`
 
 This is useful for switching light bulbs from reporting values from X/Y (which is the default) to reporting in hue / saturation (which is what bulbs report color in when changing via hue or saturation, such as with the `hue_move` and `saturation_move` commands).
@@ -164,6 +169,50 @@ devices:
                 value_template: null
                 state_value_template: '{{ value_json.state_right }}'
 ```
+
+### Removing unsupported capabilities
+
+Some devices expose generic capabilities that are not useful for every installation. For example, a cover controller can expose tilt controls even when it is connected to a roller blind without slats, or a thermostat discovery payload can expose modes that should not be offered in Home Assistant. These can be adjusted with per-entity discovery overrides.
+
+This example removes the Home Assistant tilt command/status properties from a discovered cover:
+
+```yaml
+devices:
+    '0x12345678':
+        friendly_name: living_room_blind
+        homeassistant:
+            cover:
+                tilt_command_topic: null
+                tilt_status_topic: null
+                tilt_status_template: null
+                tilt_min: null
+                tilt_max: null
+                tilt_closed_value: null
+                tilt_opened_value: null
+```
+
+This example limits a climate entity to the modes that should be offered by Home Assistant:
+
+```yaml
+devices:
+    '0x12345678':
+        friendly_name: hallway_thermostat
+        homeassistant:
+            climate:
+                modes: ['off', 'heat', 'auto']
+```
+
+### Composite controls
+
+When a Zigbee2MQTT expose is a settable composite with numeric or enum child features, Zigbee2MQTT also creates dedicated Home Assistant `number` or `select` entities for those child features. The original composite sensor remains available for viewing the full object.
+
+For example, a composite property named `manual_default_settings` with a numeric child property named `irrigation_duration` is discovered as a Home Assistant number entity using the object ID `manual_default_settings_irrigation_duration`. When changed from Home Assistant it publishes only the changed child field:
+
+```json
+{"manual_default_settings": {"irrigation_duration": 30}}
+```
+
+If a device requires the full composite object when setting a child field, its converter must merge this partial payload with the current state or expose a non-composite control instead.
 
 ### Changing device properties
 


### PR DESCRIPTION
## Summary
- Document Home Assistant heat-only discovery behavior for Bosch BTH-RM230Z
- Document Shelly 2PM Gen4 cover tilt/slat-control discovery and override behavior
- Document Shelly Presence zone discovery fallback behavior
- Document SONOFF water valve Home Assistant valve discovery and partial watering-setting writes

## Validation
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.12.1 pretty:check`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.12.1 test`