### PR TITLE
feat: add gfm alert support

### DIFF
--- a/docgen/generate_settings.ts
+++ b/docgen/generate_settings.ts
@@ -221,9 +221,8 @@ pageClass: settings-page
 
 This page contains all currently supported settings in \`configuration.yaml\`.
 
-::: tip NOTE
-The code blocks show an **example value** for each setting (may be the default or any value derived from the possibilities/examples/boundaries).
-:::
+> [!NOTE]
+> The code blocks show an **example value** for each setting (may be the default or any value derived from the possibilities/examples/boundaries).
 
 ${groupProperties(schemaJson.properties, [], schemaJson.required, schemaJson.definitions).sort().join('\r\n')}
 `;

--- a/docs/advanced/more/external_converters.md
+++ b/docs/advanced/more/external_converters.md
@@ -5,11 +5,10 @@ redirectFrom: /information/external_converters.md
 
 # External converters
 
-:::warning WARNING
-External converters are disabled by default in new installations in version 2.11.0 and later.
-See [`enable_external_js`](../../guide/configuration/all-settings.md#enable-external-js) to enable it.
-See [more details](../../guide/installation/14_securing.md#external-extensions-and-converters)
-:::
+> [!WARNING]
+> External converters are disabled by default in new installations in version 2.11.0 and later.
+> See [`enable_external_js`](../../guide/configuration/all-settings.md#enable-external-js) to enable it.
+> See [more details](../../guide/installation/14_securing.md#external-extensions-and-converters)
 
 Zigbee2MQTT uses [zigbee-herdsman-converters](https://github.com/Koenkk/zigbee-herdsman-converters) to parse messages to and from devices.
 
@@ -17,13 +16,11 @@ External converters provide a way to test support for new devices, they work ide
 
 External converters are stored in the `external_converters` folder (at the same level in the file system as the Zigbee2MQTT configuration.yaml file). They have to export a JavaScript Object or Array of Object matching the type [`DefinitionWithExtend`](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/lib/types.ts). Refer to [existing converters](https://github.com/Koenkk/zigbee-herdsman-converters/tree/master/src/devices) to get familiar with the framework.
 
-:::tip TIP
-Once your converter is ready, open a [pull request](https://github.com/Koenkk/zigbee-herdsman-converters/pulls) so it can be integrated into Zigbee2MQTT for all to use. Once the new Zigbee2MQTT version is released, you can just delete the external converter.
-:::
+> [!TIP]
+> Once your converter is ready, open a [pull request](https://github.com/Koenkk/zigbee-herdsman-converters/pulls) so it can be integrated into Zigbee2MQTT for all to use. Once the new Zigbee2MQTT version is released, you can just > delete the external converter.
 
-:::tip TIP
-The easiest way to develop is by using the [external converter development environment](https://github.com/Nerivec/z2m-external-converter-dev?tab=readme-ov-file#how-to-use)
-:::
+> [!TIP]
+> The easiest way to develop is by using the [external converter development environment](https://github.com/Nerivec/z2m-external-converter-dev?tab=readme-ov-file#how-to-use)
 
 Example:
 
@@ -83,9 +80,8 @@ import {presets, access} from 'zigbee-herdsman-converters/lib/exposes';
 
 When Zigbee2MQTT starts it publishes `zigbee2mqtt/bridge/converters` with payload `[{"name": "my-first-converter.js": "code": <HERE COMES YOUR CONVERTER CODE>}]` containing all the converters loaded from the file system. The same message is also published when a converter changes at runtime (from one of the below actions), with the appropriately updated payload.
 
-:::tip TIP
-Via the Zigbee2MQTT front end in Home Assistant, you can add or update external converters via Settings > Dev console > External converters.
-:::
+> [!TIP]
+> Via the Zigbee2MQTT front end in Home Assistant, you can add or update external converters via Settings > Dev console > External converters.
 
 ## Save converter
 

--- a/docs/advanced/more/external_extensions.md
+++ b/docs/advanced/more/external_extensions.md
@@ -5,11 +5,10 @@ redirectFrom: /information/external_extensions.md
 
 # External extensions
 
-:::warning WARNING
-External extensions are disabled by default in new installations in version 2.11.0 and later.
-See [`enable_external_js`](../../guide/configuration/all-settings.md#enable-external-js) to enable it.
-See [more details](../../guide/installation/14_securing.md#external-extensions-and-converters)
-:::
+> [!WARNING]
+> External extensions are disabled by default in new installations in version 2.11.0 and later.
+> See [`enable_external_js`](../../guide/configuration/all-settings.md#enable-external-js) to enable it.
+> See [more details](../../guide/installation/14_securing.md#external-extensions-and-converters)
 
 External extensions provide a way to extend Zigbee2MQTT behavior, they work identically to internal extensions.
 
@@ -17,9 +16,8 @@ To get familiar with the Extension framework, refer to the [source code of inter
 
 External extensions are stored in `data/external_extensions` folder and have to export a JavaScript Class that conforms to the `Extension` base class (see above link).
 
-:::tip TIP
-You can find some ready-made extensions in the following repository [https://github.com/Koenkk/zigbee2mqtt-user-extensions/](https://github.com/Koenkk/zigbee2mqtt-user-extensions/)
-:::
+> [!TIP]
+> You can find some ready-made extensions in the following repository [https://github.com/Koenkk/zigbee2mqtt-user-extensions/](https://github.com/Koenkk/zigbee2mqtt-user-extensions/)
 
 Example:
 

--- a/docs/advanced/more/switch-to-dev-branch.md
+++ b/docs/advanced/more/switch-to-dev-branch.md
@@ -8,9 +8,8 @@ redirectFrom: /how_tos/how-to-switch-to-dev-branch.md
 The Zigbee2MQTT dev branch contains the latest features, improvements and supported devices.
 In case you want to try this, you can checkout the dev branch.
 
-::: warning
-This branch is a development branch! It could be less stable than the release version!
-:::
+> [!WARNING]
+> This branch is a development branch! It could be less stable than the release version!
 
 ## Linux
 
@@ -53,18 +52,14 @@ Use the [`edge`](https://github.com/zigbee2mqtt/hassio-zigbee2mqtt) version.
 - If you have any settings in the `Configuration` page of the "regular" add-on, copy them over to that of the `Edge` add-on
 - Start the `Edge` add-on (and configure `Start on boot`, `Watchdog` & `Show in sidebar` as desired)
 
-:::caution CAUTION
-Do not start both add-ons with the same configuration at the same time. That will fail.
-:::
+> [!CAUTION]
+> Do not start both add-ons with the same configuration at the same time. That will fail.
 
-:::tip TIP
-To update the `Edge` add-on, simply uninstall it (**do not delete data**), and re-install it.
-:::
+> [!TIP]
+> To update the `Edge` add-on, simply uninstall it (**do not delete data**), and re-install it.
 
-:::tip TIP
-If you intend to stay on the `Edge` add-on permanently, once you've confirmed that `Edge` is working, you can then uninstall the "regular" add-on (**do not delete data**).
-:::
+> [!TIP]
+> If you intend to stay on the `Edge` add-on permanently, once you've confirmed that `Edge` is working, you can then uninstall the "regular" add-on (**do not delete data**).
 
-:::tip TIP
-When switching add-ons regularly, you might want to always use the `configuration.yaml` directly instead of the add-on `Configuration` page to avoid mismatching settings by mistake. Once settings are successfully moved to the `configuration.yaml`, you can just empty the corresponding boxes (`mqtt`, `serial`) in the add-on `Configuration` page and start Zigbee2MQTT again.
-:::
+> [!TIP]
+> When switching add-ons regularly, you might want to always use the `configuration.yaml` directly instead of the add-on `Configuration` page to avoid mismatching settings by mistake. Once settings are successfully moved to the `configuration.yaml`, you can just empty the corresponding boxes (`mqtt`, `serial`) in the add-on `Configuration` page and start Zigbee2MQTT again.

--- a/docs/advanced/more/tuya_xiaomi_ota_url.md
+++ b/docs/advanced/more/tuya_xiaomi_ota_url.md
@@ -1,12 +1,10 @@
 # Get Tuya and Xiaomi OTA url
 
-::: warning
-On x86 computers, Android Studio can no longer emulate ARM and run the Tuya app
-:::
+> [!WARNING]
+> On x86 computers, Android Studio can no longer emulate ARM and run the Tuya app
 
-::: warning
-This method doesn't work for Tuya devices newer than the v3.12.6 app (~2020)
-:::
+> [!WARNING]
+> This method doesn't work for Tuya devices newer than the v3.12.6 app (~2020)
 
 This guide explains how to retrieve a TuYa or Xiaomi OTA file for your device. This file can then be used to update your TuYa/Xiaomi device via Zigbee2MQTT.
 

--- a/docs/advanced/remote-adapter/connect_to_a_remote_adapter.md
+++ b/docs/advanced/remote-adapter/connect_to_a_remote_adapter.md
@@ -8,15 +8,14 @@ This how-to explains how to run Zigbee2MQTT with an adapter on a remote location
 We will use ser2net for this which allows to connect to a serial port over TCP.
 In this way you can e.g. setup a Raspberry Pi Zero with the adapter connected while running Zigbee2MQTT on a different system. The instructions below have to be executed on the system where the adapter is connected to.
 
-::: warning
-Be aware that it is not recommended to use a Zigbee Coordinator via a Serial-Proxy-Server (also known as Serial-to-IP bridge or Ser2Net remote adapter) over a WiFi, WAN, or VPN connection.
-
-Serial protocols used by Zigbee Coordinator do not have enough robustness, resilience, or fault-tolerance to handle packet loss and latency delays that can occur over unstable connections.
-
-Zigbee Coordinator requires a stable local connection to its serial port interface with no drops in communication between it and the Zigbee gateway application running on the host computer.
-
-Thus be warned that connecting to a network-attached remote Zigbee Coordinator over WiFi/WAN/VPN using Ser2Net or other Serial Proxy/Forwarding Tunnel is not supported for normal operation.
-:::
+> [!WARNING]
+> Be aware that it is not recommended to use a Zigbee Coordinator via a Serial-Proxy-Server (also known as Serial-to-IP bridge or Ser2Net remote adapter) over a WiFi, WAN, or VPN connection.
+>
+> Serial protocols used by Zigbee Coordinator do not have enough robustness, resilience, or fault-tolerance to handle packet loss and latency delays that can occur over unstable connections.
+>
+> Zigbee Coordinator requires a stable local connection to its serial port interface with no drops in communication between it and the Zigbee gateway application running on the host computer.
+>
+> Thus be warned that connecting to a network-attached remote Zigbee Coordinator over WiFi/WAN/VPN using Ser2Net or other Serial Proxy/Forwarding Tunnel is not supported for normal operation.
 
 ## 1. Install ser2net
 

--- a/docs/advanced/remote-adapter/connect_to_a_remote_sonoff_zbbridge.md
+++ b/docs/advanced/remote-adapter/connect_to_a_remote_sonoff_zbbridge.md
@@ -8,13 +8,11 @@ This how-to explains how to run Zigbee2MQTT with a commercial Sonoff ZBBridge Ga
 We will use a Sonoff ZBBridge Gateway with custom firmware to connect to a serial port over TCP.
 In this way you can use a simple premade Hub/Gateway flash it with custom firmware and then use it as your coordinator.
 
-::: warning
-Keep in mind that the EZSP support is currently **experimental**.
-:::
+> [!WARNING]
+> Keep in mind that the EZSP support is currently **experimental**.
 
-::: warning
-WiFi-based Serial-to-IP bridges are **not recommended** as the serial protocol does not have enough fault-tolerance to handle packet loss or latency delays that can normally occur over WiFi connections.
-:::
+> [!WARNING]
+> WiFi-based Serial-to-IP bridges are **not recommended** as the serial protocol does not have enough fault-tolerance to handle packet loss or latency delays that can normally occur over WiFi connections.
 
 ## 1. Flash Tasmota ZBBridge
 

--- a/docs/advanced/support-new-devices/01_support_new_devices.md
+++ b/docs/advanced/support-new-devices/01_support_new_devices.md
@@ -23,9 +23,8 @@ Zigbee2MQTT:info  2019-11-09T12:19:56: Successfully interviewed '0x00158d0001dc1
 Zigbee2MQTT:warn  2019-11-09T12:19:56: Device '0x00158d0001dc126a' with Zigbee model 'lumi.sens' and manufacturer name 'some_name' is NOT supported, please follow https://www.zigbee2mqtt.io/how-tos/support_new_devices.html
 ```
 
-::: tip
-Make sure that joining is enabled, otherwise new devices cannot join the network.
-:::
+> [!TIP]
+> Make sure that joining is enabled, otherwise new devices cannot join the network.
 
 ### 2. Creating the external definition
 
@@ -40,10 +39,9 @@ By default, the external definition will map exposed Zigbee clusters to features
 If all features work and all expected features are present, you are lucky and can skip to step 3.
 If not, you will have to extend the external definition.
 
-::: tip
-Depending on the device, it may be possible to extend the definition using other modern extends.
-This is the recommended process as it is generally easier.
-:::
+> [!TIP]
+> Depending on the device, it may be possible to extend the definition using other modern extends.
+> This is the recommended process as it is generally easier.
 
 ### 3. Extending the generated external definition
 
@@ -51,17 +49,15 @@ To extend the generated external definition, you can either save the code in a f
 
 Add and/or configure the appropriate modern extends for the device (see previous link).
 
-::: tip
-The `Clusters` tab of the device, in frontend, lists supported clusters for further analysis.
-:::
+> [!TIP]
+> The `Clusters` tab of the device, in frontend, lists supported clusters for further analysis.
 
 Once done, trigger actions on the device.
 
 If your device is not reporting anything, it could be that this device requires additional configuration. This can be done by adding a `configure:` section. _It may help to look at similar [devices](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices)._
 
-::: tip
-If your device is advertised as Tuya compatible or reports anything with `manuSpecificTuya`, additional instructions for adding your device can be found [here](./02_support_new_tuya_devices.md).
-:::
+> [!TIP]
+> If your device is advertised as Tuya compatible or reports anything with `manuSpecificTuya`, additional instructions for adding your device can be found [here](./02_support_new_tuya_devices.md).
 
 If you still see messages like below after adding and configuring all appropriate modern extends, you may need to add specific converters that modern extends do not provide. Existing converters can probably be reused, those can be found [here](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/converters/fromZigbee.ts).
 

--- a/docs/advanced/zigbee/04_sniff_zigbee_traffic.md
+++ b/docs/advanced/zigbee/04_sniff_zigbee_traffic.md
@@ -30,13 +30,11 @@ Use Adapter for loopback traffic capture. Then set the Zigbee protocol filter: `
 
 Wireshark will start and log the Zigbee messages once the sniffer is started. As these messages are encrypted we need to add 2 encryption keys. The first one is the Trust Center link key, which is the same for (almost) every Zigbee network. The second one is the network encryption key (Transport Key).
 
-::: tip TIP
-If using Wireshark on a different machine (different IP address), depending on your setup, you may get a lot of `ICMP: Destination unreachable (Port unreachable)` during the capture. You can use the filter `udp.port==17754 && !icmp` to get rid of them.
-:::
+> [!TIP]
+> If using Wireshark on a different machine (different IP address), depending on your setup, you may get a lot of `ICMP: Destination unreachable (Port unreachable)` during the capture. You can use the filter `udp.port==17754 && !icmp` to get rid of them.
 
-::: tip TIP
-You can find details on various customizations for Wireshark in the ZSmart Systems sniffer [PDF - page 7](https://www.opensmarthouse.org/files/download/ZigBeeWiresharkSniffer.pdf). **Coloring rules are processed in order until a match is found. You may need to re-order `UDP` to the bottom to get the Zigbee rules to apply properly.**
-:::
+> [!TIP]
+> You can find details on various customizations for Wireshark in the ZSmart Systems sniffer [PDF - page 7](https://www.opensmarthouse.org/files/download/ZigBeeWiresharkSniffer.pdf). **Coloring rules are processed in order until a match is found. You may need to re-order `UDP` to the bottom to get the Zigbee rules to apply properly.**
 
 ### Adding the Trust Center link key
 
@@ -131,15 +129,14 @@ Start wireshark
 sudo whsniff -c ZIGBEE_CHANNEL_NUMBER | wireshark -k -i -
 ```
 
-::: tip TIP
-Depending on your distribution and installed packages, this may result in a broken pipe after some time. You will notice that Wireshark has stopped capturing, and attempting to resume by clicking the shark fin icon will present you with an error `end of file on pipe magic during open`, if this happens you may instead need to start with:
-
-```bash
-wireshark -k -i <( path/to/whsniff -c channel_number )
-```
-
-Alternative uses are detailed on the [whsniff project page](https://github.com/homewsn/whsniff#how-to-use-locally).
-:::
+> [!TIP]
+> Depending on your distribution and installed packages, this may result in a broken pipe after some time. You will notice that Wireshark has stopped capturing, and attempting to resume by clicking the shark fin icon will present you with an error `end of file on pipe magic during open`, if this happens you may instead need to start with:
+>
+> ```bash
+> wireshark -k -i <( path/to/whsniff -c channel_number )
+> ```
+>
+> Alternative uses are detailed on the [whsniff project page](https://github.com/homewsn/whsniff#how-to-use-locally).
 
 If you just want to save the sniffed data for later analysis you can run this command (compression with gzip is optional):
 
@@ -211,9 +208,8 @@ Both Windows and Linux use the same program for sniffing. You can fetch a precom
 
 You can also find a PDF documentation from ZSmart Systems [here](https://www.opensmarthouse.org/files/download/ZigBeeWiresharkSniffer.pdf).
 
-::: tip TIP
-Linux: Some EmberZNet adapters use the exact same USB identifiers as a brltty udev-registered device, so if your EmberZNet USB dongle is not recognized, just disable the rule of brltty for idVendor=1a86, idProduct=7523 (same as the CH340 serial converter used in the EmberZNet adapter). Edit /`usr/lib/udev/rules.d/85-brltty.rules` and comment `# ENV{PRODUCT}=="1a86/7523/*", ENV{BRLTTY_BRAILLE_DRIVER}="bm", GOTO="brltty_usb_run"`. Unplug and replug the EmberZNet adapter.
-:::
+> [!TIP]
+> Linux: Some EmberZNet adapters use the exact same USB identifiers as a brltty udev-registered device, so if your EmberZNet USB dongle is not recognized, just disable the rule of brltty for idVendor=1a86, idProduct=7523 (same as the CH340 serial converter used in the EmberZNet adapter). Edit /`usr/lib/udev/rules.d/85-brltty.rules` and comment `# ENV{PRODUCT}=="1a86/7523/*", ENV{BRLTTY_BRAILLE_DRIVER}="bm", GOTO="brltty_usb_run"`. Unplug and replug the EmberZNet adapter.
 
 #### 2. Sniffing traffic
 

--- a/docs/devices/E2013.md
+++ b/docs/devices/E2013.md
@@ -24,16 +24,14 @@ pageClass: device-page
 
 
 <!-- Notes BEGIN: You can edit here. Add "## Notes" headline if not already present. -->
-::: warning Known Issues with This Device
-
-The IKEA PARASOLL door/window sensor is known to suffer from serious usability issues in some Zigbee networks, resulting in some sensors regularly going unavailable / draining their battery.
-
-Whether this issue will affect you appears to depend on the other devices / routers in your Zigbee network, though the exact devices causing this issue have not been confirmed. Further discussion and investigation is available in the GitHub issue: [zigbee2mqtt#22579](https://github.com/Koenkk/zigbee2mqtt/issues/22579)
-
-In the meantime, **it is generally not recommended to buy PARASOLL sensors specifically for use with a Zigbee2MQTT network**.
-
-:::
-
+> [!WARNING]
+> Known issues with this device
+>
+> The IKEA PARASOLL door/window sensor is known to suffer from serious usability issues in some Zigbee networks, resulting in some sensors regularly going unavailable / draining their battery.
+>
+> Whether this issue will affect you appears to depend on the other devices / routers in your Zigbee network, though the exact devices causing this issue have not been confirmed. Further discussion and investigation is available in the GitHub issue: [zigbee2mqtt#22579](https://github.com/Koenkk/zigbee2mqtt/issues/22579)
+>
+> In the meantime, **it is generally not recommended to buy PARASOLL sensors specifically for use with a Zigbee2MQTT network**.
 
 ## Pairing
 To pair the device, press the pairing button 4 times in 5 seconds to factory reset, it should now enter pairing mode.

--- a/docs/guide/adapters/README.md
+++ b/docs/guide/adapters/README.md
@@ -24,9 +24,8 @@ All officially supported adapters are listed on this page. Note that before an a
 
 - [ZBOSS based (Nordic Semiconductor)](./zboss.md)
 
-::: tip TIP
-Want to migrate to a different adapter? Read [this](../faq/README.md#how-do-i-migrate-from-one-adapter-to-another)
-:::
+> [!TIP]
+> Want to migrate to a different adapter? Read [this](../faq/README.md#how-do-i-migrate-from-one-adapter-to-another)
 
 ## Notes
 

--- a/docs/guide/adapters/deconz.md
+++ b/docs/guide/adapters/deconz.md
@@ -1,14 +1,12 @@
 # deCONZ (Dresden Elektronik)
 
-::: warning ATTENTION
-Various features are not supported by this adapter, in case you depend on these features, consider a different adapter.
-
-- Inter-PAN, which is required for [touchlink](../../guide/usage/touchlink.md)
-- Lowering the [transmit power](../../guide/configuration/adapter-settings.md)
-- ConBee II (and possibly RaspBee II) [may exhibit network connectivity issues (MacNoAck)](https://github.com/Koenkk/zigbee2mqtt/issues/28041)
-- [Install codes](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestinstall_codeadd) support requires recent coordinator firmware. This is required to pair some devices.
-
-:::
+> [!WARNING]
+> Various features are not supported by this adapter, in case you depend on these features, consider a different adapter.
+>
+> - Inter-PAN, which is required for [touchlink](../../guide/usage/touchlink.md)
+> - Lowering the [transmit power](../../guide/configuration/adapter-settings.md)
+> - ConBee II (and possibly RaspBee II) [may exhibit network connectivity issues (MacNoAck)](https://github.com/Koenkk/zigbee2mqtt/issues/28041)
+> - [Install codes](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestinstall_codeadd) support requires recent coordinator firmware. This is required to pair some devices.
 
 ### Configuration
 

--- a/docs/guide/adapters/emberznet.md
+++ b/docs/guide/adapters/emberznet.md
@@ -15,9 +15,8 @@ serial:
 
 Other supported settings are: `adapter_concurrent` and `transmit_power` ([docs](../configuration/adapter-settings.md)).
 
-::: tip TIP
-The use of `adapter: ezsp` is now deprecated. See [https://github.com/Koenkk/zigbee2mqtt/discussions/21462](https://github.com/Koenkk/zigbee2mqtt/discussions/21462)
-:::
+> [!TIP]
+> The use of `adapter: ezsp` is now deprecated. See [https://github.com/Koenkk/zigbee2mqtt/discussions/21462](https://github.com/Koenkk/zigbee2mqtt/discussions/21462)
 
 ### Firmware flashing
 
@@ -482,13 +481,12 @@ Analyze log files in your browser and get an automated review of your network.
 
 ## [EXPERT] Customizing stack configuration
 
-::: warning ATTENTION
-This feature modifies the behavior of your adapter, and the network. Using improper values for your network can completely break it. Only modify any of these values if you are absolutely sure your network will benefit from it. Most networks will be just fine with the defaults.
-:::
+> [!WARNING]
+> This feature modifies the behavior of your adapter, and the network. Using improper values for your network can completely break it. Only modify any of these values if you are absolutely sure your network will benefit from it.
+> Most networks will be just fine with the defaults.
 
-::: warning ATTENTION
-Do not open a new issue in Zigbee2MQTT before confirming the problem is present with the default configuration.
-:::
+> [!IMPORTANT]
+> Do not open a new issue in Zigbee2MQTT before confirming the problem is present with the default configuration.
 
 You can modify the EmberZNet default stack configuration by creating a file `stack_config.json` in the same folder as your `coordinator_backup.json`. This configuration can only be done manually.
 

--- a/docs/guide/adapters/flashing/copy_ieee_addr.md
+++ b/docs/guide/adapters/flashing/copy_ieee_addr.md
@@ -1,4 +1,5 @@
 ---
+redirectFrom: /guide/adapters/flashing/copy_ieeaddr.md
 ---
 
 # Copying the ieee address of an adapter
@@ -25,11 +26,10 @@ Supports: CC2652, CC1352, CC2538, EFR32-based coordinators
 3. Scroll to the IEEE section and click `Read` to retrieve the current IEEE address of your coordinator (secondary for TI, primary for EFR32-based adapters)
 4. Enter the new IEEE address in the corresponding field and click `Write`
 
-::: warning
-If you're using an EFR32-based adapter and receive an error when attempting to write a new IEEE address, this indicates that your device's firmware doesn't support NV3 tokens. You can still write a new IEEE address to the MFG_CUSTOM_EUI_64 field, but this is a **ONE-TIME** write operation and cannot be changed afterward! If you're certain you want to proceed, check the `Force` checkbox and click `Write` again.
-
-**`Force` option performs a ONE-TIME write that cannot be reversed!**
-:::
+> [!WARNING]
+> If you're using an EFR32-based adapter and receive an error when attempting to write a new IEEE address, this indicates that your device's firmware doesn't support NV3 tokens. You can still write a new IEEE address to the MFG_CUSTOM_EUI_64 field, but this is a **ONE-TIME** write operation and cannot be changed afterward! If you're certain you want to proceed, check the `Force` checkbox and click `Write` again.
+>
+> **`Force` option performs a ONE-TIME write that cannot be reversed!**
 
 ## ZigStar Multi Tool
 

--- a/docs/guide/adapters/zboss.md
+++ b/docs/guide/adapters/zboss.md
@@ -1,10 +1,15 @@
 # ZBOSS adapters
 
-::: warning ATTENTION
+> [!WARNING]
+> Support for this adapter is **experimental**, not yet recommended for production setups
 
-Support for this adapter is **experimental**, not recommended yet for production setups
-
-:::
+> [!WARNING]
+> Currently, this adapter does not support various functions, so if you depend on these functions, consider using a different adapter.
+>
+> - [Changing the channel](../configuration/zigbee-network.md#changing-the-zigbee-channel), changing requires re-pairing all devices.
+> - Adding [install codes](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestinstall_codeadd), which is required to pair some devices.
+> - [Backups](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestbackup)
+> - Inter-PAN, which is required for [touchlink](../../guide/usage/touchlink.md)
 
 The adapter for the ZBOSS protocol is based on the example of ZBOSS NCP Host [Zigbee NCP (Network Co-Processor)](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/zigbee/ncp/README.html) for Nordic Semiconductor chips, such as nRF5340, nRF52840, nRF52833, nRF21540.
 
@@ -13,16 +18,6 @@ Also, thanks to the special firmware https://github.com/tostmann/esp-coordinator
 The interaction between the chip and the host occurs according to [ZBOSS NCP Serial Protocol](https://cloud.dsr-corporation.com/index.php/s/BAn4LtRWbJjFiAm).
 
 The adapter code is based on the [zigpy-zboss library](https://github.com/kardia-as/zigpy-zboss).
-
-::: warning ATTENTION
-Currently, this adapter does not support various functions, so if you depend on these functions, consider using a different adapter.
-
-- [Changing the channel](../configuration/zigbee-network.md#changing-the-zigbee-channel), changing requires re-pairing all devices.
-- Adding [install codes](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestinstall_codeadd), which is required to pair some devices.
-- [Backups](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestbackup)
-- Inter-PAN, which is required for [touchlink](../../guide/usage/touchlink.md)
-
-:::
 
 ### Configuration
 

--- a/docs/guide/adapters/zigate.md
+++ b/docs/guide/adapters/zigate.md
@@ -1,31 +1,18 @@
 # ZiGate adapters
 
-::: warning ATTENTION
-The implementation of this adapter is **not maintained** anymore.
-Consider buying one of the recommended adapters instead.
-:::
+> [!WARNING]
+> The implementation of this adapter is **not maintained** anymore.
+> Consider buying one of the recommended adapters instead.
 
-::: warning ATTENTION
-
-Support for this adapter is **experimental**, not recommended yet for production setups
-
-:::
+> [!WARNING]
+> Various features are not supported by this adapter, in case you depend on these features, consider a different adapter.
+>
+> - [Changing the channel](../configuration/zigbee-network.md#changing-the-zigbee-channel), changing requires re-pairing all devices.
+> - Adding [install codes](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestinstall_codeadd), which is required to pair some devices.
+> - [Backups](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestbackup)
+> - Inter-PAN, which is required for [touchlink](../../guide/usage/touchlink.md)
 
 Initial development started on experimental (alpha stage) support for various ZigGate adapters. This includes all ZiGate compatible hardware adapters which are currently based on NXP Zigbee MCU chips like JN5168 and JN5169 with ZigGate 3.1d firmware or later.
-
-::: warning ATTENTION
-Various features are not supported by this adapter, in case you depend on these features, consider a different adapter.
-
-- [Changing the channel](../configuration/zigbee-network.md#changing-the-zigbee-channel), changing requires re-pairing all devices.
-- Adding [install codes](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestinstall_codeadd), which is required to pair some devices.
-- [Backups](../../guide/usage/mqtt_topics_and_messages.md#zigbee2mqttbridgerequestbackup)
-- Inter-PAN, which is required for [touchlink](../../guide/usage/touchlink.md)
-
-:::
-
-::: warning ATTENTION
-zigbee-herdsman is looking for maintainers for the ZiGate adapter. See [https://github.com/Koenkk/zigbee-herdsman/issues/1037](https://github.com/Koenkk/zigbee-herdsman/issues/1037)
-:::
 
 ### Configuration
 

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -5,17 +5,15 @@ redirectFrom: /information/configuration.md
 
 # Configuration
 
-::: warning ATTENTION
-Never rely solely on configurations produced by LLMs like ChatGPT! Always verify the generated configurations against the relevant documentation. Not doing so can potentially break your setup.
-:::
+> [!CAUTION]
+> Never rely solely on configurations produced by LLMs like ChatGPT! Always verify the generated configurations against the relevant documentation. Not doing so can potentially break your setup.
 
 Zigbee2MQTT is configured using [YAML](https://en.wikipedia.org/wiki/YAML) based `configuration.yaml` file.
 The file have to be located in the `data` directory within your installation. The `data` directory and the `configuration.yaml` has to be writeable for Zigbee2MQTT process because it can get updated - e.g. if you change the settings in the frontend. It's possible specify a custom data directory by setting the `ZIGBEE2MQTT_DATA` environment variable.
 
-::: tip CONVENTION
-The _dot-notation_ of a config-key like `mqtt.server` means `server` property within the `mqtt`
-section. All _dot-notation_ references are absolute.
-:::
+> [!IMPORTANT]
+> The _dot-notation_ of a config-key like `mqtt.server` means `server` property within the `mqtt`
+> section. All _dot-notation_ references are absolute.
 
 ## Generate minimal configuration
 
@@ -41,6 +39,5 @@ set `ZIGBEE2MQTT_CONFIG_MQTT_BASE_TOPIC` to the desired value.
 Configuration options can be changed at runtime by publishing the appropriate MQTT payload with the topic `zigbee2mqtt/bridge/request/options`.
 See [MQTT Topics and Messages](../usage/mqtt_topics_and_messages.md#zigbee2mqtt-bridge-request) for details.
 
-::: tip NOTE
-Some options will require a restart before being effective.
-:::
+> [!NOTE]
+> Some options will require a restart before being effective.

--- a/docs/guide/configuration/adapter-settings.md
+++ b/docs/guide/configuration/adapter-settings.md
@@ -4,9 +4,8 @@ sidebarDepth: 1
 
 # Adapter settings
 
-::: warning ATTENTION
-Not all features are supported for every adapter, to see what's supported, go to your [adapter page](../../guide/adapters/README.md).
-:::
+> [!WARNING]
+> Not all features are supported for every adapter, to see what's supported, go to your [adapter page](../../guide/adapters/README.md).
 
 ## Basic configuration
 
@@ -50,9 +49,8 @@ Zigbee2MQTT supports automatic discovery of Zigbee network Adapters. In order to
 
 If you have a more than 1 device with the same mDNS service type (name), Zigbee2MQTT with autodiscover option will connect to the random one. So for proper use we recommend to have only one physically connected network adapter with the same mDNS service type (name). Otherwise, please set-up a settings over IP address and port, as described on the passage above.
 
-::: warning ATTENTION
-When using this autodetection, the following parameters in `configuration.yaml` will be ignored: `adapter`, `baudrate`
-:::
+> [!IMPORTANT]
+> When using this autodetection, the following parameters in `configuration.yaml` will be ignored: `adapter`, `baudrate`.
 
 List of tested devices supporting mDNS Zeroconf autodiscovery:
 
@@ -95,6 +93,5 @@ advanced:
 
 <!-- TODO: some notes about rtscts? Is it useful, which adapter supports it? -->
 
-::: tip
-It's also possible to connect USB Adapters over TCP. See how to connect a [remote adapter](../../advanced/remote-adapter/connect_to_a_remote_adapter.md).
-:::
+> [!TIP]
+> It's also possible to connect USB Adapters over TCP. See how to connect a [remote adapter](../../advanced/remote-adapter/connect_to_a_remote_adapter.md).

--- a/docs/guide/configuration/all-settings.md
+++ b/docs/guide/configuration/all-settings.md
@@ -12,9 +12,8 @@ pageClass: settings-page
 
 This page contains all currently supported settings in `configuration.yaml`.
 
-::: tip NOTE
-The code blocks show an **example value** for each setting (may be the default or any value derived from the possibilities/examples/boundaries).
-:::
+> [!NOTE]
+> The code blocks show an **example value** for each setting (may be the default or any value derived from the possibilities/examples/boundaries).
 
 ## advanced
 

--- a/docs/guide/configuration/configuration-update.md
+++ b/docs/guide/configuration/configuration-update.md
@@ -8,17 +8,14 @@ Starting with v2.0.0 Zigbee2MQTT includes an automatic settings migration system
 
 The migration system will automatically make a backup of your current `data/configuration.yaml` before starting a migration. The backup file will be named according to its version, for example `data/configuration_backup_v1.yaml`.
 
-:::warning IMPORTANT
-Configuration values set through Home Assistant add-on configuration page, or through [environment variables](./README.md#environment-variables) are not persisted to the `configuration.yaml`. As such, they cannot be processed by the migration system and will require your intervention if a migration is required for any of them.
-:::
+> [!IMPORTANT]
+> Configuration values set through Home Assistant add-on configuration page, or through [environment variables](./README.md#environment-variables) are not persisted to the `configuration.yaml`. As such, they cannot be processed by the migration system and will require your intervention if a migration is required for any of them.
 
-:::warning IMPORTANT
-While this automatically migrates Zigbee2MQTT settings, it **cannot** migrate side-effects on third parties (like Home Assistant). Make sure you go over the [migration notes](#migration-notes) and the link given to adjust things accordingly on that front.
-:::
+> [!IMPORTANT]
+> While this automatically migrates Zigbee2MQTT settings, it **cannot** migrate side-effects on third parties (like Home Assistant). Make sure you go over the [migration notes](#migration-notes) and the link given to adjust things accordingly on that front.
 
-:::caution CAUTION
-Do not edit the `version` setting manually. If you do, you run the risk of corrupting your `configuration.yaml`, the migration system may no longer work properly.
-:::
+> [!CAUTION]
+> Do not edit the `version` setting manually. If you do, you run the risk of corrupting your `configuration.yaml`, the migration system may no longer work properly.
 
 ## Migration notes
 

--- a/docs/guide/configuration/devices-groups.md
+++ b/docs/guide/configuration/devices-groups.md
@@ -46,14 +46,12 @@ Every Zigbee Device supports the following list of options.
 **`friendly_name`**  
 Used in the MQTT topic of a device. By default, this is the device ID (e.g. `0x00128d0001d9e1d2`).
 
-::: tip
-You can use the `/` separator in `friendly_name` to structure devices.
-For example, using a `friendly_name` like `kitchen/floor_light` would result in a corresponding MQTT structure with `kitchen` as folder containing `floor_light` in MQTT Explorer.
-:::
+> [!TIP]
+> You can use the `/` separator in `friendly_name` to structure devices.
+> For example, using a `friendly_name` like `kitchen/floor_light` would result in a corresponding MQTT structure with `kitchen` as folder containing `floor_light` in MQTT Explorer.
 
-::: warning
-Note that a `friendly_name` is **NOT** allowed to end with `/`, `/` + one of the possible [endpoint names](https://github.com/Koenkk/zigbee2mqtt/blob/master/lib/util/utils.ts#L30) (e.g. `/left`) or `/` + a number (e.g. `/4`).
-:::
+> [!IMPORTANT]
+> A `friendly_name` is **NOT** allowed to end with `/`, `/` + one of the possible [endpoint names](https://github.com/Koenkk/zigbee2mqtt/blob/master/lib/util/utils.ts#L30) (e.g. `/left`) or `/` + a number (e.g. `/4`).
 
 **`description`**  
 Description of this device, e.g. `This device is in the kitchen`, will be shown in the frontend.
@@ -175,9 +173,8 @@ groups:
             icon: mdi:lightbulb-group
 ```
 
-::: warning
-The group key has to be unique and a quoted integer.
-:::
+> [!IMPORTANT]
+> The group key has to be unique and a quoted integer.
 
 **`homeassistant`**  
 Allows overriding the values of the Home Assistant discovery payload for this group. Any Home Assistant MQTT discovery property can be overridden.

--- a/docs/guide/configuration/frontend.md
+++ b/docs/guide/configuration/frontend.md
@@ -52,9 +52,8 @@ To specify the `auth_token` in a different file set e.g. `auth_token: '!secret.y
 
 You can change the package used for frontend (requires a restart of Zigbee2MQTT). This will change the web-based UI of Zigbee2MQTT accordingly.
 
-::: warning IMPORTANT
-The features, links and general design in each package will vary.
-:::
+> [!IMPORTANT]
+> The features, links and general design in each package will vary.
 
 ##### zigbee2mqtt-windfront
 

--- a/docs/guide/configuration/zigbee-network.md
+++ b/docs/guide/configuration/zigbee-network.md
@@ -22,13 +22,11 @@ advanced:
     network_key: [1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 13]
 ```
 
-::: tip
-Set `network_key: GENERATE` to let Zigbee2MQTT generate a new random key on the first start. The `configuration.yml` gets updated with the new key. Changing the network_key requires re-pairing of all devices.
-:::
+> [!TIP]
+> Set `network_key: GENERATE` to let Zigbee2MQTT generate a new random key on the first start. The `configuration.yml` gets updated with the new key. Changing the network_key requires re-pairing of all devices.
 
-::: tip
-[Reduce Wi-Fi interference by changing the Zigbee channel](../../advanced/zigbee/02_improve_network_range_and_stability.md#reduce-wi-fi-interference-by-changing-the-zigbee-channel)
-:::
+> [!TIP]
+> [Reduce Wi-Fi interference by changing the Zigbee channel](../../advanced/zigbee/02_improve_network_range_and_stability.md#reduce-wi-fi-interference-by-changing-the-zigbee-channel)
 
 ### Configurator
 
@@ -38,13 +36,11 @@ Set `network_key: GENERATE` to let Zigbee2MQTT generate a new random key on the 
 
 Changing the channel of an existing Zigbee network is supported. In Zigbee, this is done by broadcasting a network update indicating the channel change. Devices that are asleep during the broadcast (usually battery powered end devices) will not switch immediately, but the next time they wake-up. It is therefore advised to trigger them after the channel change.
 
-::: warning
-Some Zigbee devices do not support changing channels. In case a device remains unresponsive several minutes after the change, and after having been triggered/woken up, you may have to re-pair it manually.
-:::
+> [!WARNING]
+> Some Zigbee devices do not support changing channels. In case a device remains unresponsive several minutes after the change, and after having been triggered/woken up, you may have to re-pair it manually.
 
-::: warning
-Changing channels is only supported for the `zstack` and `ember` adapter.
-:::
+> [!WARNING]
+> Changing channels is only supported for the `zstack` and `ember` adapter.
 
 Zigbee2MQTT will send this broadcast during startup if the channel in the configuration has been changed. The following logging will be produced:
 

--- a/docs/guide/faq/README.md
+++ b/docs/guide/faq/README.md
@@ -57,17 +57,17 @@ This problem can be divided in 2 categories; no logging is shown at all OR inter
 
 Want to migrate from e.g. a CC2530/CC2531 to a more powerful adapter (e.g. CC2652/CC1352)? Then follow these instructions below:
 
-::: warning
-Migration from one adapter to another requires backup and restore support which is so far only implemented for the `zstack` (Texas Instrument) and `ember` adapters. Backup and restore is **not supported** for any other adapters (`conbee`, `ezsp`, `zboss` and `zigate`). However you might have success using [this method](https://github.com/Koenkk/zigbee2mqtt/discussions/26716).
+> [!WARNING]
+> Migration from one adapter to another requires backup and restore support which is so far only implemented for the `zstack` (Texas Instrument) and `ember` adapters. Backup and restore is **not supported** for any other adapters (`conbee`, `ezsp`, `zboss` and `zigate`). However you might have success using [this method](https://github.com/Koenkk/zigbee2mqtt/discussions/26716).
 
-Note that when switching from `zstack` -> `ember` or `ember` -> `zstack` re-pairing **might not** be required, however results might vary as this is not officially supported. After switching, check if all devices are working and re-pair the ones that are not. In case pairing new devices is not working, re-pair some routers close to the coordinator while only permitting joining via the coordinator. Pairing should then work via routers that have been re-paired.
-:::
+> [!NOTE]
+> When switching from `zstack` -> `ember` or `ember` -> `zstack` re-pairing **might not** be required, however results might vary as this is not officially supported. After switching, check if all devices are working and re-pair the ones that are not. In case pairing new devices is not working, re-pair some routers close to the coordinator while only permitting joining via the coordinator. Pairing should then work via routers that have been re-paired.
 
 1. First make sure you are running the latest version of Zigbee2MQTT
 1. Stop Zigbee2MQTT
 1. Determine whether migrating [requires re-pairing of your devices](#what-does-and-does-not-require-re-pairing-of-all-devices)
     - If re-pairing is required: remove `data/coordinator_backup.json` (if it exists) and `data/database.db` (if running as a Home Assistant addon, `data/` is renamed `zigbee2mqtt/`)
-    - If re-pairing is **not** required: [copy the ieee address of the old adapter into the new one](../adapters/flashing/copy_ieeaddr.html)
+    - If re-pairing is **not** required: [copy the ieee address of the old adapter into the new one](../adapters/flashing/copy_ieee_addr.md)
 1. Update the `serial` -> `port` in your `configuration.yaml`
     - Note in some cases you may also need to update the `baud` if coming from an older adapter (i.e. zbt-1 -> zbt2)
 1. Start Zigbee2MQTT

--- a/docs/guide/getting-started/README.md
+++ b/docs/guide/getting-started/README.md
@@ -18,10 +18,9 @@ In order to use Zigbee2MQTT we need the following hardware:
 
 3. <img src="../../images/xiaomi_sensors.jpg" title="Zigbee devices" class="float-left" /> One or more **Zigbee devices** which will be paired with Zigbee2MQTT. <br class="clear" />
 
-::: tip TIP
-<img alt="USB Cable" src="../../images/usb_extension_cable.jpg" class="float-left" /> To improve network range and stability use a USB extension cable. If you experience ANY trouble with device (timeouts, not pairing, devices unreachable, devices dropping from the network, etc.) this is the first thing to do to avoid interference.
-See [Improve network range and stability](../../advanced/zigbee/02_improve_network_range_and_stability.md). <br class="clear" />
-:::
+> [!TIP]
+> <img alt="USB Cable" src="../../images/usb_extension_cable.jpg" class="float-left" /> To improve network range and stability use a USB extension cable. If you experience ANY trouble with device (timeouts, not pairing, devices unreachable, devices dropping from the network, etc.) this is the first thing to do to avoid interference.
+> See [Improve network range and stability](../../advanced/zigbee/02_improve_network_range_and_stability.md). <br class="clear" />
 
 ## Installation
 
@@ -37,25 +36,21 @@ The onboarding page, by default, is reachable at the same URL as the frontend (`
 
 If the `adapter type` is unknown by the discovery process, you can find a list of the most common adapters in the corresponding pages: [zstack](../adapters/zstack.md), [ember](../adapters/emberznet.md), [deconz](../adapters/deconz.md), [zigate](../adapters/zigate.md), [zboss](../adapters/zboss.md).
 
-:::tip TIP
-The adapter discovery process will try to find serial and mDNS-discoverable devices.
-Refreshing the page will re-execute the discovery process.
-
-_Note: This may not be available on all setups. If not, you will have to enter the adapter path and type manually._
-:::
+> [!NOTE]
+> The adapter discovery process will try to find serial and mDNS-discoverable devices. Refreshing the page will re-execute the discovery process.
+>
+> _This may not be available on all setups. If not, you will have to enter the adapter path and type manually._
 
 If Zigbee2MQTT fails validation after submitting the configuration, the page will show the error details.
 
 If Zigbee2MQTT fails to start after submitting the initial configuration (due to something like a wrong adapter path), the onboarding will be executed again on the following start.
 
-:::tip TIP
-Onboarding failure pages will hold the `node` process from exiting until the page's `Close` button is triggered or the process is manually exited.
-:::
+> [!IMPORTANT]
+> Onboarding failure pages will hold the `node` process from exiting until the page's `Close` button is triggered or the process is manually exited.
 
-:::tip TIP
-You can also force the onboarding to run later (if configuration needs changing) with the environment variable `Z2M_ONBOARD_FORCE_RUN=1`.
-Depending on your setup, this may be offered in form of a toggle (Home Assistant add-on for example), or you may have to set it manually for the `node` process.
-:::
+> [!TIP]
+> You can also force the onboarding to run later (if configuration needs changing) with the environment variable `Z2M_ONBOARD_FORCE_RUN=1`.
+> Depending on your setup, this may be offered in form of a toggle (Home Assistant add-on for example), or you may have to set it manually for the `node` process.
 
 :::details Environment variables available to customize the onboarding process
 The following environment variables are available, if your setup requires customizing the onboarding server:

--- a/docs/guide/installation/01_linux.md
+++ b/docs/guide/installation/01_linux.md
@@ -4,10 +4,9 @@ next: 14_securing.md
 
 # Linux
 
-::: warning
-We recommend using [Docker](./02_docker.md) for installation instead.
-This eliminates common setup challenges such as setting up NodeJS and installing dependencies.
-:::
+> [!WARNING]
+> We recommend using [Docker](./02_docker.md) for installation instead.
+> This eliminates common setup challenges such as setting up NodeJS and installing dependencies.
 
 These instructions explain how to run Zigbee2MQTT on Linux.
 
@@ -15,17 +14,17 @@ For the sake of simplicity this guide assumes running on a Raspberry Pi 4, but i
 
 Therefore the user `pi` is used the following examples, but the user may differ between distributions e.g. `openhabian` should be used on Openhabian.
 
-::: tip TIP
-Before starting make sure you have an MQTT broker installed on your system.
-There are many tutorials available on how to do this, [example](https://randomnerdtutorials.com/how-to-install-mosquitto-broker-on-raspberry-pi/).
-Mosquitto is the recommended MQTT broker but others should also work fine.
-:::
+> [!TIP]
+> Before starting make sure you have an MQTT broker installed on your system.
+> There are many tutorials available on how to do this, [example](https://randomnerdtutorials.com/how-to-install-mosquitto-broker-on-raspberry-pi/).
+> Mosquitto is the recommended MQTT broker but others should also work fine.
 
 ## Installing
 
 ```bash
 # Set up Node.js repository, install Node.js and required dependencies.
-# NOTE 1: Older i386 hardware can work with [unofficial-builds.nodejs.org](https://unofficial-builds.nodejs.org/download/release/v20.9.0/ e.g. Version 20.9.0 should work.
+# NOTE 1: Older i386 hardware can work with https://unofficial-builds.nodejs.org/download/release/v20.9.0/
+#         e.g. Version 20.9.0 should work.
 # NOTE 2: For Ubuntu see installing through Snap below.
 sudo apt-get install -y curl
 sudo curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
@@ -47,24 +46,25 @@ cd /opt/zigbee2mqtt
 pnpm install --frozen-lockfile
 ```
 
-::: tip TIP
-On Ubuntu, Node.js can be installed through Snap
-
-```bash
-# Install latest nodejs from snap store
-# The --classic argument is required here as Node.js needs full access to your system in order to be useful.
-# You can also use the --channel=XX argument to install a legacy version where XX is the version you want to install (we need 14+).
-sudo snap install node --classic
-corepack enable
-
-# Verify node has been installed
-# If you encounter an error at this stage and used the snap store instructions, adjust the BIN path as follows:
-## PATH=$PATH:/snap/node/current/bin
-# then re-verify Node.js as above
-node --version
-```
-
-:::
+> [!TIP]
+> On Ubuntu, Node.js can be installed through Snap
+>
+> ```bash
+> # Install latest nodejs from snap store
+> # The --classic argument is required here as Node.js needs full access
+> # to your system in order to be useful.
+> # You can also use the --channel=XX argument to install a legacy version
+> # where XX is the version you want to install (we need 14+).
+> sudo snap install node --classic
+> corepack enable
+>
+> # Verify node has been installed
+> # If you encounter an error at this stage and used the snap store instructions,
+> # adjust the BIN path as follows:
+> ## PATH=$PATH:/snap/node/current/bin
+> # then re-verify Node.js as above
+> node --version
+> ```
 
 ## Starting Zigbee2MQTT
 
@@ -127,32 +127,20 @@ User=pi
 WantedBy=multi-user.target
 ```
 
-::: tip NOTE
-
+> [!TIP]
 > If you are using a Raspberry Pi 1 or Zero AND if you followed this [guide](https://gist.github.com/Koenkk/11fe6d4845f5275a2a8791d04ea223cb), replace `ExecStart=/usr/bin/node index.js` with `ExecStart=/usr/local/bin/node index.js`.
 
-:::
+> [!TIP]
+> If you are using a Raspberry Pi or a system running from a SD card, you will likely want to minimize the amount of log files written to disk. Systemd service with `StandardOutput=inherit` will result in logging everything twice: once in `journalctl` through the systemd unit and once from Zigbee2MQTT default logging to files under `data/log`. You will likely want to keep only one of them:
+>
+> - Keep only the logs under `data/log` --> use `StandardOutput=null` in the systemd unit. **or**
+> - Keep only the `journalctl` logging --> set [`advanced.log_output = ['console']`](https://www.zigbee2mqtt.io/guide/configuration/logging.html) in Zigbee2MQTT configuration.
 
-::: tip
+> [!TIP]
+> If you want to use another directory to place all Zigbee2MQTT data, add `Environment=ZIGBEE2MQTT_DATA=/path/to/data` below `[Service]`
 
-If you are using a Raspberry Pi or a system running from a SD card, you will likely want to minimize the amount of log files written to disk. Systemd service with `StandardOutput=inherit` will result in logging everything twice: once in `journalctl` through the systemd unit and once from Zigbee2MQTT default logging to files under `data/log`. You will likely want to keep only one of them:
-
-- Keep only the logs under `data/log` --> use `StandardOutput=null` in the systemd unit. **or**
-- Keep only the `journalctl` logging --> set [`advanced.log_output = ['console']`](https://www.zigbee2mqtt.io/guide/configuration/logging.html) in Zigbee2MQTT configuration.
-
-:::
-
-::: tip
-
-If you want to use another directory to place all Zigbee2MQTT data, add `Environment=ZIGBEE2MQTT_DATA=/path/to/data` below `[Service]`
-
-:::
-
-::: tip
-
-Using `Type=notify` makes systemd aware of when Zigbee2MQTT has started up and is e.g. listening on its [Frontend](../configuration/frontend.md) sockets. This is useful for starting other, dependent systemd units or for using the `ExecStartPost=` attribute. For example, to allow a [Reverse Proxy](../configuration/frontend.md#nginx-proxy-configuration) to access Zigbee2MQTT's Unix socket, you could add `ExecStartPost=setfacl -m u:www-data:rw /run/zigbee2mqtt/zigbee2mqtt.sock` to the `[Service]` section and `apt install acl`. Save the file and exit.
-
-:::
+> [!TIP]
+> Using `Type=notify` makes systemd aware of when Zigbee2MQTT has started up and is e.g. listening on its [Frontend](../configuration/frontend.md) sockets. This is useful for starting other, dependent systemd units or for using the `ExecStartPost=` attribute. For example, to allow a [Reverse Proxy](../configuration/frontend.md#nginx-proxy-configuration) to access Zigbee2MQTT's Unix socket, you could add `ExecStartPost=setfacl -m u:www-data:rw /run/zigbee2mqtt/zigbee2mqtt.sock` to the `[Service]` section and `apt install acl`. Save the file and exit.
 
 Verify that the configuration works:
 

--- a/docs/guide/installation/02_docker.md
+++ b/docs/guide/installation/02_docker.md
@@ -15,10 +15,9 @@ The following tags are available:
 - Latest dev version (based on [`dev`](https://github.com/Koenkk/zigbee2mqtt/tree/dev) branch): `latest-dev`
 - Specific release version, e.g: `2.0.0`, `2.0`, `2`
 
-::: warning
-For Raspberry Pi 1 and zero users: there is a bug in Docker which selects the wrong image architecture.
-Before running the container pull the correct image with `docker pull ghcr.io/koenkk/zigbee2mqtt --platform linux/arm/v6`.
-:::
+> [!WARNING]
+> For Raspberry Pi 1 and zero users: there is a bug in Docker which selects the wrong image architecture.
+> Before running the container pull the correct image with `docker pull ghcr.io/koenkk/zigbee2mqtt --platform linux/arm/v6`.
 
 ## Running the container
 
@@ -48,10 +47,9 @@ $ docker run \
 - `-e TZ=Europe/Amsterdam`: configure the timezone
 - `-p 8080:8080`: port forwarding from inside Docker container to host (for the frontend)
 
-::: tip
-If you run the MQTT-Server on the same host (localhost) you could use the IP
-of the `docker0` bridge to establish the connection: `server: mqtt://172.17.0.1`.
-:::
+> [!TIP]
+> If you run the MQTT-Server on the same host (localhost) you could use the IP
+> of the `docker0` bridge to establish the connection: `server: mqtt://172.17.0.1`.
 
 On first start, Zigbee2MQTT will start the onboarding on port 8080.
 Navigate to this board and configure accordingly.
@@ -115,9 +113,10 @@ $ podman run \
    ghcr.io/koenkk/zigbee2mqtt
 ```
 
-::: tip
-With SELinux enabled you may need to append a `:z` suffix to the volume mount: `-v $(pwd)/data:/app/data:z`
 :::
+
+> [!TIP]
+> With SELinux enabled you may need to append a `:z` suffix to the volume mount: `-v $(pwd)/data:/app/data:z`
 
 ### Updating
 

--- a/docs/guide/installation/03_ha_addon.md
+++ b/docs/guide/installation/03_ha_addon.md
@@ -4,12 +4,10 @@ next: 14_securing.md
 
 # Home Assistant addon
 
-::: warning ATTENTION
-Only 64-bit architectures (aarch64 and amd64) are supported by Home Assistant. That means hardware like the Sonoff iHost (32-bit) or old Raspberry Pi (armv7) cannot be used.
-:::
+> [!IMPORTANT]
+> Only 64-bit architectures (aarch64 and amd64) are supported by Home Assistant. That means hardware like the Sonoff iHost (32-bit) or old Raspberry Pi (armv7) cannot be used.
 
-::: warning ATTENTION
-If you're using a Raspberry Pi, ensure you have at least a Raspberry Pi 4, as running it on a Raspberry Pi 3 may cause instability due to its limited resources.
-:::
+> [!WARNING]
+> If you're using a Raspberry Pi, ensure you have at least a Raspberry Pi 4, as running it on a Raspberry Pi 3 may cause instability due to its limited resources.
 
 If you are running Home Assistant OS or a Supervised Home Assistant instance the easiest way to install Zigbee2MQTT is via the addon. Instructions on how to install it can be found [here](https://github.com/zigbee2mqtt/hassio-zigbee2mqtt#installation).

--- a/docs/guide/installation/05_windows.md
+++ b/docs/guide/installation/05_windows.md
@@ -9,11 +9,10 @@ redirectFrom:
 
 These instructions explain how to run Zigbee2MQTT on Windows.
 
-::: tip TIP
-Before starting make sure you have an MQTT broker installed on your system.
-There are many tutorials available on how to do this, [example](https://cedalo.com/blog/how-to-install-mosquitto-mqtt-broker-on-windows/).
-Mosquitto is the recommended MQTT broker but others should also work fine.
-:::
+> [!TIP]
+> Before starting make sure you have an MQTT broker installed on your system.
+> There are many tutorials available on how to do this, [example](https://cedalo.com/blog/how-to-install-mosquitto-mqtt-broker-on-windows/).
+> Mosquitto is the recommended MQTT broker but others should also work fine.
 
 ## Install a USB-to-UART Bridge Virtual COM Port driver
 
@@ -70,22 +69,19 @@ Zigbee2MQTT:info 2019-10-18 10:56:24 PM Coordinator firmware version: '20190608'
 
 Zigbee2MQTT can be stopped anytime by pressing `CTRL + C` and then confirming with `Y`.
 
-::: warning ATTENTION
-
-In case Zigbee2MQTT fails to start with `USB adapter discovery error (No valid USB adapter found). Specify valid 'adapter' and 'port' in your configuration.`, we need to configure the `serial` section in the `configuration.yaml`.
-
-First determine which COM port is assigned to your device:
-
-1. Open up Start menu and start typing `Device Manager`
-1. Expand `Ports (COM & LPT)`
-1. Look for a node similar to `USB Serial Device (COM4)`
-
-![Device Manager](../../images/devicemanager.png)
-
-For the example above, we would use `port: COM4` in the `configuration.yaml`.
-Next configure the `serial` section as described [here](../configuration/adapter-settings.md).
-
-:::
+> [!IMPORTANT]
+> In case Zigbee2MQTT fails to start with `USB adapter discovery error (No valid USB adapter found). Specify valid 'adapter' and 'port' in your configuration.`, we need to configure the `serial` section in the `configuration.yaml`.
+>
+> First determine which COM port is assigned to your device:
+>
+> 1. Open up Start menu and start typing `Device Manager`
+> 1. Expand `Ports (COM & LPT)`
+> 1. Look for a node similar to `USB Serial Device (COM4)`
+>
+> ![Device Manager](../../images/devicemanager.png)
+>
+> For the example above, we would use `port: COM4` in the `configuration.yaml`.
+> Next configure the `serial` section as described [here](../configuration/adapter-settings.md).
 
 ## Updating Zigbee2MQTT
 

--- a/docs/guide/installation/14_securing.md
+++ b/docs/guide/installation/14_securing.md
@@ -8,10 +8,9 @@ redirectFrom:
 
 # Securing the installation
 
-::: warning
-This page provides an overview of how security applies to a typical installation.
-Each setup being slightly different, not all, and/or more, could apply.
-:::
+> [!IMPORTANT]
+> This page provides an overview of how security applies to a typical installation.
+> Each setup being slightly different, not all, and/or more, could apply.
 
 A useful way to think about Zigbee2MQTT in terms of security is to compare it to the software running on a network router: it provides configuration and control of a network.
 As such, it is, by default, only locally accessible.
@@ -53,23 +52,20 @@ It is used to publish data and to control every aspect of Zigbee2MQTT (configura
 
 See [MQTT configuration](../configuration/mqtt.md) for the full reference.
 
-:::caution CAUTION
-Do not expose the MQTT broker publicly without securing its access.
-Refer to the available documentation and guides for your broker.
-:::
+> [!CAUTION]
+> Do not expose the MQTT broker publicly without securing its access.
+> Refer to the available documentation and guides for your broker.
 
-:::caution CAUTION
-Using `reject_unauthorized: false` in production is dangerous. Its disables TLS certificate validation and makes the connection vulnerable.
-:::
+> [!CAUTION]
+> Using `reject_unauthorized: false` in production is dangerous. Its disables TLS certificate validation and makes the connection vulnerable.
 
 ## Frontend
 
 The frontend uses the same API as MQTT, but wrapped in a [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) for in-browser access.
 Anyone who can reach the frontend has full control over Zigbee2MQTT, same as MQTT.
 
-:::caution CAUTION
-Do not expose the frontend publicly without securing its access.
-:::
+> [!CAUTION]
+> Do not expose the frontend publicly without securing its access.
 
 ### Authentication
 
@@ -102,9 +98,8 @@ frontend:
     host: '/run/zigbee2mqtt/zigbee2mqtt.sock'
 ```
 
-:::warning WARNING
-Beware of the specific requirements of some systems in this regard (Docker, Home Assistant, etc.).
-:::
+> [!IMPORTANT]
+> Beware of the specific requirements of some systems in this regard (Docker, Home Assistant, etc.).
 
 ## Zigbee network
 
@@ -112,13 +107,11 @@ Beware of the specific requirements of some systems in this regard (Docker, Home
 
 Zigbee communication is encrypted using a 128-bit network key.
 
-:::caution CAUTION
-Changing this key requires re-pairing all devices.
-:::
+> [!CAUTION]
+> Changing this key requires re-pairing all devices.
 
-:::caution CAUTION
-If you are currently running a network with the old default key `[1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 13]`, it is strongly suggested you change it.
-:::
+> [!CAUTION]
+> If you are currently running a network with the old default key `[1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 13]`, it is strongly suggested you change it.
 
 To generate a new random key on next startup, use [Onboarding](../getting-started/README.md#onboarding), or update it manually:
 
@@ -153,9 +146,8 @@ The Network Address is randomly assigned on device join and usually remains the 
 The "permit join" state determines whether new devices are allowed to join the network.
 Joining is enabled temporarily (for 254 seconds by default) via the dedicated frontend button or via MQTT. You can also close the joining window manually once pairing is complete.
 
-:::tip TIP
-Freshly joined devices may automatically permit joining on themselves for a specific duration (max 254 seconds).
-:::
+> [!TIP]
+> Freshly joined devices may automatically permit joining on themselves for a specific duration (max 254 seconds).
 
 #### Install codes
 
@@ -172,14 +164,13 @@ See also [Add install code via MQTT](../../guide/usage/mqtt_topics_and_messages.
 For stricter control over which devices are allowed on the network, use a passlist or blocklist.
 See [Device blocklist / passlist](../configuration/block-pass-list.md) for more details.
 
-:::tip TIP
-Devices that are not allowed are removed from the network on startup (e.g. configuration changes since last run), and on join attempts.
-Note: removal is a request sent to the targeted device to "ask it" to leave, a malicious device could purposely ignore it.
-:::
+> [!NOTE]
+> Devices that are not allowed are removed from the network on startup (e.g. configuration changes since last run), and on join attempts.
+>
+> Removal is a request sent to the targeted device to "ask it" to leave, a malicious device could purposely ignore it.
 
-:::tip TIP
-Using a passlist is the most restrictive and therefore most secure option, only explicitly trusted devices can join.
-:::
+> [!TIP]
+> Using a passlist is the most restrictive and therefore most secure option, only explicitly trusted devices can join.
 
 ### Inter-PAN
 
@@ -189,9 +180,8 @@ Touchlink (previously known as ZLL) uses inter-PAN messaging.
 Inter-PAN is usually reserved for highly specific operations (e.g. resetting a device to factory settings via Touchlink), undesired messages are aggressively dropped, and close physical proximity is required.
 This limits the impact of its lack of security.
 
-:::warning WARNING
-Avoid devices that keep Touchlink permanently enabled, especially in places with relative ease of access; a malicious user could otherwise disrupt the network.
-:::
+> [!WARNING]
+> Avoid devices that keep Touchlink permanently enabled, especially in places with relative ease of access; a malicious user could otherwise disrupt the network.
 
 ### Zigbee 4.0
 
@@ -205,10 +195,9 @@ NOTE: It will take time before devices catch up to the new standard and support 
 By design, external extensions and converters execute arbitrary user-provided JavaScript code within the Zigbee2MQTT process.
 This grants significant customization flexibility, but also means that malicious or buggy code can compromise the entire Zigbee2MQTT instance, and potentially the host system.
 
-:::caution CAUTION
-Only add external extensions and converters from trusted, reviewed sources.
-Treat them with the same level of scrutiny as any other code/scripts running on your system.
-:::
+> [!CAUTION]
+> Only add external extensions and converters from trusted, reviewed sources.
+> Treat them with the same level of scrutiny as any other code/scripts running on your system.
 
 ## Firmware updates (OTA)
 
@@ -220,7 +209,6 @@ See [OTA updates](../usage/ota_updates.md) for more details.
 By default, Zigbee2MQTT matches and retrieves OTA images from the [Koenkk/zigbee-OTA](https://github.com/Koenkk/zigbee-OTA) repository.
 This repository is a mirror of manufacturer-provided firmware updates, both manually and automatically curated.
 
-:::caution CAUTION
-Only use firmware from trusted sources.
-Avoid using custom OTA index URLs unless you fully trust the source.
-:::
+> [!CAUTION]
+> Only use firmware from trusted sources.
+> Avoid using custom OTA index URLs unless you fully trust the source.

--- a/docs/guide/installation/15_watchdog.md
+++ b/docs/guide/installation/15_watchdog.md
@@ -21,9 +21,8 @@ In addition, the following behaviors always apply:
 - A problem with settings will always ignore the watchdog and stop Z2M.
 - A manual stop/restart (like `CTRL+C`) will ignore the watchdog to comply with user intent.
 
-::: tip TIP
-In non-containerized environments, to handle NodeJS crashes, you will need a dedicated watchdog program on your operating system to allow restarting the Zigbee2MQTT process automatically.
-:::
+> [!TIP]
+> In non-containerized environments, to handle NodeJS crashes, you will need a dedicated watchdog program on your operating system to allow restarting the Zigbee2MQTT process automatically.
 
 ## Customized delays
 

--- a/docs/guide/usage/binding.md
+++ b/docs/guide/usage/binding.md
@@ -16,9 +16,8 @@ A use case for binding is, for example, the TRADFRI wireless dimmer. Binding the
 
 ## Commands
 
-::: tip
-All commands below can also be executed via the frontend, click on your device and go to the _Bind_ tab.
-:::
+> [!TIP]
+> All commands below can also be executed via the frontend, click on your device and go to the _Bind_ tab.
 
 Binding can be configured by using either `zigbee2mqtt/bridge/request/device/bind` to bind and `zigbee2mqtt/bridge/request/device/unbind` to unbind. The payload should be `{"from": SOURCE, "to": TARGET}` where `SOURCE` and `TARGET` can be the `friendly_name` of a group or device. Example request payload: `{"from": "my_remote", "to": "my_bulb"}`, example response payload: `{"data":{"from":"my_remote","from_endpoint":"default","to":"my_bulb","clusters":["genScenes","genOnOff","genLevelCtrl"],"failed":[]},"status":"ok"}`. The `clusters` in the response indicate the bound/unbound clusters, `failed` indicates any failed to bind/unbind clusters. In case all clusters fail to bind the `status` is set to `error`.
 
@@ -38,9 +37,8 @@ If wanting to bind to specific endpoints instead of the default ones, specify th
 
 `SOURCE_ENDPOINT` and `TARGET_ENDPOINT` are optional. `SOURCE_ENDPOINT` will default to the default endpoint for the `SOURCE` device if not supplied. `TARGET_ENDPOINT` behaves the same, but is only used if `TARGET` is a device.
 
-::: tip
-The default endpoint for a device is the first registered endpoint (most often endpoint ID 1).
-:::
+> [!TIP]
+> The default endpoint for a device is the first registered endpoint (most often endpoint ID 1).
 
 ### Binding a remote to a group
 
@@ -65,9 +63,8 @@ To clear all bindings, just send the topic with the payload e.g. `{"target": "my
 
 To selectively clear bindings by IEEE address, send the topic with the payload e.g. `{"target": "my_deivce", "ieee_list": ["0xa1a2a3a4a5a6a7a8", "0xb1b2b3b4b5b6b7b8"]}`.
 
-::: tip
-Clearing bindings will automatically adjust the cached data that Zigbee2MQTT uses internally based on the request/response. After successfully executing this requests, bindings in Zigbee2MQTT should reflect actual bindings on the device.
-:::
+> [!TIP]
+> Clearing bindings will automatically adjust the cached data that Zigbee2MQTT uses internally based on the request/response. After successfully executing this requests, bindings in Zigbee2MQTT should reflect actual bindings on the device.
 
 ## Devices
 

--- a/docs/guide/usage/groups.md
+++ b/docs/guide/usage/groups.md
@@ -6,9 +6,8 @@ redirectFrom: /information/groups.md
 
 Zigbee2MQTT has support for Zigbee groups. By using Zigbee groups you can control multiple devices simultaneously with one command.
 
-::: tip
-Groups are much more efficient than controlling devices separately as it significantly reduces the stress on a network when controlling multiple devices at once.
-:::
+> [!TIP]
+> Groups are much more efficient than controlling devices separately as it significantly reduces the stress on a network when controlling multiple devices at once.
 
 ## Creating a group
 

--- a/docs/guide/usage/integrations/home_assistant.md
+++ b/docs/guide/usage/integrations/home_assistant.md
@@ -92,9 +92,8 @@ automation:
 
 This method works by responding to the state change event of a sensor. For this `homeassistant.legacy_action_sensor: true` needs to be set in your `configuration.yaml`. See the [docs](../../configuration/homeassistant.md) for more info.
 
-::: warning
-Note that this feature is deprecated and will be removed in the future. It's recommended to use the MQTT device trigger instead.
-:::
+> [!WARNING]
+> Note that this feature is deprecated and will be removed in the future. It's recommended to use the MQTT device trigger instead.
 
 ```yaml
 automation:

--- a/docs/guide/usage/mqtt_topics_and_messages.md
+++ b/docs/guide/usage/mqtt_topics_and_messages.md
@@ -11,10 +11,9 @@ This page describes which MQTT topics are used by Zigbee2MQTT. Note that the bas
 
 The `FRIENDLY_NAME` is the IEEE-address or, if defined, the `friendly_name` of a device or group.
 
-::: tip
-You can use the `/` separator in `friendly_name` to structure devices and groups.
-For example, using a `friendly_name` like `kitchen/floor_light` would result in a corresponding MQTT structure with `kitchen` as folder containing `floor_light` in MQTT Explorer.
-:::
+> [!TIP]
+> You can use the `/` separator in `friendly_name` to structure devices and groups.
+> For example, using a `friendly_name` like `kitchen/floor_light` would result in a corresponding MQTT structure with `kitchen` as folder containing `floor_light` in MQTT Explorer.
 
 Published messages are **always** in a JSON format. Each device produces a different JSON message. To see what your device publishes check the "Exposes" section on the device page which can be accessed via ["Supported devices"](../../supported-devices/). Some examples:
 
@@ -468,9 +467,8 @@ Creates a backup of the `data` folder (without the `data/log` directory). Payloa
 
 Allows to add an install code to the coordinator. Use this when you want to pair a Zigbee 3.0 devices which can only be paired with an install code. These devices typically have a QR code on it. When scanning this QR code you will get a code, e.g. `ZB10SG0D831018234800400000000000000000009035EAFFFE424793DLKAE3B287281CF11F550733A0CFC38AA31E802`. Publish this code to `zigbee2mqtt/bridge/request/install_code/add` with payload `{"value":"THE_CODE"}`. Example response: `{"data":{"value":"THE_CODE"},"status":"ok"}`.
 
-::: tip TIP
-The WindFront frontend does not automatically activate permit joining after adding an install code. This allows you to permit joining on whichever device you want or "all", same as a regular device.
-:::
+> [!TIP]
+> The WindFront frontend does not automatically activate permit joining after adding an install code. This allows you to permit joining on whichever device you want or "all", same as a regular device.
 
 ### Device
 
@@ -493,9 +491,8 @@ If you want to keep the device configuration when removing a device add the opti
 
 To also clear the cache when removing a device add the optional `clear_cache` property (default `false`) to the payload, example: `{"id":"my_bulb","clear_cache":true}`; next join from that device will be from a clean slate (full interview from scratch).
 
-::: tip TIP
-If you are developing a new device (e.g. ESPHome), use `clear_cache` to prevent potentially stale data from being restored on re-pairing.
-:::
+> [!TIP]
+> If you are developing a new device (e.g. ESPHome), use `clear_cache` to prevent potentially stale data from being restored on re-pairing.
 
 In case you also want to block the device the optional `block` property (default `false`) can be added, example: `{"id":"my_bulb","block":true}`. Note that Zigbee doesn't have a block functionality, therefore when a device is blocked, Zigbee2MQTT will immediately request the device to remove itself from the network when it joins.
 
@@ -590,9 +587,8 @@ The Minimum Reporting Change is like telling your device to speak up only when s
 If you set a minimum reporting change of 1 degree for a temperature sensor, it means the sensor won't bother you with updates unless the temperature changes by at least 1 degree.
 It's a way to filter out minor fluctuations and focus on important changes in the environment.
 
-::: tip NOTE
-Support for `reportable_change` depends on the type of the attribute. For e.g. a `measure`-type attribute would likely support it, but a `enum`-type attribute would not. If supplied and not supported, it is ignored.
-:::
+> [!TIP]
+> Support for `reportable_change` depends on the type of the attribute. For e.g. a `measure`-type attribute would likely support it, but a `enum`-type attribute would not. If supplied and not supported, it is ignored.
 
 To disable reporting set the `maximum_report_interval` to `65535`.
 
@@ -614,9 +610,8 @@ Example payloads:
 - For multiple attributes: `{"id":"my_bulb","endpoint":1,"cluster":"genLevelCtrl","configs":[{"attribute":"currentLevel"},{"attribute":"currentFrequency"}]}`
 - For manufacturer-specific attribute: `{"id":"my_bulb","endpoint":1,"cluster":"genLevelCtrl","configs":[{"attribute":"currentLevel"}], "manufacturer_code": 0x1234}`
 
-::: tip
-Reading reporting config will automatically adjust the cached data that Zigbee2MQTT uses internally based on the request/response. After successfully executing this requests, reporting config in Zigbee2MQTT should reflect the actual reporting config on the device.
-:::
+> [!TIP]
+> Reading reporting config will automatically adjust the cached data that Zigbee2MQTT uses internally based on the request/response. After successfully executing this requests, reporting config in Zigbee2MQTT should reflect the actual reporting config on the device.
 
 ### Group
 
@@ -687,15 +682,13 @@ E.g.:
 
 `{"action":"just_an_example","params":{"abcd": 1, "zyx": "my_device"}}`
 
-::: tip
-Specific up-to-date actions/parameters can be observed directly in the source code [https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/converters/actions.ts](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/converters/actions.ts)
-:::
+> [!TIP]
+> Specific up-to-date actions/parameters can be observed directly in the source code [https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/converters/actions.ts](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/converters/actions.ts)
 
 ##### Action: `raw`
 
-::: warning
-This allows sending requests that could negatively impact or even break your network. Use with caution!
-:::
+> [!CAUTION]
+> This allows sending requests that could negatively impact or even break your network.
 
 Special action that allows to send entirely custom payloads. The given payload is analyzed to chose the proper method of sending (ZCL, ZDO, etc.).
 See link above for parameters details (beyond the scope of this documentation).

--- a/docs/guide/usage/ota_updates.md
+++ b/docs/guide/usage/ota_updates.md
@@ -6,19 +6,17 @@ redirectFrom: /information/ota_updates.md
 
 This feature allows updating the firmware of Zigbee devices over-the-air.
 
-::: warning
-Firmware updates can provide bug fixes, security updates and other welcomed features.
-However, they can also change device behavior in ways that may affect Zigbee2MQTT compatibility and potentially introduce buggy, or even malicious functionality.
-**Review the release notes before applying a firmware update.**
-:::
+> [!WARNING]
+> Firmware updates can provide bug fixes, security updates and other welcomed features.
+> However, they can also change device behavior in ways that may affect Zigbee2MQTT compatibility and potentially introduce buggy, or even malicious functionality.
+> **Review the release notes before applying a firmware update.**
 
 By default, Zigbee2MQTT matches and retrieves OTA images from the [Koenkk/zigbee-OTA](https://github.com/Koenkk/zigbee-OTA) repository (if it has internet access).
 This repository is a mirror of manufacturer-provided firmware updates, both manually and automatically curated.
 [Using custom/local sources](#using-custom-firmware-files-or-index) is explained further down the page.
 
-::: tip
-Most actions and configurations on this page can be done via the frontend.
-:::
+> [!TIP]
+> Most actions and configurations on this page can be done via the frontend.
 
 ## Update status
 
@@ -75,13 +73,12 @@ If an update is available (`"update_available":true`), the response will also co
 
 ## Starting an update
 
-::: warning WARNINGS
-The update process greatly varies in duration: 10-100 minutes depending on device, settings and network stability. The device is usable during this time, but heavy traffic is added on the network. Therefore, the best practice is to **update one device at a time, while the network is in low demand.**
-
-When uploading the OTA file completes, the device will reboot with the new firmware. **The reboot may cause unwanted interruptions or turn-ons, due to power-on behavior (e.g. light-up in the middle of the night)!**
-
-Since updating can drastically change the device behavior, Zigbee2MQTT treats it similarly to pairing a new device. It will automatically re-interview to detect new capabilities and **re-configure to ensure normal operation (this may overwrite custom reporting intervals with the default values)**
-:::
+> [!WARNING]
+> The update process greatly varies in duration: 10-100 minutes depending on device, settings and network stability. The device is usable during this time, but heavy traffic is added on the network. Therefore, the best practice is to **update one device at a time, while the network is in low demand.**
+>
+> When uploading the OTA file completes, the device will reboot with the new firmware. **The reboot may cause unwanted interruptions or turn-ons, due to power-on behavior (e.g. light-up in the middle of the night)!**
+>
+> Since updating can drastically change the device behavior, Zigbee2MQTT treats it similarly to pairing a new device. It will automatically re-interview to detect new capabilities and **re-configure to ensure normal operation (this may overwrite custom reporting intervals with the default values)**
 
 ### Manual update request
 
@@ -99,9 +96,8 @@ Note that `software_build_id` and `date_code` are **optional** device attributes
 
 It's possible to schedule the update for the next time the device requests an OTA update check.
 
-:::tip TIP
-This can help for battery-powered devices that usually don't respond to [manual update requests](#manual-update-request) unless physically woken up right before triggering. Some brands/models are known to only update this way (e.g. some Legrand devices).
-:::
+> [!TIP]
+> This can help for battery-powered devices that usually don't respond to [manual update requests](#manual-update-request) unless physically woken up right before triggering. Some brands/models are known to only update this way (e.g. some Legrand devices).
 
 To schedule, send a message to `zigbee2mqtt/bridge/request/device/ota_update/schedule` with payload `{"id":"deviceID"}` where deviceID can be the `ieee_address` or `friendly_name` of the device, example request: `{"id":"my_remote"}`.  
 The same applies for downgrade with topic `zigbee2mqtt/bridge/request/device/ota_update/schedule/downgrade`.
@@ -149,9 +145,8 @@ Zigbee2MQTT will ignore the custom value for some devices and automatically use 
 
 Devices can be updated from custom sources, by supplying the firmware files directly, or by listing them in a custom index.
 
-:::caution CAUTION
-Improper use of custom OTA index or firmware files can brick devices. Due to the nature of "custom firmware", several of the regular OTA constraints are bypassed in this mode. **Use trusted sources!**
-:::
+> [!CAUTION]
+> Improper use of custom OTA index or firmware files can brick devices. Due to the nature of "custom firmware", several of the regular OTA constraints are bypassed in this mode. **Use trusted sources!**
 
 An OTA index file is a list of firmware images available in designated locations. By default, Zigbee2MQTT uses the [upgrade index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index.json), and the [downgrade index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index1.json) from the [zigbee-OTA](https://github.com/Koenkk/zigbee-OTA) repository.
 
@@ -160,9 +155,8 @@ A custom update index can be supplied globally (by editing `configuration.yaml`)
 The override OTA index file shall have the same structure as the [zigbee-OTA index file](https://github.com/Koenkk/zigbee-OTA/blob/master/index.json).
 See the [repository README](https://github.com/Koenkk/zigbee-OTA/tree/master?tab=readme-ov-file#notes-for-maintainers--developers) if an image requires extra metadata.
 
-:::tip TIP
-The following tool can generate indexes and do more helpful operations: [https://nerivec.github.io/zigbee-ota-file-editor/](https://nerivec.github.io/zigbee-ota-file-editor/)
-:::
+> [!TIP]
+> The following tool can generate indexes and do more helpful operations: [https://nerivec.github.io/zigbee-ota-file-editor/](https://nerivec.github.io/zigbee-ota-file-editor/)
 
 If the default Zigbee2MQTT index is inaccessible (e.g. air gapped network), only the local OTA index will be used.  
 If both indexes are available, records in the override index will take precedence over the ones in the default index.

--- a/docs/guide/usage/touchlink.md
+++ b/docs/guide/usage/touchlink.md
@@ -30,14 +30,12 @@ Other adapters/drivers are currently **not supported**.
 
 Compatible devices expose the `Touchlink` cluster, which includes most Philips and IKEA devices, some Tuya light bulbs, Namron relays and more.
 
-::: warning
-Some devices may disable Touchlink after a few minutes! _(security measure)_  
-Power-cycle the device to make sure it's active.
-:::
+> [!IMPORTANT]
+> Some devices may disable Touchlink after a few minutes! _(security measure)_  
+> Power-cycle the device to make sure it's active.
 
-::: tip
-All commands below can also be executed via the frontend _Touchlink_ tab.
-:::
+> [!TIP]
+> All commands below can also be executed via the frontend _Touchlink_ tab.
 
 ## Scan
 

--- a/docs/guide/usage/troubleshooting.md
+++ b/docs/guide/usage/troubleshooting.md
@@ -53,7 +53,7 @@ Some TCP adapters also allow you to do that from their own interface.
 **Make sure you have a `coordinator_backup.json` and `configuration.yaml` present in your Zigbee2MQTT data folder before doing this; Zigbee2MQTT will need them to restore the network after the reset.**
 
 > [!TIP]
-> Installation details for `ember-zli` can be found here: https://github.com/Nerivec/ember-zli/wiki#installation
+> Installation details for `ember-zli` can be found here: [https://github.com/Nerivec/ember-zli/wiki#installation](https://github.com/Nerivec/ember-zli/wiki#installation)
 
 > [!IMPORTANT]
 > If you have known-good devices in your network, migrating the IEEE is not usually necessary.
@@ -72,15 +72,13 @@ Devices that spam data reports can quickly crowd the network and reduce the over
 You can disable or decrease the rate of reports of a device (for all or specific states). If possible, configure [reporting](../usage/mqtt_topics_and_messages.md#zigbee2mqtt-bridge-request-device-reporting-configure) to better match your need and fit what your network can handle.
 However, often enough the devices cited above also don't allow proper configuration, in that case, there is no real way to fix them, you can only replace them with better ones.
 
-::: tip TIP
-Several Open Source projects offer alternative Tuya OTA update firmware (be sure to read all associated documentation before using these). Examples:
-
-- [https://github.com/romasku/tuya-zigbee-switch](https://github.com/romasku/tuya-zigbee-switch)
-- [https://github.com/pvvx/ZigbeeTLc](https://github.com/pvvx/ZigbeeTLc)
-- [https://github.com/Andrik45719/ZY-M100](https://github.com/Andrik45719/ZY-M100)
-- [https://github.com/slacky1965](https://github.com/slacky1965)
-
-:::
+> [!TIP]
+> Several Open Source projects offer alternative Tuya OTA update firmware (be sure to read all associated documentation before using these). Examples:
+>
+> - [https://github.com/romasku/tuya-zigbee-switch](https://github.com/romasku/tuya-zigbee-switch)
+> - [https://github.com/pvvx/ZigbeeTLc](https://github.com/pvvx/ZigbeeTLc)
+> - [https://github.com/Andrik45719/ZY-M100](https://github.com/Andrik45719/ZY-M100)
+> - [https://github.com/slacky1965](https://github.com/slacky1965)
 
 ## Disconnect with MQTT v5
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "@vuepress/client": "2.0.0-rc.31",
         "@vuepress/plugin-docsearch": "2.0.0-rc.132",
         "@vuepress/plugin-google-analytics": "2.0.0-rc.130",
+        "@vuepress/plugin-markdown-hint": "2.0.0-rc.132",
         "@vuepress/plugin-redirect": "2.0.0-rc.131",
         "@vuepress/plugin-register-components": "2.0.0-rc.132",
         "@vuepress/plugin-sitemap": "2.0.0-rc.132",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@vuepress/plugin-google-analytics':
         specifier: 2.0.0-rc.130
         version: 2.0.0-rc.130(vuepress@2.0.0-rc.31(@vue/compiler-sfc@3.5.40)(@vuepress/bundler-vite@2.0.0-rc.31(@types/node@26.1.2)(@vue/compiler-sfc@3.5.40)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23))(yaml@2.9.0))(esbuild@0.28.0)(rolldown@1.2.0)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23)))
+      '@vuepress/plugin-markdown-hint':
+        specifier: 2.0.0-rc.132
+        version: 2.0.0-rc.132(@vuepress/bundler-vite@2.0.0-rc.31(@types/node@26.1.2)(@vue/compiler-sfc@3.5.40)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23))(yaml@2.9.0))(markdown-it@14.3.0)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3))(vuepress@2.0.0-rc.31(@vue/compiler-sfc@3.5.40)(@vuepress/bundler-vite@2.0.0-rc.31(@types/node@26.1.2)(@vue/compiler-sfc@3.5.40)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23))(yaml@2.9.0))(esbuild@0.28.0)(rolldown@1.2.0)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23)))
       '@vuepress/plugin-redirect':
         specifier: 2.0.0-rc.131
         version: 2.0.0-rc.131(@vuepress/bundler-vite@2.0.0-rc.31(@types/node@26.1.2)(@vue/compiler-sfc@3.5.40)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23))(yaml@2.9.0))(typescript@6.0.3)(vuepress@2.0.0-rc.31(@vue/compiler-sfc@3.5.40)(@vuepress/bundler-vite@2.0.0-rc.31(@types/node@26.1.2)(@vue/compiler-sfc@3.5.40)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23))(yaml@2.9.0))(esbuild@0.28.0)(rolldown@1.2.0)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23)))
@@ -411,8 +414,8 @@ packages:
       markdown-it:
         optional: true
 
-  '@mdit/plugin-alert@1.0.1':
-    resolution: {integrity: sha512-gEZgbwlK2JSNIW3izqQyPoYJ8NXAEU0aON7XYpUHBzyD9km+ny5zFkAmoogMAzR8ird8iCQiK5pSv3nOtPBlLw==}
+  '@mdit/plugin-alert@1.0.3':
+    resolution: {integrity: sha512-IWMW8EOOa1ukc7YQQoIuZ8mwPUF5yM4qbHm2s+j5QSrPGob7bUKyvFYOQ9QYiW03J4izsf8GzTSwLCtlHkqMEw==}
     engines: {node: '>=22'}
     peerDependencies:
       markdown-it: ^14.2.0
@@ -420,8 +423,8 @@ packages:
       markdown-it:
         optional: true
 
-  '@mdit/plugin-container@1.0.1':
-    resolution: {integrity: sha512-dT6eoqKxpWcsIHYPTNjIOq/pIzhv6LJTNXjfLSk847goQtlvMZ/Y+kRKH+wQGqDKmNwxDbEQfDbcoqhNXEjuhA==}
+  '@mdit/plugin-container@1.0.2':
+    resolution: {integrity: sha512-gCpqmadamWVbDI7+OgkywDGjfgqxrjZo3U+iK+sH7vERnZyX4sx1X65pXbqrem8Q5/4yO5t0d+kWkPC733ceRw==}
     engines: {node: '>=22'}
     peerDependencies:
       markdown-it: ^14.2.0
@@ -784,6 +787,9 @@ packages:
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
 
+  '@types/markdown-it@14.2.0':
+    resolution: {integrity: sha512-NoQ2yGlLWj4wpxMs+TYmRKk3thDrQ97agr7sFqfLsAlvoS8SNQuTrlObhFqG9iugdTtgOE9jpJ6FNM4ZGsa5xQ==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -1024,11 +1030,24 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
+  '@vueuse/core@14.4.0':
+    resolution: {integrity: sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==}
+    peerDependencies:
+      vue: ^3.5.0
+
   '@vueuse/metadata@14.3.0':
     resolution: {integrity: sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==}
 
+  '@vueuse/metadata@14.4.0':
+    resolution: {integrity: sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==}
+
   '@vueuse/shared@14.3.0':
     resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/shared@14.4.0':
+    resolution: {integrity: sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==}
     peerDependencies:
       vue: ^3.5.0
 
@@ -1187,6 +1206,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  baseline-browser-mapping@2.11.16:
+    resolution: {integrity: sha512-H/bNPUFHewJHyCTdjn1n3Pit5+2GmWT6mmeHImPX+8MA9NA6b67jO4gYmi4jTbCJb2otq34KMZnovndDPqJwhQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
@@ -1211,6 +1235,11 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -1228,6 +1257,9 @@ packages:
 
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
+
+  caniuse-lite@1.0.30001809:
+    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1383,6 +1415,9 @@ packages:
   electron-to-chromium@1.5.396:
     resolution: {integrity: sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==}
 
+  electron-to-chromium@1.5.411:
+    resolution: {integrity: sha512-gglkxzokjHfawpGxq75XdBV2/l3BAPzrsMs70qgaZdTW5rpV1tC4MdgJVP9fN126bODA4ZJQkn1wryEzJyQXIg==}
+
   emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
@@ -1419,8 +1454,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@2.3.1:
-    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1911,6 +1946,10 @@ packages:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
 
+  node-releases@2.0.53:
+    resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
+    engines: {node: '>=18'}
+
   nostics@1.2.0:
     resolution: {integrity: sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==}
 
@@ -2398,6 +2437,12 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  update-browserslist-db@1.3.1:
+    resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
@@ -2822,15 +2867,15 @@ snapshots:
     optionalDependencies:
       markdown-it: 14.3.0
 
-  '@mdit/plugin-alert@1.0.1(markdown-it@14.3.0)':
+  '@mdit/plugin-alert@1.0.3(markdown-it@14.3.0)':
     dependencies:
-      '@types/markdown-it': 14.1.2
+      '@types/markdown-it': 14.2.0
     optionalDependencies:
       markdown-it: 14.3.0
 
-  '@mdit/plugin-container@1.0.1(markdown-it@14.3.0)':
+  '@mdit/plugin-container@1.0.2(markdown-it@14.3.0)':
     dependencies:
-      '@types/markdown-it': 14.1.2
+      '@types/markdown-it': 14.2.0
     optionalDependencies:
       markdown-it: 14.3.0
 
@@ -3101,6 +3146,11 @@ snapshots:
       '@types/markdown-it': 14.1.2
 
   '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/markdown-it@14.2.0':
     dependencies:
       '@types/linkify-it': 5.0.0
       '@types/mdurl': 2.0.0
@@ -3467,11 +3517,11 @@ snapshots:
 
   '@vuepress/plugin-markdown-hint@2.0.0-rc.132(@vuepress/bundler-vite@2.0.0-rc.31(@types/node@26.1.2)(@vue/compiler-sfc@3.5.40)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23))(yaml@2.9.0))(markdown-it@14.3.0)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3))(vuepress@2.0.0-rc.31(@vue/compiler-sfc@3.5.40)(@vuepress/bundler-vite@2.0.0-rc.31(@types/node@26.1.2)(@vue/compiler-sfc@3.5.40)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23))(yaml@2.9.0))(esbuild@0.28.0)(rolldown@1.2.0)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23)))':
     dependencies:
-      '@mdit/plugin-alert': 1.0.1(markdown-it@14.3.0)
-      '@mdit/plugin-container': 1.0.1(markdown-it@14.3.0)
-      '@types/markdown-it': 14.1.2
+      '@mdit/plugin-alert': 1.0.3(markdown-it@14.3.0)
+      '@mdit/plugin-container': 1.0.2(markdown-it@14.3.0)
+      '@types/markdown-it': 14.2.0
       '@vuepress/helper': 2.0.0-rc.131(@vuepress/bundler-vite@2.0.0-rc.31(@types/node@26.1.2)(@vue/compiler-sfc@3.5.40)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23))(yaml@2.9.0))(typescript@6.0.3)(vuepress@2.0.0-rc.31(@vue/compiler-sfc@3.5.40)(@vuepress/bundler-vite@2.0.0-rc.31(@types/node@26.1.2)(@vue/compiler-sfc@3.5.40)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23))(yaml@2.9.0))(esbuild@0.28.0)(rolldown@1.2.0)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23)))
-      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@6.0.3))
+      '@vueuse/core': 14.4.0(vue@3.5.40(typescript@6.0.3))
       vuepress: 2.0.0-rc.31(@vue/compiler-sfc@3.5.40)(@vuepress/bundler-vite@2.0.0-rc.31(@types/node@26.1.2)(@vue/compiler-sfc@3.5.40)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(typescript@6.0.3)(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23))(yaml@2.9.0))(esbuild@0.28.0)(rolldown@1.2.0)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.47.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(webpack@5.106.2(esbuild@0.28.0)(postcss@8.5.23))
     transitivePeerDependencies:
       - '@vuepress/bundler-vite'
@@ -3640,9 +3690,22 @@ snapshots:
       '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@6.0.3))
       vue: 3.5.40(typescript@6.0.3)
 
+  '@vueuse/core@14.4.0(vue@3.5.40(typescript@6.0.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 14.4.0
+      '@vueuse/shared': 14.4.0(vue@3.5.40(typescript@6.0.3))
+      vue: 3.5.40(typescript@6.0.3)
+
   '@vueuse/metadata@14.3.0': {}
 
+  '@vueuse/metadata@14.4.0': {}
+
   '@vueuse/shared@14.3.0(vue@3.5.40(typescript@6.0.3))':
+    dependencies:
+      vue: 3.5.40(typescript@6.0.3)
+
+  '@vueuse/shared@14.4.0(vue@3.5.40(typescript@6.0.3))':
     dependencies:
       vue: 3.5.40(typescript@6.0.3)
 
@@ -3830,6 +3893,9 @@ snapshots:
 
   baseline-browser-mapping@2.11.1: {}
 
+  baseline-browser-mapping@2.11.16:
+    optional: true
+
   big.js@5.2.2: {}
 
   birpc@2.9.0: {}
@@ -3855,6 +3921,15 @@ snapshots:
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
+  browserslist@4.28.8:
+    dependencies:
+      baseline-browser-mapping: 2.11.16
+      caniuse-lite: 1.0.30001809
+      electron-to-chromium: 1.5.411
+      node-releases: 2.0.53
+      update-browserslist-db: 1.3.1(browserslist@4.28.8)
+    optional: true
+
   buffer-from@1.1.2:
     optional: true
 
@@ -3871,6 +3946,9 @@ snapshots:
       get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001806: {}
+
+  caniuse-lite@1.0.30001809:
+    optional: true
 
   ccount@2.0.1: {}
 
@@ -4025,6 +4103,9 @@ snapshots:
 
   electron-to-chromium@1.5.396: {}
 
+  electron-to-chromium@1.5.411:
+    optional: true
+
   emojis-list@3.0.0: {}
 
   encoding-sniffer@0.2.1:
@@ -4050,7 +4131,7 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@2.3.1:
+  es-module-lexer@2.3.2:
     optional: true
 
   es-object-atoms@1.1.1:
@@ -4552,6 +4633,9 @@ snapshots:
 
   node-releases@2.0.51: {}
 
+  node-releases@2.0.53:
+    optional: true
+
   nostics@1.2.0: {}
 
   nth-check@2.1.1:
@@ -5026,6 +5110,13 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  update-browserslist-db@1.3.1(browserslist@4.28.8):
+    dependencies:
+      browserslist: 4.28.8
+      escalade: 3.2.0
+      picocolors: 1.1.1
+    optional: true
+
   v8-compile-cache-lib@3.0.1: {}
 
   vfile-location@5.0.3:
@@ -5156,10 +5247,10 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.18.0
       acorn-import-phases: 1.0.4(acorn@8.18.0)
-      browserslist: 4.28.7
+      browserslist: 4.28.8
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.24.5
-      es-module-lexer: 2.3.1
+      es-module-lexer: 2.3.2
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1

--- a/sidebar.ts
+++ b/sidebar.ts
@@ -51,6 +51,7 @@ export const sidebar: SidebarOptions = {
                 '/guide/usage/mqtt_topics_and_messages.md',
                 '/guide/usage/exposes.md',
                 '/guide/usage/health.md',
+                '/guide/usage/troubleshooting.md',
             ],
         },
         {

--- a/vuepress.config.ts
+++ b/vuepress.config.ts
@@ -5,6 +5,7 @@ import {defaultTheme} from '@vuepress/theme-default';
 import viteBundler from '@vuepress/bundler-vite';
 import {googleAnalyticsPlugin} from '@vuepress/plugin-google-analytics';
 import {sitemapPlugin} from '@vuepress/plugin-sitemap';
+import {markdownHintPlugin} from '@vuepress/plugin-markdown-hint';
 import {redirectPlugin} from '@vuepress/plugin-redirect';
 import {docsearchPlugin} from '@vuepress/plugin-docsearch';
 import {registerComponentsPlugin} from '@vuepress/plugin-register-components';
@@ -183,6 +184,10 @@ const conf = defineUserConfig({
             },
         },
         redirectPlugin(),
+        markdownHintPlugin({
+            // Enable gfm alert
+            alert: true,
+        }),
     ],
 });
 


### PR DESCRIPTION
Moves all `:::` alerts to GitHub style alerts.
It cleans up the docs quite nicely, and of course, has the added benefit of being visible if consulting the docs on GitHub directly.
Added the dep explicitly, even though it was already pulled in by vuepress internally; more stable since we're using the import now.
Also cleaned up a few levels as I went through the list to use the full range.

https://ecosystem.vuejs.press/plugins/markdown/markdown-hint.html

I suggest we reject the use of `:::` for alerts in future PRs, and reserve it for `details`.

Also fixed the new troubleshooting page, which wasn't added to the sidebar. :hammer: 

cc: @andrei-lazarov 