### PR TITLE
Add quarterly Dependabot updates for GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 updates:
+    - package-ecosystem: 'github-actions'
+      directory: /
+      schedule:
+          interval: quarterly
+      groups:
+          github-actions:
+              patterns:
+                  - '*'
     - package-ecosystem: npm
       versioning-strategy: increase
       directory: /


### PR DESCRIPTION
Currently the GH actions are outdated and throw annotations like:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4, pnpm/action-setup@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
