### PR TITLE
KAJPLATS notes: 15 minute pairing window, cycle timing, scene table

### DIFF
--- a/docgen/device_page_notes/ikea_kajplats.ts
+++ b/docgen/device_page_notes/ikea_kajplats.ts
@@ -19,6 +19,8 @@ export function ikeaKajplats(definition: Definition) {
 2. **Power-cycle the lamp ${cycles} times** (or ${otherCycles}, depending on model) to start Zigbee pairing.  
    When successful, the light will flash white. *Tip: Use a smart plug*
 
+The lamp counts a cycle only if power is cut within about 2 s after it comes on. Keep the ON phase at about 1 s: with 2.5 s or 3 s ON the cycles were not counted (measured on a GU10 CWS, firmware 1.1.0).
+
 If the device flashes, but does not join, this may help:
 - Use a default Zigbee channel (11, 15, 20, 25)
 - Bring it very close to the coordinator
@@ -27,7 +29,7 @@ If the device flashes, but does not join, this may help:
 
 [Touchlink](../guide/usage/touchlink.md) reset is also possible, but it seems the device only identifies for 15s, without leaving its current network and entering pairing mode.
 
-Note that Matter pairing (via Bluetooth) is simultaneously active for 5 minutes after power-on, even if the device is already paired to a Zigbee network.
+Note that Matter pairing (via Bluetooth) is simultaneously active for 15 minutes after power-on, even if the device is already paired to a Zigbee network. That is the Matter SDK default and matches [IKEA's support page](https://www.ikea.com/nl/en/customer-service/product-support/smart-lighting/smart-lighting-support-pubd8491250/); measured at about 15 minutes on a GU10 CWS with firmware 1.1.0.
 
 ## Firmware
 The device does not support OTA updates via Zigbee. Instead, updates are provided over Matter.  
@@ -38,6 +40,7 @@ View available updates [here](https://webui.dcl.csa-iot.org/models) (search *KAJ
 - The device may come with null model and manufacturer attributes. In this case, Zigbee2MQTT will recognize it generically. A firmware update may fix it. Alternatively, edit \`database.db\` manually, as described in [this issue](https://github.com/Koenkk/zigbee-herdsman-converters/issues/11939#issuecomment-4239257579)
 - Power-on behavior may not work, only in Zigbee mode, on some models (at least one variant of [LED2401G5](./LED2401G5.md))
 - Scenes, groups and the *OffWithEffect* command may fail, with the INSUFFICIENT_SPACE error. See more info and workaround in [this issue](https://github.com/Koenkk/zigbee2mqtt/issues/30211#issuecomment-4019236515)
+- The scene table holds 12 scenes on the GU10 CWS (firmware 1.1.0); the E27 1521 lm model is reported with 8 in the issue above. A scene stores on/off, brightness and, when the lamp is in XY color mode, the XY color. Color temperature is not stored, and recalling a scene does not switch the lamp out of color temperature mode.
 - The device may not announce itself on power restore. As a result, it can be unreachable after being powered off for a long time. Discussion in [this issue](https://github.com/Koenkk/zigbee2mqtt/issues/32115)
 
 `;


### PR DESCRIPTION
Changes `docgen/device_page_notes/ikea_kajplats.ts`, the template from #4971 by @andrei-lazarov. One sentence is corrected and two notes are added. The rest of the text is unchanged.

The note says Matter pairing over Bluetooth stays active for 5 minutes after power-on. On a KAJPLATS GU10 CWS (LED2410R5, firmware 1.1.0) the commissionable BLE advertisement (service data 0xFFF6) stayed on for about 906 s after power-on in two scans, with fast advertising for the first 30 to 40 s and slow advertising after that. That is the Matter SDK default, `CHIP_DEVICE_CONFIG_DISCOVERY_TIMEOUT_SECS (15 * 60)` in [CHIPDeviceConfig.h](https://github.com/project-chip/connectedhomeip/blob/master/src/include/platform/CHIPDeviceConfig.h), and IKEA's [support page](https://www.ikea.com/nl/en/customer-service/product-support/smart-lighting/smart-lighting-support-pubd8491250/) for BILRESA, KAJPLATS and MYGGSPRAY says the products are ready to connect for 15 minutes after power-on and that a light restarts the window when it is turned off and on again. The sentence now says 15 minutes and links the IKEA page.

The lamp counts a power cycle only if power is cut within about 2 s after it comes on. On the same lamp, 6 cycles with 3.0 s ON and 6 cycles with 2.5 s ON (1.5 s OFF) did not reset it. 6 cycles with 1.0 s ON (1.5 s OFF) did: Zigbee2MQTT logged device_leave and the lamp was back in Matter mode. The [Home Assistant blueprint](https://community.home-assistant.io/t/ikea-kajplats-smart-bulb-zigbee-pairing-mode-power-cycle/988507) uses 700 ms ON and 1500 ms OFF and forum posts suggest 1 s, without saying where the limit is, so the note gives the limit and a value that works.

GetSceneMembership on the GU10 CWS reports a capacity of 12. ViewScene lists the stored extension fields as OnOff, Level and, only for scenes stored in XY mode, Color X/Y. Color temperature is never stored, and recall restores the X/Y attributes without switching the lamp out of color temperature mode. Koenkk/zigbee2mqtt#30211 reports 8 scenes total on LED2408G10; the note quotes that with the link already in the Issues list.

`pnpm run docgen` regenerates the 21 KAJPLATS pages and changes nothing else. The regenerated docs are left out, as in #5181 and #5315; say so if you want them in the PR.
