### PR TITLE
Hue dimmer switch 2: document toggle behavior

### DIFF
--- a/docs/devices/929002398602.md
+++ b/docs/devices/929002398602.md
@@ -52,16 +52,21 @@ By default, the device is bound to the coordinator, but it can also be used to d
 As the device is sleeping by default, you will need to wake it up after sending the bind/unbind command by pressing any button.
 
 When endpoint `1` is bound to a light or a group of lights, the behavior is as follows:
-| Button | Click | Action | Comment |
-|-----|-----|-----|-----|
-| Power | Single, Double  | Toggle state | The device keeps track of each press, alternating between on and off actions. The on action is using the `commandOn` command. The off action is using the `commandOffWithEffect` command with `{"effectid":0,"effectvariant":0}` payload. |
-| Brightness up | Single | Step up the brightness | In steps of 30 points (around 12%), using the `commandStep` command with `{"stepmode":0,"stepsize":30,"transtime":9}` payload. |
-| Brightness up | Long | Smoothly increase the brightness | In steps of 63 points (around 25%), using the `commandStep` command with `{"stepmode":0,"stepsize":63,"transtime":9}` payload. Sends the `commandStop` command, on button release. |
-| Brightness down | Single | Step down the brightness | In steps of 30 points (around 12%), using the `commandStep` command with `{"stepmode":1,"stepsize":30,"transtime":9}` payload. |
-| Brightness down | Long | Smoothly decrease the brightness | In steps of 63 points (around 25%), using the `commandStep` command with `{"stepmode":1,"stepsize":63,"transtime":9}` payload. Sends the `commandStop` command, on button release. |
-| Hue | Single | Switch between scenes | The device keeps track of each press, alternating between two scenes (`"sceneid":1` and `"sceneid":2`) in a predetermined group with a groupID specific to the particular device¹ using the `commandRecall` command. |
 
-¹ To obtain the groupID and set up the binding, you need to follow these steps:
+| Click  | Button | Command                                            |
+| ------ | ------ | -------------------------------------------------- |
+| Single | Power  | Alternating¹ *On* / *OffWithEffect (0,0)*          |
+| Single | Up     | *Step (Up, 30 points, 0.9s transition)*            |
+| Long   | Up     | *Step (Up, 63 points, 0.9s transition)* + *Stop*   |
+| Single | Down   | *Step (Down, 30 points, 0.9s transition)*          |
+| Long   | Down   | *Step (Down, 63 points, 0.9s transition)* + *Stop* |
+| Single | Hue    | *RecallScene² (G, S)*                              |
+
+¹ The remote tries to determine the correct command. Behavior depends on the firmware version:
+- v2.77.39: Remote reads onOff state from **the coordinator** -> This fails in Zigbee2MQTT -> Remote stores the state and falls-back to simple alternation
+- v2.85.1: Remote reads onOff state from **the parent** (~nearest router) -> It replies with on/off -> Remote sends the opposite command (*Off*/*On*). This is an issue if the parent and the target are different devices!
+
+² The device alternates between two scenes (1 and 2) in a predetermined group, specific to the particular remote. To obtain the groupID and set up the binding, follow these steps:
 
 - turn on debug level logging in Zigbee2MQTT
 - make sure dimmer is paired


### PR DESCRIPTION
- Documenting the findings in https://github.com/Koenkk/zigbee2mqtt/issues/31955

Thanks @burmistrzak! Please verify 🙂
Maybe you can also complete the table with "Z2M action" column, after this is merged?
I don't have the device to test