### PR TITLE
Document Shelly Presence zone discovery

### DIFF
--- a/docs/devices/S4SN-0U61X.md
+++ b/docs/devices/S4SN-0U61X.md
@@ -24,7 +24,10 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
+## Notes
 
+### Presence zones
+Zigbee2MQTT discovers configured presence zones from the Shelly device configuration over RPC. After the configuration has been read, only configured zones are exposed. Before this discovery has completed, or when the RPC read fails, Zigbee2MQTT falls back to the maximum supported zone list.
 
 <!-- Notes END: Do not edit below this line -->
 
@@ -169,4 +172,3 @@ To read (`/get`) the value publish a message to topic `zigbee2mqtt/FRIENDLY_NAME
 - `net_mask` (text): Subnet mask for the static IP configuration 
 - `gateway` (text): Default gateway address for static IP configuration 
 - `name_server` (text): Name server address for static IP configuration 
-


### PR DESCRIPTION
## Summary
- Document Shelly Presence configured-zone discovery over RPC.
- Document the fallback to the maximum supported zone list when config readback has not completed or fails.

## Related code PR
- Koenkk/zigbee-herdsman-converters#12506

## Validation
- `git diff --check`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.12.1 pretty:check`