### PR TITLE
add docker-compose example with EMQX

### DIFF
--- a/docs/guide/installation/02_docker.md
+++ b/docs/guide/installation/02_docker.md
@@ -183,5 +183,6 @@ You can optionally skip `zigbee2mqtt` and it will pull any new images for all co
 
 ## Additional links
 
+- [Docker Compose example with EMQX as the MQTT broker](https://www.emqx.com/en/blog/zigbee2mqtt-in-2026#run-zigbee2mqtt-with-emqx)
 - [Docker Stack device mapping](./docker//docker_stack.md)
 - [Docker on Synology DSM 7.0](./docker//docker_synology.md)


### PR DESCRIPTION
Adds an external end-to-end Docker Compose example that runs Zigbee2MQTT with EMQX as its MQTT broker. The current Docker guide covers Zigbee2MQTT itself but assumes a broker is already available.

Disclosure: I authored the linked guide and work for EMQ. This does not change Zigbee2MQTT’s Mosquitto recommendation.