### PR TITLE
Document Home Assistant discovery overrides

### DIFF
--- a/docs/guide/configuration/devices-groups.md
+++ b/docs/guide/configuration/devices-groups.md
@@ -78,7 +78,7 @@ sure to set `mqtt.version` to `5` (see `mqtt` configuration above)
 QoS level for MQTT messages of this device. [What is QoS?](https://www.npmjs.com/package/mqtt#about-qos)
 
 **`homeassistant`**  
-Allows overriding the values of the Home Assistant discovery payload. See example above.
+Allows overriding the values of the Home Assistant discovery payload. Overrides can be set globally for the device or for a specific discovered entity under its `object_id`; setting a property to `null` removes it from the discovery payload. See [Home Assistant discovery overrides](../usage/integrations/home_assistant.md#overriding-discovery-properties) for examples.
 
 **`debounce`**  
 Debounces messages of this device. When setting e.g. `debounce: 1` and a message from a device is

--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -117,6 +117,11 @@ Group discovery properties can be overridden via `groups.<id>.homeassistant` in 
 
 Any Home Assistant MQTT discovery property can be overridden on a device. Two examples are shown below. For a full and current list of discovery properties, see [the Home Assistant MQTT Discovery integration](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery) and [the Home Assistant extension](https://github.com/Koenkk/zigbee2mqtt/blob/03ba647dc6b5f299f8f3ab441712999fcb3a253e/lib/extension/homeassistant.ts) in the Zigbee2MQTT source code.
 
+Overrides can be set at the device level or for a specific discovered entity under its `object_id`.
+The entity `object_id` is the part used in the Home Assistant discovery payload, for example `light`, `cover`, `climate`, `temperature`, or a generated composite child such as `manual_default_settings_irrigation_duration`.
+Device-specific overrides are applied after Zigbee2MQTT's built-in compatibility mappings, so they can be used to remove or adjust discovery properties that do not match your installation.
+Set a discovery property to `null` to remove it from the Home Assistant discovery payload.
+
 ### Changing `supported_color_modes`
 
 This is useful for switching light bulbs from reporting values from X/Y (which is the default) to reporting in hue / saturation (which is what bulbs report color in when changing via hue or saturation, such as with the `hue_move` and `saturation_move` commands).
@@ -164,6 +169,50 @@ devices:
                 value_template: null
                 state_value_template: '{{ value_json.state_right }}'
 ```
+
+### Removing unsupported capabilities
+
+Some devices expose generic capabilities that are not useful for every installation. For example, a cover controller can expose tilt controls even when it is connected to a roller blind without slats, or a thermostat discovery payload can expose modes that should not be offered in Home Assistant. These can be adjusted with per-entity discovery overrides.
+
+This example removes the Home Assistant tilt command/status properties from a discovered cover:
+
+```yaml
+devices:
+    '0x12345678':
+        friendly_name: living_room_blind
+        homeassistant:
+            cover:
+                tilt_command_topic: null
+                tilt_status_topic: null
+                tilt_status_template: null
+                tilt_min: null
+                tilt_max: null
+                tilt_closed_value: null
+                tilt_opened_value: null
+```
+
+This example limits a climate entity to the modes that should be offered by Home Assistant:
+
+```yaml
+devices:
+    '0x12345678':
+        friendly_name: hallway_thermostat
+        homeassistant:
+            climate:
+                modes: ['off', 'heat', 'auto']
+```
+
+### Composite controls
+
+When a Zigbee2MQTT expose is a settable composite with numeric or enum child features, Zigbee2MQTT also creates dedicated Home Assistant `number` or `select` entities for those child features. The original composite sensor remains available for viewing the full object.
+
+For example, a composite property named `manual_default_settings` with a numeric child property named `irrigation_duration` is discovered as a Home Assistant number entity using the object ID `manual_default_settings_irrigation_duration`. When changed from Home Assistant it publishes only the changed child field:
+
+```json
+{"manual_default_settings": {"irrigation_duration": 30}}
+```
+
+If a device requires the full composite object when setting a child field, its converter must merge this partial payload with the current state or expose a non-composite control instead.
 
 ### Changing device properties
 

--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -122,6 +122,12 @@ The entity `object_id` is the part used in the Home Assistant discovery payload,
 Device-specific overrides are applied after Zigbee2MQTT's built-in compatibility mappings, so they can be used to remove or adjust discovery properties that do not match your installation.
 Set a discovery property to `null` to remove it from the Home Assistant discovery payload.
 
+The override can also change the discovery `type` (for example, from `switch` to
+`light`), replace the `schema` used by the entity, or set `value_template` and
+other discovery fields such as `valueTemplate` supported by the selected schema.
+Use the exact property names from the Home Assistant MQTT discovery payload; the
+override is merged into that payload after Zigbee2MQTT's built-in mappings.
+
 ### Changing `supported_color_modes`
 
 This is useful for switching light bulbs from reporting values from X/Y (which is the default) to reporting in hue / saturation (which is what bulbs report color in when changing via hue or saturation, such as with the `hue_move` and `saturation_move` commands).

--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -122,11 +122,6 @@ The entity `object_id` is the part used in the Home Assistant discovery payload,
 Device-specific overrides are applied after Zigbee2MQTT's built-in compatibility mappings, so they can be used to remove or adjust discovery properties that do not match your installation.
 Set a discovery property to `null` to remove it from the Home Assistant discovery payload.
 
-The override can also change the discovery `type` (for example, from `switch` to
-`light`), replace the `schema` used by the entity, or set `value_template` and
-other discovery fields such as `valueTemplate` supported by the selected schema.
-Use the exact property names from the Home Assistant MQTT discovery payload; the
-override is merged into that payload after Zigbee2MQTT's built-in mappings.
 
 ### Changing `supported_color_modes`
 
@@ -207,18 +202,6 @@ devices:
             climate:
                 modes: ['off', 'heat', 'auto']
 ```
-
-### Composite controls
-
-When a Zigbee2MQTT expose is a settable composite with numeric or enum child features, Zigbee2MQTT also creates dedicated Home Assistant `number` or `select` entities for those child features. The original composite sensor remains available for viewing the full object.
-
-For example, a composite property named `manual_default_settings` with a numeric child property named `irrigation_duration` is discovered as a Home Assistant number entity using the object ID `manual_default_settings_irrigation_duration`. When changed from Home Assistant it publishes only the changed child field:
-
-```json
-{"manual_default_settings": {"irrigation_duration": 30}}
-```
-
-If a device requires the full composite object when setting a child field, its converter must merge this partial payload with the current state or expose a non-composite control instead.
 
 ### Changing device properties
 

--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -118,10 +118,11 @@ Group discovery properties can be overridden via `groups.<id>.homeassistant` in 
 Any Home Assistant MQTT discovery property can be overridden on a device. Two examples are shown below. For a full and current list of discovery properties, see [the Home Assistant MQTT Discovery integration](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery) and [the Home Assistant extension](https://github.com/Koenkk/zigbee2mqtt/blob/03ba647dc6b5f299f8f3ab441712999fcb3a253e/lib/extension/homeassistant.ts) in the Zigbee2MQTT source code.
 
 Overrides can be set at the device level or for a specific discovered entity under its `object_id`.
-The entity `object_id` is the part used in the Home Assistant discovery payload, for example `light`, `cover`, `climate`, `temperature`, or a generated composite child such as `manual_default_settings_irrigation_duration`.
+The entity `object_id` is the part used in the Home Assistant discovery payload, for example `light`, `cover`, `climate`, or `temperature`.
 Device-specific overrides are applied after Zigbee2MQTT's built-in compatibility mappings, so they can be used to remove or adjust discovery properties that do not match your installation.
 Set a discovery property to `null` to remove it from the Home Assistant discovery payload.
 
+Converter authors can also set `homeassistant` metadata on an expose: `type` selects the discovery component, `schema` sets the discovery payload's `schema`, and `valueTemplate` sets its `value_template` (`null` removes that template). These are converter metadata fields; user configuration overrides use the MQTT discovery property names, such as `value_template`, rather than `valueTemplate`.
 
 ### Changing `supported_color_modes`
 


### PR DESCRIPTION
## Summary
- Document per-entity Home Assistant discovery overrides under device `homeassistant` config.
- Document removing unsupported discovery capabilities by setting payload keys to `null`.
- Document scalar composite child discovery behavior.

## Related code PRs
- Koenkk/zigbee2mqtt#32361
- Koenkk/zigbee2mqtt#32362 (older draft, likely superseded by #32363)
- Koenkk/zigbee2mqtt#32363
- Koenkk/zigbee2mqtt#32379

## Validation
- `git diff --check`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.12.1 pretty:check`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.12.1 test`

## Draft status

Kept as draft while the scalar-composite discovery approach is still being reviewed. If Koenkk/zigbee2mqtt#32362 is closed as superseded, this docs branch should be narrowed to the final Koenkk/zigbee2mqtt#32363 behavior before leaving draft.
