### PR TITLE
Document Shelly 2PM cover tilt discovery

### DIFF
--- a/docs/devices/S4SW-002P16EU-COVER.md
+++ b/docs/devices/S4SW-002P16EU-COVER.md
@@ -42,9 +42,11 @@ Zigbee2MQTT exposes switch input type controls for each input endpoint reported 
 
 ### Cover Mode Features
 When operating in cover mode, this device provides:
-- Window covering controls (lift and tilt)
+- Window covering controls
 - Position feedback
 - State reporting (OPEN/CLOSE)
+
+Tilt support is only available when slat control is enabled on the Shelly device. The `cover_tilt_enabled` device option controls whether Zigbee2MQTT exposes tilt: `auto` reads the Shelly cover configuration over RPC, while `true` or `false` can be used to override the detected value.
 
 Vendor product page: [Shelly 2PM Gen4](https://kb.shelly.cloud/knowledge-base/shelly-2pm-gen4)
 
@@ -126,4 +128,3 @@ To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME
 - `net_mask` (text): Subnet mask for the static IP configuration 
 - `gateway` (text): Default gateway address for static IP configuration 
 - `name_server` (text): Name server address for static IP configuration 
-


### PR DESCRIPTION
## Summary
- Document that Shelly 2PM Gen4 cover tilt is exposed only when slat control is enabled.
- Document the `cover_tilt_enabled` auto/override behavior.

## Related code PR
- Koenkk/zigbee-herdsman-converters#12497

## Validation
- `git diff --check`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.12.1 pretty:check`

## Draft status

Kept as draft until Koenkk/zigbee-herdsman-converters#12497 is ready and the final default/auto-detection behavior is confirmed. This docs branch should match the source PR exactly before leaving draft.
