### PR TITLE
Document Home Assistant config readback

### DIFF
--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -41,6 +41,10 @@ without having to restart Home Assistant. It also makes it possible to show whic
 
 The device specific configuration allows you to modify the discovery payload. Here you can also prevent a device from being discovered. See [Device specific configuration](../../configuration/devices-groups.html#specific-device-options) for the available options.
 
+## Configuration state readback
+
+Some configuration entities are only useful in Home Assistant after Zigbee2MQTT knows their current state. Zigbee2MQTT reads back selected known configuration exposes when a device reconnects or is reconfigured, so newly discovered config controls do not stay `unknown` until the device reports them by itself.
+
 ## Responding to button actions
 
 To respond to button actions you can use one of the following Home Assistant configurations.


### PR DESCRIPTION
## Summary
- Document that Zigbee2MQTT reads back selected known configuration exposes on reconnect/reconfigure.
- Explain why some Home Assistant config entities no longer remain unknown until self-reporting.

## Related code PR
- Koenkk/zigbee2mqtt#32376

## Validation
- `git diff --check`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx pnpm@10.12.1 pretty:check`

## Draft status

Kept as draft while Koenkk/zigbee2mqtt#32376 is still being reworked against review feedback.