### PR TITLE
docs: document mqtt.server_name TLS SNI override

### DIFF
--- a/docs/guide/configuration/mqtt.md
+++ b/docs/guide/configuration/mqtt.md
@@ -29,6 +29,10 @@ mqtt:
     client_id: 'MY_CLIENT_ID'
     # Optional: disable self-signed SSL certificates (default: true)
     reject_unauthorized: true
+    # Optional: override the TLS SNI / hostname used for certificate verification when it differs
+    # from the host in 'server', e.g. connecting to an internal hostname while validating a public
+    # certificate SAN. Leave unset to use the hostname from 'server'. (default: nothing)
+    server_name: 'mqtt.example.com'
     # Optional: Include device information to mqtt messages (default: false)
     include_device_information: true
     # Optional: MQTT keepalive in seconds (default: 60)


### PR DESCRIPTION
Documents the new `mqtt.server_name` setting added in Koenkk/zigbee2mqtt#32417.

`mqtt.server_name` overrides the TLS SNI / certificate-hostname used when connecting to the MQTT broker, without disabling certificate validation. This is useful when connecting to the broker via a hostname or IP that is not listed in the broker certificate's Subject Alternative Names (e.g. an internal Docker/Kubernetes service name) while the certificate is only valid for a public domain.

Adds the setting to the MQTT server connection example in `docs/guide/configuration/mqtt.md`, grouped with the other TLS options.

Made with [Cursor](https://cursor.com)