### PR TITLE
Document Home Assistant electrical telemetry diagnostics

### DIFF
--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -43,7 +43,7 @@ The device specific configuration allows you to modify the discovery payload. He
 
 ## Electrical telemetry entities
 
-Devices with a primary controllable entity, such as a switch, light, cover, lock, or fan, can also expose electrical measurements. In Home Assistant, secondary telemetry such as voltage and AC frequency is treated as diagnostic data when the device also exposes primary power or energy data.
+Device definitions can mark secondary electrical measurements with Home Assistant discovery metadata. For modern meter-based devices, voltage, phase voltage, and AC frequency are exposed as diagnostic entities, while primary power, energy, and current entities stay visible as normal measurements.
 
 ## Responding to button actions
 

--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -41,6 +41,10 @@ without having to restart Home Assistant. It also makes it possible to show whic
 
 The device specific configuration allows you to modify the discovery payload. Here you can also prevent a device from being discovered. See [Device specific configuration](../../configuration/devices-groups.html#specific-device-options) for the available options.
 
+## Electrical telemetry entities
+
+Devices with a primary controllable entity, such as a switch, light, cover, lock, or fan, can also expose electrical measurements. In Home Assistant, secondary telemetry such as voltage and AC frequency is treated as diagnostic data when the device also exposes primary power or energy data.
+
 ## Responding to button actions
 
 To respond to button actions you can use one of the following Home Assistant configurations.


### PR DESCRIPTION
## Summary
- Document that converter-provided Home Assistant metadata can categorize secondary electrical telemetry.
- Clarify that modern meter voltage, phase voltage, and AC frequency entities are diagnostic, while primary power/energy/current measurements remain normal entities.

## Related code PRs
- Koenkk/zigbee-herdsman-converters#12531
- Koenkk/zigbee2mqtt#32380

## Validation
- `git diff --check`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.12.1 pretty:check`

## Draft status

Kept as draft while the paired code PRs are still under review.
