### PR TITLE
Set 4-space indent for GitHub YAML files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ insert_final_newline = true
 
 [{*.md, *.pug}]
 trim_trailing_whitespace = false
+
+[.github/**.yml]
+indent_size = 4


### PR DESCRIPTION
Update `.editorconfig` to apply `indent_size = 4` for `.github/**.yml` files as currently used.

This keeps GitHub workflow/config YAML formatting consistent.